### PR TITLE
Replacing naive path parser with parser combinator

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -47,6 +47,7 @@ val codegenSettings = Seq(
   libraryDependencies ++= testDependencies ++ Seq(
     "org.scalameta" %% "scalameta" % "1.8.0"
     , "io.swagger" % "swagger-parser" % "1.0.32"
+    , "org.tpolecat" %% "atto-core"  % "0.6.0"
     , "org.typelevel" %% "cats" % catsVersion
   )
   // Dev

--- a/modules/codegen/src/main/scala/com/twilio/swagger/codegen/SwaggerUtil.scala
+++ b/modules/codegen/src/main/scala/com/twilio/swagger/codegen/SwaggerUtil.scala
@@ -3,6 +3,7 @@ package com.twilio.swagger.codegen
 import _root_.io.swagger.models._
 import _root_.io.swagger.models.parameters._
 import _root_.io.swagger.models.properties._
+import cats.syntax.either._
 import com.twilio.swagger.codegen.extract.{Default, ScalaType}
 import java.util.{Map => JMap}
 import scala.collection.immutable.Seq
@@ -214,6 +215,25 @@ object SwaggerUtil {
       }.getOrElse(ignoredType)
     } else {
       ignoredType
+    }
+  }
+
+  object paths {
+    def generateUrlPathParams(path: String)(termMunger: Term.Name => Term.Name): Term = {
+      import atto._, Atto._
+
+      val term: Parser[Term.Apply] = many(letter).map(_.mkString("")).map(term => q"Formatter.addPath(${termMunger(Term.Name(term))})")
+      val variable: Parser[Term.Apply] = char('{') ~> term <~ char('}')
+      val other: Parser[String] = many1(notChar('{')).map(_.toList.mkString)
+      val pattern: Parser[List[Either[String, Term.Apply]]] = many(either(variable, other).map(_.swap: Either[String, Term.Apply]))
+
+      (for {
+        parts <- pattern.parseOnly(path).either
+        result = parts.map({
+          case Left(part) => Lit.String(part)
+          case Right(term) => term
+        }).foldLeft[Term](q"host + basePath")({ case (a, b) => q"${a} + ${b}" })
+      } yield result).right.get
     }
   }
 }

--- a/modules/codegen/src/main/scala/com/twilio/swagger/codegen/generators/AkkaHttpClientGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/swagger/codegen/generators/AkkaHttpClientGenerator.scala
@@ -3,6 +3,7 @@ package generators
 
 import _root_.io.swagger.models._
 import cats.arrow.FunctionK
+import cats.data.NonEmptyList
 import cats.instances.all._
 import cats.syntax.flatMap._
 import cats.syntax.functor._
@@ -59,28 +60,15 @@ object AkkaHttpClientGenerator {
           "^([A-Z])".r.replaceAllIn(fromSnakeOrDashed, m => m.group(1).toLowerCase(Locale.US))
         }
 
-        def generateUrlPathParams(path: String): Term = {
-          val tpl = "\\{([^}]+)\\}".r
-          val tplWithQuery = "\\{([^}]+)\\}\\?(.*)".r
-          val base: Term = path.split('/').drop(1).foldLeft[Term](q"host + basePath") {
-            case (url, tpl(term)) => q""" $url + "/" + Formatter.addPath(${Term.Name(toCamelCase(term))}) """
-            case (url, tplWithQuery(term, query)) =>  q""" $url + "/" + Formatter.addPath(${Term.Name(toCamelCase(term))}) + "?" + $query """
-            case (url,   segment) => q""" $url + "/" + ${segment} """
-          }
-
-          if (path.endsWith("/")) {
-            q""" $base + "/" """
-          } else {
-            base
-          }
-        }
-
         def generateUrlWithParams(path: String, parameters: Seq[ScalaParameter]): Term = {
-          val baseTerm = if (path.contains("?")) {
-            q"""${generateUrlPathParams(path)} + "&" """
+          val base = SwaggerUtil.paths.generateUrlPathParams(path)({ case Term.Name(term) => Term.Name(toCamelCase(term)) })
+          val suffix = if (path.contains("?")) {
+            Lit.String("&")
           } else {
-            q"""${generateUrlPathParams(path)} + "?" """
+            Lit.String("?")
           }
+
+          val baseTerm = q"${base} + ${suffix}"
           parameters.foldLeft[Term](baseTerm) { case (a, ScalaParameter(_, paramName, argName, _)) =>
             q""" $a + Formatter.addArg(${Lit.String(argName.value)}, ${paramName})"""
           }

--- a/src/test/scala/core/PathParserSpec.scala
+++ b/src/test/scala/core/PathParserSpec.scala
@@ -1,0 +1,23 @@
+package swagger
+
+import com.twilio.swagger.codegen.SwaggerUtil
+import org.scalatest.{FunSuite, Matchers}
+import scala.meta._
+
+class PathParserSpec extends FunSuite with Matchers {
+
+  List[(String, Term)](
+    ("", q""" host + basePath """)
+  , ("/", q""" host + basePath + "/" """)
+  , ("/foo", q""" host + basePath + "/foo" """)
+  , ("/foo/", q""" host + basePath + "/foo/" """)
+  , ("/{foo}", q""" host + basePath + "/" + Formatter.addPath(foo) """)
+  , ("/{foo}.json", q""" host + basePath + "/" + Formatter.addPath(foo) + ".json" """)
+  , ("/{foo}/{bar}.json", q""" host + basePath + "/" + Formatter.addPath(foo) + "/" + Formatter.addPath(bar) + ".json" """)
+  ).foreach { case (str, expected) =>
+    test(str) {
+      val gen = SwaggerUtil.paths.generateUrlPathParams(str)(identity)
+      gen.structure shouldBe(expected.structure)
+    }
+  }
+}


### PR DESCRIPTION
Uses atto, and supports paths that have previously not been parsable
(resulting in code that compiled, but would not have all values
interpolated)