### PR TITLE
Adding support for "type: array" definitions

### DIFF
--- a/modules/codegen/src/main/scala/com/twilio/swagger/codegen/ProtocolGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/swagger/codegen/ProtocolGenerator.scala
@@ -110,7 +110,10 @@ object ProtocolGenerator {
   }
 
   def modelTypeAlias[F[_]](clsName: String, model: ModelImpl)(implicit A: AliasProtocolTerms[F]): Free[F, ProtocolElems] = {
-    val tpe = Option(model.getType).map(SwaggerUtil.typeName(_, None, ScalaType(model))).getOrElse(t"Json")
+    val tpe = Option(model.getType)
+      .fold[Type](t"Json")(raw =>
+        SwaggerUtil.typeName(raw, Option(model.getFormat), ScalaType(model))
+      )
     typeAlias(clsName, tpe)
   }
 

--- a/modules/codegen/src/main/scala/com/twilio/swagger/codegen/generators/CirceProtocolGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/swagger/codegen/generators/CirceProtocolGenerator.scala
@@ -21,7 +21,7 @@ object CirceProtocolGenerator {
         Target.pure(Either.fromOption(Option(swagger.getEnum).map(_.asScala.to[List]), "Model has no enumerations"))
 
       case ExtractType(swagger) =>
-        Target.pure(Either.fromOption(Option(swagger.getType).map(SwaggerUtil.typeName(_, None, ScalaType(swagger))), "Unable to determine type"))
+        Target.pure(Either.fromOption(Option(swagger.getType).map(SwaggerUtil.typeName(_, Option(swagger.getFormat), ScalaType(swagger))), "Unable to determine type"))
 
       case RenderMembers(clsName, elems) =>
         Target.pure(q"""

--- a/src/test/scala/core/issues/61.scala
+++ b/src/test/scala/core/issues/61.scala
@@ -21,14 +21,26 @@ class Issue61 extends FunSuite with Matchers {
     |    type: array
     |    items:
     |      type: string
+    |  Bar:
+    |    type: integer
+    |    format: int64
     |""".stripMargin)
 
   test("Generate plain array alias definition") {
     val definitions = Target.unsafeExtract(ProtocolGenerator.fromSwagger[CodegenApplication](swagger).foldMap(AkkaHttp)).elems
-    val RandomType(tpe, List(tdef, cdef)) :: Nil = definitions
+    val RandomType(tpe, List(tdef, cdef)) :: _ :: Nil = definitions
 
     tpe.structure shouldBe(t"List[String]".structure)
     tdef.structure shouldBe(q"type Foo = List[String]".structure)
     cdef.structure shouldBe(q"object Foo".structure)
+  }
+
+  test("Generate primitive type aliases") {
+    val definitions = Target.unsafeExtract(ProtocolGenerator.fromSwagger[CodegenApplication](swagger).foldMap(AkkaHttp)).elems
+    val _ :: RandomType(tpe, List(tdef, cdef)) :: Nil = definitions
+
+    tpe.structure shouldBe(t"Long".structure)
+    tdef.structure shouldBe(q"type Bar = Long".structure)
+    cdef.structure shouldBe(q"object Bar".structure)
   }
 }


### PR DESCRIPTION
Previously, creating a definition with the type `array` would just produce a type alias like:
```
type Foo = Json
```

Now, an alias with the structure
```
type Foo = List[Long]
```
will be generated. During the process, I also fixed support primitive type formats, previously `format` was ignored.