### PR TITLE
Adding unsafe extractors

### DIFF
--- a/modules/codegen/src/main/scala/com/twilio/swagger/codegen/package.scala
+++ b/modules/codegen/src/main/scala/com/twilio/swagger/codegen/package.scala
@@ -16,12 +16,14 @@ package codegen {
     def pure[T](x: T): Target[T] = Either.right(x)
     def log[T](x: String): Target[T] = Either.left(x)
     def fromOption[T](x: Option[T], default: => String): Target[T] = Either.fromOption(x, default)
+    def unsafeExtract[T](x: Target[T]): T = x.valueOr({ err => throw new Exception(err.toString) })
   }
 
   object CoreTarget {
     def pure[T](x: T): CoreTarget[T] = Either.right(x)
     def fromOption[T](x: Option[T], default: => Error): CoreTarget[T] = Either.fromOption(x, default)
     def log[T](x: Error): CoreTarget[T] = Either.left(x)
+    def unsafeExtract[T](x: CoreTarget[T]): T = x.valueOr({ err => throw new Exception(err.toString) })
   }
 }
 

--- a/src/test/scala/cli/WritePackageSpec.scala
+++ b/src/test/scala/cli/WritePackageSpec.scala
@@ -68,7 +68,7 @@ class WritePackageSpec extends FunSuite with Matchers {
     , context=Context.empty.copy(framework=Some("akka-http"))
     ), List.empty)
 
-    val result: List[WriteTree] = Common.processArgs[CoreTerm](args).foldMap(CoreTermInterp).right.get.toList.flatMap(injectSwagger(swagger, _).right.get)
+    val result: List[WriteTree] = CoreTarget.unsafeExtract(Common.processArgs[CoreTerm](args).foldMap(CoreTermInterp)).toList.flatMap(x => Target.unsafeExtract(injectSwagger(swagger, x)))
 
     val paths = result.map(_.path)
 
@@ -101,7 +101,7 @@ class WritePackageSpec extends FunSuite with Matchers {
     , context=Context.empty.copy(framework=Some("akka-http"))
     ), List.empty)
 
-    val result: List[WriteTree] = Common.processArgs[CoreTerm](args).foldMap(CoreTermInterp).right.get.toList.flatMap(injectSwagger(swagger, _).right.get)
+    val result: List[WriteTree] = CoreTarget.unsafeExtract(Common.processArgs[CoreTerm](args).foldMap(CoreTermInterp)).toList.flatMap(x => Target.unsafeExtract(injectSwagger(swagger, x)))
 
     val paths = result.map(_.path)
 

--- a/src/test/scala/core/PathParserSpec.scala
+++ b/src/test/scala/core/PathParserSpec.scala
@@ -1,6 +1,6 @@
 package swagger
 
-import com.twilio.swagger.codegen.SwaggerUtil
+import com.twilio.swagger.codegen.{SwaggerUtil, Target}
 import com.twilio.swagger.codegen.generators.ScalaParameter
 import org.scalatest.{FunSuite, Matchers}
 import scala.collection.immutable.Seq
@@ -26,7 +26,7 @@ class PathParserSpec extends FunSuite with Matchers {
   , ("/{foo_bar}/{bar_baz}.json", q""" host + basePath + "/" + Formatter.addPath(fooBar) + "/" + Formatter.addPath(barBaz) + ".json" """)
   ).foreach { case (str, expected) =>
     test(str) {
-      val gen = SwaggerUtil.paths.generateUrlPathParams(str, args)(identity).right.get
+      val gen = Target.unsafeExtract(SwaggerUtil.paths.generateUrlPathParams(str, args)(identity))
       gen.toString shouldBe(expected.toString)
     }
   }

--- a/src/test/scala/generators/AkkaHttp/Client/Tracing.scala
+++ b/src/test/scala/generators/AkkaHttp/Client/Tracing.scala
@@ -3,7 +3,7 @@ package tests.generators.AkkaHttp.Client
 import _root_.io.swagger.parser.SwaggerParser
 import cats.instances.all._
 import com.twilio.swagger.codegen.generators.AkkaHttp
-import com.twilio.swagger.codegen.{Client, Clients, Context, ClientGenerator, ProtocolGenerator, RandomType, CodegenApplication}
+import com.twilio.swagger.codegen.{Client, Clients, Context, ClientGenerator, ProtocolGenerator, RandomType, CodegenApplication, Target}
 import org.scalatest.{FunSuite, Matchers}
 import scala.collection.immutable.{Seq => ISeq}
 import scala.meta._
@@ -33,7 +33,7 @@ class AkkaHttpClientTracingTest extends FunSuite with Matchers {
       |          description: Success
       |""".stripMargin)
 
-    val Right(Clients(clients, _)) = ClientGenerator.fromSwagger[CodegenApplication](Context.empty.copy(tracing=true), swagger)(List.empty).foldMap(AkkaHttp)
+    val Clients(clients, _) = Target.unsafeExtract(ClientGenerator.fromSwagger[CodegenApplication](Context.empty.copy(tracing=true), swagger)(List.empty).foldMap(AkkaHttp))
     val Client(tags, className, statements) :: _ = clients
 
     val Seq(cmp, cls) = statements.dropWhile(_.isInstanceOf[Import])
@@ -83,7 +83,7 @@ class AkkaHttpClientTracingTest extends FunSuite with Matchers {
       |          description: Success
       |""".stripMargin)
 
-    val Right(Clients(clients, _)) = ClientGenerator.fromSwagger[CodegenApplication](Context.empty.copy(tracing=true), swagger)(List.empty).foldMap(AkkaHttp)
+    val Clients(clients, _) = Target.unsafeExtract(ClientGenerator.fromSwagger[CodegenApplication](Context.empty.copy(tracing=true), swagger)(List.empty).foldMap(AkkaHttp))
     val Client(tags, className, statements) :: _ = clients
 
     val Seq(cmp, cls) = statements.dropWhile(_.isInstanceOf[Import])

--- a/src/test/scala/generators/AkkaHttp/Server.scala
+++ b/src/test/scala/generators/AkkaHttp/Server.scala
@@ -3,7 +3,7 @@ package tests.generators.AkkaHttp
 import _root_.io.swagger.parser.SwaggerParser
 import cats.instances.all._
 import com.twilio.swagger.codegen.generators.AkkaHttp
-import com.twilio.swagger.codegen.{Context, Server, Servers, ServerGenerator, CodegenApplication}
+import com.twilio.swagger.codegen.{Context, Server, Servers, ServerGenerator, CodegenApplication, Target}
 import org.scalatest.{FunSuite, Matchers}
 
 class AkkaHttpServerTest extends FunSuite with Matchers {
@@ -93,7 +93,7 @@ class AkkaHttpServerTest extends FunSuite with Matchers {
   test("Ensure routes are generated") {
     val swagger = new SwaggerParser().parse(spec)
 
-    val Right(Servers(output, _)) = ServerGenerator.fromSwagger[CodegenApplication](Context.empty, swagger).foldMap(AkkaHttp)
+    val Servers(output, _) = Target.unsafeExtract(ServerGenerator.fromSwagger[CodegenApplication](Context.empty, swagger).foldMap(AkkaHttp))
     val _ :: Server(pkg, extraImports, genHandler :: genResource :: Nil) :: Nil = output
 
     val handler = q"""
@@ -126,7 +126,7 @@ class AkkaHttpServerTest extends FunSuite with Matchers {
   test("Ensure routes are generated with tracing") {
     val swagger = new SwaggerParser().parse(spec)
 
-    val Right(Servers(output, _)) = ServerGenerator.fromSwagger[CodegenApplication](Context.empty.copy(tracing=true), swagger).foldMap(AkkaHttp)
+    val Servers(output, _) = Target.unsafeExtract(ServerGenerator.fromSwagger[CodegenApplication](Context.empty.copy(tracing=true), swagger).foldMap(AkkaHttp))
     val Server(pkg, extraImports, genHandler :: genResource :: Nil) :: _ :: Nil = output
 
     val handler = q"""

--- a/src/test/scala/swagger/AkkaHttpClientGeneratorTest.scala
+++ b/src/test/scala/swagger/AkkaHttpClientGeneratorTest.scala
@@ -3,7 +3,7 @@ package swagger
 import _root_.io.swagger.parser.SwaggerParser
 import cats.instances.all._
 import com.twilio.swagger.codegen.generators.AkkaHttp
-import com.twilio.swagger.codegen.{Client, Clients, Context, ClientGenerator, CodegenApplication}
+import com.twilio.swagger.codegen.{Client, Clients, Context, ClientGenerator, CodegenApplication, Target}
 import org.scalatest.{FunSuite, Matchers}
 
 class AkkaHttpClientGeneratorTest extends FunSuite with Matchers {
@@ -111,7 +111,7 @@ class AkkaHttpClientGeneratorTest extends FunSuite with Matchers {
 
   test("Ensure responses are generated") {
     val swagger = new SwaggerParser().parse(spec)
-    val Right(Clients(List(Client(tags, className, statements)), _)) = ClientGenerator.fromSwagger[CodegenApplication](Context.empty.copy(framework=Some("akka-http")), swagger)(List.empty).foldMap(AkkaHttp)
+    val Clients(List(Client(tags, className, statements)), _) = Target.unsafeExtract(ClientGenerator.fromSwagger[CodegenApplication](Context.empty.copy(framework=Some("akka-http")), swagger)(List.empty).foldMap(AkkaHttp))
 
     tags should equal (Seq("store"))
 
@@ -156,7 +156,7 @@ class AkkaHttpClientGeneratorTest extends FunSuite with Matchers {
 
   test("Ensure traced responses are generated") {
     val swagger = new SwaggerParser().parse(spec)
-    val Right(Clients(List(Client(tags, className, statements)), _)) = ClientGenerator.fromSwagger[CodegenApplication](Context.empty.copy(framework=Some("akka-http"), tracing=true), swagger)(List.empty).foldMap(AkkaHttp)
+    val Clients(List(Client(tags, className, statements)), _) = Target.unsafeExtract(ClientGenerator.fromSwagger[CodegenApplication](Context.empty.copy(framework=Some("akka-http"), tracing=true), swagger)(List.empty).foldMap(AkkaHttp))
 
     tags should equal (Seq("store"))
 

--- a/src/test/scala/swagger/BacktickTest.scala
+++ b/src/test/scala/swagger/BacktickTest.scala
@@ -4,7 +4,7 @@ import _root_.io.swagger.parser.SwaggerParser
 import cats.instances.all._
 import collection.JavaConverters._
 import com.twilio.swagger.codegen.generators.AkkaHttp
-import com.twilio.swagger.codegen.{Context, ClassDefinition, EnumDefinition, Client, Clients, ClientGenerator, ProtocolGenerator, CodegenApplication}
+import com.twilio.swagger.codegen.{Context, ClassDefinition, EnumDefinition, Client, Clients, ClientGenerator, ProtocolGenerator, CodegenApplication, Target}
 import org.scalatest.{FunSuite, Matchers}
 import scala.collection.immutable.{Seq => ISeq}
 import scala.meta._
@@ -66,7 +66,7 @@ class BacktickTest extends FunSuite with Matchers {
     |""".stripMargin)
 
   test("Ensure paths are generated with escapes") {
-    val Right(Clients(clients, _)) = ClientGenerator.fromSwagger[CodegenApplication](Context.empty, swagger)(List.empty).foldMap(AkkaHttp)
+    val Clients(clients, _) = Target.unsafeExtract(ClientGenerator.fromSwagger[CodegenApplication](Context.empty, swagger)(List.empty).foldMap(AkkaHttp))
     val Client(tags, className, statements) :: _ = clients
 
     tags should equal (Seq("dashy-package"))
@@ -116,7 +116,7 @@ class BacktickTest extends FunSuite with Matchers {
     cmp.toString shouldNot include ("``")
   }
 
-  val definitions = ProtocolGenerator.fromSwagger[CodegenApplication](swagger).foldMap(AkkaHttp).right.get.elems
+  val definitions = Target.unsafeExtract(ProtocolGenerator.fromSwagger[CodegenApplication](swagger).foldMap(AkkaHttp)).elems
 
   test("Ensure dtos are generated with escapes") {
     val definition = q"""

--- a/src/test/scala/swagger/ClientGeneratorTest.scala
+++ b/src/test/scala/swagger/ClientGeneratorTest.scala
@@ -3,7 +3,7 @@ package swagger
 import _root_.io.swagger.parser.SwaggerParser
 import cats.instances.all._
 import com.twilio.swagger.codegen.generators.AkkaHttp
-import com.twilio.swagger.codegen.{Client, Clients, Context, ClientGenerator, CodegenApplication}
+import com.twilio.swagger.codegen.{Client, Clients, Context, ClientGenerator, CodegenApplication, Target}
 import org.scalatest.{FunSuite, Matchers}
 
 class ClientGeneratorTest extends FunSuite with Matchers {
@@ -122,7 +122,7 @@ class ClientGeneratorTest extends FunSuite with Matchers {
 
   test("Ensure responses are generated") {
     val swagger = new SwaggerParser().parse(spec)
-    val Right(Clients(clients, _)) = ClientGenerator.fromSwagger[CodegenApplication](Context.empty, swagger)(List.empty).foldMap(AkkaHttp)
+    val Clients(clients, _) = Target.unsafeExtract(ClientGenerator.fromSwagger[CodegenApplication](Context.empty, swagger)(List.empty).foldMap(AkkaHttp))
     val Client(tags, className, statements) :: _ = clients
 
     tags should equal (Seq("store"))

--- a/src/test/scala/swagger/DefinitionSpec.scala
+++ b/src/test/scala/swagger/DefinitionSpec.scala
@@ -3,7 +3,7 @@ package swagger
 import _root_.io.swagger.parser.SwaggerParser
 import cats.instances.all._
 import com.twilio.swagger.codegen.generators.AkkaHttp
-import com.twilio.swagger.codegen.{ClassDefinition, EnumDefinition, ProtocolGenerator, CodegenApplication}
+import com.twilio.swagger.codegen.{ClassDefinition, EnumDefinition, ProtocolGenerator, CodegenApplication, Target}
 import org.scalatest.{FunSuite, Matchers}
 import scala.collection.immutable.{Seq => ISeq}
 import scala.meta._
@@ -69,7 +69,7 @@ class DefinitionSpec extends FunSuite with Matchers {
     |""".stripMargin)
 
   test("Plain objects should be generated") {
-    val definitions = ProtocolGenerator.fromSwagger[CodegenApplication](swagger).foldMap(AkkaHttp).right.get.elems
+    val definitions = Target.unsafeExtract(ProtocolGenerator.fromSwagger[CodegenApplication](swagger).foldMap(AkkaHttp)).elems
     val ClassDefinition(_, cls, cmp) :: _ = definitions
 
     val definition = q"""
@@ -90,7 +90,7 @@ class DefinitionSpec extends FunSuite with Matchers {
   }
 
   test("Enumerations should be generated") {
-    val definitions = ProtocolGenerator.fromSwagger[CodegenApplication](swagger).foldMap(AkkaHttp).right.get.elems
+    val definitions = Target.unsafeExtract(ProtocolGenerator.fromSwagger[CodegenApplication](swagger).foldMap(AkkaHttp)).elems
     val _ :: _ :: EnumDefinition(_, _, cls, cmp) :: _ = definitions
 
     val definition = q"""
@@ -123,7 +123,7 @@ class DefinitionSpec extends FunSuite with Matchers {
   }
 
   test("Camel case conversion should happen") {
-    val definitions = ProtocolGenerator.fromSwagger[CodegenApplication](swagger).foldMap(AkkaHttp).right.get.elems
+    val definitions = Target.unsafeExtract(ProtocolGenerator.fromSwagger[CodegenApplication](swagger).foldMap(AkkaHttp)).elems
     val _ :: _ :: _ :: _ :: ClassDefinition(_, cls, cmp) :: _ = definitions
 
     val definition = q"""
@@ -144,7 +144,7 @@ class DefinitionSpec extends FunSuite with Matchers {
   }
 
   test("Defaults should work") {
-    val definitions = ProtocolGenerator.fromSwagger[CodegenApplication](swagger).foldMap(AkkaHttp).right.get.elems
+    val definitions = Target.unsafeExtract(ProtocolGenerator.fromSwagger[CodegenApplication](swagger).foldMap(AkkaHttp)).elems
     val _ :: _ :: _ :: _ :: _ :: ClassDefinition(_, cls, cmp) :: _ = definitions
 
     val definition = q"""

--- a/src/test/scala/swagger/EnumTest.scala
+++ b/src/test/scala/swagger/EnumTest.scala
@@ -3,7 +3,7 @@ package swagger
 import _root_.io.swagger.parser.SwaggerParser
 import cats.instances.all._
 import com.twilio.swagger.codegen.generators.AkkaHttp
-import com.twilio.swagger.codegen.{Client, Clients, Context, EnumDefinition, ClientGenerator, ProtocolGenerator, CodegenApplication}
+import com.twilio.swagger.codegen.{Client, Clients, Context, EnumDefinition, ClientGenerator, ProtocolGenerator, CodegenApplication, Target}
 import org.scalatest.{FunSuite, Matchers}
 import scala.collection.immutable.{Seq => ISeq}
 import scala.meta._
@@ -80,7 +80,7 @@ class EnumTest extends FunSuite with Matchers {
     }
     """
 
-    val definitions = ProtocolGenerator.fromSwagger[CodegenApplication](swagger).foldMap(AkkaHttp).right.get.elems
+    val definitions = Target.unsafeExtract(ProtocolGenerator.fromSwagger[CodegenApplication](swagger).foldMap(AkkaHttp)).elems
     definitions.length should equal (1)
     val EnumDefinition(_, _, cls, cmp) = definitions.head
     cls.structure should equal(definition.structure)
@@ -89,8 +89,8 @@ class EnumTest extends FunSuite with Matchers {
   }
 
   test("Use enums") {
-    val definitions = ProtocolGenerator.fromSwagger[CodegenApplication](swagger).foldMap(AkkaHttp).right.get.elems
-    val Right(Clients(clients, _)) = ClientGenerator.fromSwagger[CodegenApplication](Context.empty, swagger)(definitions).foldMap(AkkaHttp)
+    val definitions = Target.unsafeExtract(ProtocolGenerator.fromSwagger[CodegenApplication](swagger).foldMap(AkkaHttp)).elems
+    val Clients(clients, _) = Target.unsafeExtract(ClientGenerator.fromSwagger[CodegenApplication](Context.empty, swagger)(definitions).foldMap(AkkaHttp))
     val Client(tags, className, statements) :: _ = clients
 
     val Seq(cmp, cls) = statements.dropWhile(_.isInstanceOf[Import])

--- a/src/test/scala/swagger/MultipartTest.scala
+++ b/src/test/scala/swagger/MultipartTest.scala
@@ -3,7 +3,7 @@ package swagger
 import _root_.io.swagger.parser.SwaggerParser
 import cats.instances.all._
 import com.twilio.swagger.codegen.generators.AkkaHttp
-import com.twilio.swagger.codegen.{Client, Clients, Context, ClientGenerator, CodegenApplication}
+import com.twilio.swagger.codegen.{Client, Clients, Context, ClientGenerator, CodegenApplication, Target}
 import org.scalatest.{FunSuite, Matchers}
 import scala.collection.immutable.{Seq => ISeq}
 import scala.meta._
@@ -48,7 +48,7 @@ class MultipartTest extends FunSuite with Matchers {
     |""".stripMargin)
 
   test("Multipart form data") {
-    val Right(Clients(clients, _)) = ClientGenerator.fromSwagger[CodegenApplication](Context.empty, swagger)(List.empty).foldMap(AkkaHttp)
+    val Clients(clients, _) = Target.unsafeExtract(ClientGenerator.fromSwagger[CodegenApplication](Context.empty, swagger)(List.empty).foldMap(AkkaHttp))
     val Client(_, className, statements) :: _ = clients
 
     val Seq(_, cls) = statements.dropWhile(_.isInstanceOf[Import])

--- a/src/test/scala/swagger/PropertyExtractors.scala
+++ b/src/test/scala/swagger/PropertyExtractors.scala
@@ -2,7 +2,7 @@ package swagger
 
 import cats.instances.all._
 import com.twilio.swagger.codegen.generators.AkkaHttp
-import com.twilio.swagger.codegen.{ClassDefinition, Client, Context, ClientGenerator, ProtocolGenerator, RandomType, CodegenApplication}
+import com.twilio.swagger.codegen.{ClassDefinition, Client, Context, ClientGenerator, ProtocolGenerator, RandomType, CodegenApplication, Target}
 import io.swagger.parser.SwaggerParser
 import org.scalatest.{FunSuite, Matchers}
 import scala.collection.immutable.{Seq => ISeq}
@@ -64,7 +64,7 @@ class PropertyExtractors extends FunSuite with Matchers {
 */
 
   test("Render all primitive types correctly") {
-    val definitions = ProtocolGenerator.fromSwagger[CodegenApplication](swagger).foldMap(AkkaHttp).right.get.elems
+    val definitions = Target.unsafeExtract(ProtocolGenerator.fromSwagger[CodegenApplication](swagger).foldMap(AkkaHttp)).elems
     val ClassDefinition(_, cls, cmp) :: _ = definitions
 
     val definition = q"""

--- a/src/test/scala/swagger/ScalaType.scala
+++ b/src/test/scala/swagger/ScalaType.scala
@@ -3,7 +3,7 @@ package swagger
 import _root_.io.swagger.parser.SwaggerParser
 import cats.instances.all._
 import com.twilio.swagger.codegen.generators.AkkaHttp
-import com.twilio.swagger.codegen.{ClassDefinition, ProtocolGenerator, CodegenApplication}
+import com.twilio.swagger.codegen.{ClassDefinition, ProtocolGenerator, CodegenApplication, Target}
 import org.scalatest.{FunSuite, Matchers}
 import scala.collection.immutable.{Seq => ISeq}
 import scala.meta._
@@ -26,7 +26,7 @@ class ScalaTypesTest extends FunSuite with Matchers {
     |""".stripMargin)
 
   test("Generate no definitions") {
-    val definitions = ProtocolGenerator.fromSwagger[CodegenApplication](swagger).foldMap(AkkaHttp).right.get.elems
+    val definitions = Target.unsafeExtract(ProtocolGenerator.fromSwagger[CodegenApplication](swagger).foldMap(AkkaHttp)).elems
     definitions.length should equal (1)
 
     val definition = q"""

--- a/src/test/scala/swagger/SchemeTest.scala
+++ b/src/test/scala/swagger/SchemeTest.scala
@@ -3,7 +3,7 @@ package swagger
 import _root_.io.swagger.parser.SwaggerParser
 import cats.instances.all._
 import com.twilio.swagger.codegen.generators.AkkaHttp
-import com.twilio.swagger.codegen.{Client, Clients, Context, ClientGenerator, CodegenApplication}
+import com.twilio.swagger.codegen.{Client, Clients, Context, ClientGenerator, CodegenApplication, Target}
 import org.scalatest.{FunSuite, Matchers}
 import scala.collection.immutable.{Seq => ISeq}
 import scala.meta._
@@ -62,7 +62,7 @@ class SchemeTest extends FunSuite with Matchers {
       }
     """
 
-    val Right(Clients(clients, _)) = ClientGenerator.fromSwagger[CodegenApplication](Context.empty, swagger)(List.empty).foldMap(AkkaHttp)
+    val Clients(clients, _) = Target.unsafeExtract(ClientGenerator.fromSwagger[CodegenApplication](Context.empty, swagger)(List.empty).foldMap(AkkaHttp))
     val Client(tags, className, statements) :: _ = clients
     val Seq(cmp, cls) = statements.dropWhile(_.isInstanceOf[Import])
 

--- a/src/test/scala/swagger/protocols/BigObject.scala
+++ b/src/test/scala/swagger/protocols/BigObject.scala
@@ -4,7 +4,7 @@ package protocols
 import _root_.io.swagger.parser.SwaggerParser
 import cats.instances.all._
 import com.twilio.swagger.codegen.generators.AkkaHttp
-import com.twilio.swagger.codegen.{ClassDefinition, EnumDefinition, ProtocolGenerator, CodegenApplication}
+import com.twilio.swagger.codegen.{ClassDefinition, EnumDefinition, ProtocolGenerator, CodegenApplication, Target}
 import org.scalatest.{FunSuite, Matchers}
 import scala.collection.immutable.{Seq => ISeq}
 import scala.meta._
@@ -116,7 +116,7 @@ class BigObjectSpec extends FunSuite with Matchers {
     |""".stripMargin)
 
   test("Big objects can be generated") {
-    val definitions = ProtocolGenerator.fromSwagger[CodegenApplication](swagger).foldMap(AkkaHttp).right.get.elems
+    val definitions = Target.unsafeExtract(ProtocolGenerator.fromSwagger[CodegenApplication](swagger).foldMap(AkkaHttp)).elems
     val ClassDefinition(_, cls, cmp) :: _ = definitions
 
     val definition = q"""


### PR DESCRIPTION
Funneling everything that previously knew about the structure of responses through `Target.unsafeExtract` and `CoreTarget.unsafeExtract`