### PR TITLE
Issure #94: Add server/client aware context for circe encoders/decoders

### DIFF
--- a/modules/codegen/src/test/scala/core/issues/Issue94.scala
+++ b/modules/codegen/src/test/scala/core/issues/Issue94.scala
@@ -1,0 +1,67 @@
+package core.issues
+
+import com.twilio.guardrail.generators.Http4s
+import com.twilio.guardrail.{ClassDefinition, Context, ProtocolDefinitions, StaticDefns}
+import org.scalatest.{FunSpec, Matchers}
+import support.SwaggerSpecRunner
+
+import scala.meta._
+
+class Issue94 extends FunSpec with Matchers with SwaggerSpecRunner {
+
+  describe("ReadOnly parameter should be returned from server") {
+
+    val swagger: String = """
+      | openapi: "3.0.0"
+      | info:
+      |   title: Server should write out readOnly parameters.
+      |   version: 1.0.0
+      | components:
+      |   schemas:
+      |     ObjectWithWriteOnly:
+      |       type: object
+      |       properties:
+      |         prop:
+      |           type: string
+      |           writeOnly: true
+      |     ObjectWithReadOnly:
+      |       type: object
+      |       properties:
+      |         prop:
+      |           type: string
+      |           readOnly: true""".stripMargin
+
+    val (
+      ProtocolDefinitions(
+      ClassDefinition(_, _, _, StaticDefns(_, _, writeOnlyEncoder :: _ :: Nil), _) ::
+      ClassDefinition(_, _, _, StaticDefns(_, _, readOnlyEncoder :: _ :: Nil), _) :: Nil, _, _, packageObjectContents
+      ), // ProtocolDefinitions
+      _, // clients
+      _, // Servers
+    ) = runSwaggerSpec(swagger)(Context.empty, Http4s)
+
+    it("Ensure correct code is generated") {
+
+      val expectedReadOnlyResult =
+        q"""
+           implicit def encodeObjectWithReadOnly(implicit ec: EncodingContext) = {
+             val readOnlyKeys = Set[String]("prop")
+             val writeOnlyKeys = Set[String]()
+             Encoder.forProduct1("prop")((o: ObjectWithReadOnly) => o.prop).mapJsonObject(_.filterKeys(ec.filter(readOnlyKeys, writeOnlyKeys)))
+           }
+         """
+
+      val expectedWriteOnlyResult =
+        q"""
+           implicit def encodeObjectWithWriteOnly(implicit ec: EncodingContext) = {
+             val readOnlyKeys = Set[String]()
+             val writeOnlyKeys = Set[String]("prop")
+             Encoder.forProduct1("prop")((o: ObjectWithWriteOnly) => o.prop).mapJsonObject(_.filterKeys(ec.filter(readOnlyKeys, writeOnlyKeys)))
+           }
+         """
+
+      readOnlyEncoder.structure shouldBe expectedReadOnlyResult.structure
+      writeOnlyEncoder.structure shouldBe expectedWriteOnlyResult.structure
+    }
+  }
+}


### PR DESCRIPTION
Hello, and thank you for an awesome tool!

I have run into #94 so I thought I might give it a try to figure out a solution.

Right now my solution would include creating and using an implicit `EncodingContext` (name in development) that would specify if the definition is used on server side or client side and thus generate two different results.

The generated servers and clients would then define their respective `EncodingContext`.
Do you think they should be defined the server/client package or should they maybe be defined in the protocol package and be imported into the server/client respectively?

Client encoders should exclude readOnly and include writeOnly were as 
Server encoders should include readOnly and exclude WriteOnly.

This would be a bit of a rewrite but would allow guardrails circe encodings to have different behavior on client and server side.

WDYT? 

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.