### PR TITLE
Constraining enum members based on their enum property to avoid collisions

### DIFF
--- a/modules/codegen/src/main/scala/com/twilio/swagger/codegen/generators/CirceProtocolGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/swagger/codegen/generators/CirceProtocolGenerator.scala
@@ -27,8 +27,8 @@ object CirceProtocolGenerator {
       case RenderMembers(clsName, elems) =>
         Target.pure(q"""
           object members {
-            ..${elems.map({ case (value, pascalValue) =>
-              q"""case object ${pascalValue} extends ${Ctor.Ref.Name(clsName)}(${Lit.String(value)})"""
+            ..${elems.map({ case (value, termName, defaultTerm) =>
+              q"""case object ${termName} extends ${Ctor.Ref.Name(clsName)}(${Lit.String(value)})"""
             }).to[Seq]}
           }
         """)

--- a/modules/codegen/src/main/scala/com/twilio/swagger/codegen/generators/ScalaParameter.scala
+++ b/modules/codegen/src/main/scala/com/twilio/swagger/codegen/generators/ScalaParameter.scala
@@ -57,7 +57,7 @@ object ScalaParameter {
             .flatMap {
               case EnumDefinition(Type.Name(`tpeName`), elems, _, _) =>
                 baseDefaultValue.flatMap {
-                  case Lit.String(name) => elems.find(_._1 == name).map(_._2) // FIXME: Failed lookups don't fail codegen, causing mismatches like `foo: Bar = "baz"`
+                  case Lit.String(name) => elems.find(_._1 == name).map(_._3) // FIXME: Failed lookups don't fail codegen, causing mismatches like `foo: Bar = "baz"`
                 }
               case _ => None
             } headOption

--- a/modules/codegen/src/main/scala/com/twilio/swagger/codegen/protocol/terms/EnumProtocolTerm.scala
+++ b/modules/codegen/src/main/scala/com/twilio/swagger/codegen/protocol/terms/EnumProtocolTerm.scala
@@ -8,7 +8,7 @@ import scala.meta._
 sealed trait EnumProtocolTerm[T]
 case class ExtractEnum(swagger: ModelImpl) extends EnumProtocolTerm[Either[String, Seq[String]]]
 case class ExtractType(swagger: ModelImpl) extends EnumProtocolTerm[Either[String, Type]]
-case class RenderMembers(clsName: String, elems: Seq[(String, Term.Name)]) extends EnumProtocolTerm[Defn.Object]
+case class RenderMembers(clsName: String, elems: Seq[(String, Term.Name, Term)]) extends EnumProtocolTerm[Defn.Object]
 case class EncodeEnum(clsName: String) extends EnumProtocolTerm[Defn.Val]
 case class DecodeEnum(clsName: String) extends EnumProtocolTerm[Defn.Val]
 case class RenderClass(clsName: String, tpe: Type) extends EnumProtocolTerm[Defn.Class]

--- a/modules/codegen/src/main/scala/com/twilio/swagger/codegen/protocol/terms/EnumProtocolTerms.scala
+++ b/modules/codegen/src/main/scala/com/twilio/swagger/codegen/protocol/terms/EnumProtocolTerms.scala
@@ -11,7 +11,7 @@ class EnumProtocolTerms[F[_]](implicit I: Inject[EnumProtocolTerm, F]) {
     Free.inject[EnumProtocolTerm, F](ExtractEnum(swagger))
   def extractType(swagger: ModelImpl): Free[F, Either[String, Type]] =
     Free.inject[EnumProtocolTerm, F](ExtractType(swagger))
-  def renderMembers(clsName: String, elems: Seq[(String, Term.Name)]): Free[F, Defn.Object] =
+  def renderMembers(clsName: String, elems: Seq[(String, Term.Name, Term)]): Free[F, Defn.Object] =
     Free.inject[EnumProtocolTerm, F](RenderMembers(clsName, elems))
   def encodeEnum(clsName: String): Free[F, Defn.Val] =
     Free.inject[EnumProtocolTerm, F](EncodeEnum(clsName))

--- a/src/test/scala/swagger/EnumTest.scala
+++ b/src/test/scala/swagger/EnumTest.scala
@@ -108,9 +108,9 @@ class EnumTest extends FunSuite with Matchers {
               Left(Left(e))
           }))
         }
-        def getFoo(pathparam: Bar, bar: Bar, defaultparam: Bar = ILikeSpaces, headers: scala.collection.immutable.Seq[HttpHeader] = Nil): EitherT[Future, Either[Throwable, HttpResponse], Bar] = {
+        def getFoo(pathparam: Bar, bar: Bar, defaultparam: Bar = Bar.ILikeSpaces, headers: scala.collection.immutable.Seq[HttpHeader] = Nil): EitherT[Future, Either[Throwable, HttpResponse], Bar] = {
           val allHeaders = headers ++ scala.collection.immutable.Seq[Option[HttpHeader]]().flatten
-          wrap[Bar](httpClient(HttpRequest(method = HttpMethods.GET, uri = host + basePath + "/" + "foo" + "/" + Formatter.addPath(pathparam) + "?" + Formatter.addArg("bar", bar) + Formatter.addArg("defaultparam", defaultparam), entity = HttpEntity.Empty, headers = allHeaders)))
+          wrap[Bar](httpClient(HttpRequest(method = HttpMethods.GET, uri = host + basePath + "/foo/" + Formatter.addPath(pathparam) + "?" + Formatter.addArg("bar", bar) + Formatter.addArg("defaultparam", defaultparam), entity = HttpEntity.Empty, headers = allHeaders)))
         }
       }
     """


### PR DESCRIPTION
This permits two different enums to contain the same value, and doesn't pollute the local namespace with more `_` imports