### PR TITLE
Adding 2.12 cross-compile

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,8 @@ name := projectName
 organization in ThisBuild := "com.twilio"
 version in ThisBuild := "0.26.0-SNAPSHOT"
 
-scalaVersion in ThisBuild := "2.11.8"
+scalaVersion in ThisBuild := "2.12.2"
+crossScalaVersions := Seq("2.11.8", "2.12.2")
 
 val akkaVersion = "10.0.10"
 val catsVersion = "0.9.0"
@@ -55,7 +56,6 @@ val codegenSettings = Seq(
   , scalacOptions in ThisBuild ++= Seq(
       "-language:higherKinds",
       "-Xexperimental",
-      "-Ybackend:GenBCode",
       "-Ydelambdafy:method",
       "-Xlint:_",
       "-feature",

--- a/src/test/scala/cli/WritePackageSpec.scala
+++ b/src/test/scala/cli/WritePackageSpec.scala
@@ -68,7 +68,7 @@ class WritePackageSpec extends FunSuite with Matchers {
     , context=Context.empty.copy(framework=Some("akka-http"))
     ), List.empty)
 
-    val result: List[WriteTree] = Common.processArgs(args).foldMap(CoreTermInterp).right.get.toList.flatMap(injectSwagger(swagger, _).right.get)
+    val result: List[WriteTree] = Common.processArgs[CoreTerm](args).foldMap(CoreTermInterp).right.get.toList.flatMap(injectSwagger(swagger, _).right.get)
 
     val paths = result.map(_.path)
 
@@ -101,7 +101,7 @@ class WritePackageSpec extends FunSuite with Matchers {
     , context=Context.empty.copy(framework=Some("akka-http"))
     ), List.empty)
 
-    val result: List[WriteTree] = Common.processArgs(args).foldMap(CoreTermInterp).right.get.toList.flatMap(injectSwagger(swagger, _).right.get)
+    val result: List[WriteTree] = Common.processArgs[CoreTerm](args).foldMap(CoreTermInterp).right.get.toList.flatMap(injectSwagger(swagger, _).right.get)
 
     val paths = result.map(_.path)
 


### PR DESCRIPTION
This is to support building the swagger-codegen sbt plugin; the sbt plugin hasn't been a priority since scala.meta was not designed to support 2.10, it was never possible to write before.