### PR TITLE
feat: add support for http4s AuthedRoutes middleware

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,7 @@ val akkaVersion          = "10.0.14"
 val catsVersion          = "1.6.0"
 val catsEffectVersion    = "1.0.0"
 val circeVersion         = "0.10.1"
-val http4sVersion        = "0.20.0"
+val http4sVersion        = "0.20.10"
 val scalatestVersion     = "3.0.8"
 val javaparserVersion    = "3.7.1"
 val endpointsVersion     = "0.8.0"
@@ -70,6 +70,7 @@ val exampleCases: List[ExampleCase] = List(
   ExampleCase(sampleResource("redaction.yaml"), "redaction"),
   ExampleCase(sampleResource("server1.yaml"), "tracer").args("--tracing"),
   ExampleCase(sampleResource("server2.yaml"), "tracer").args("--tracing"),
+  ExampleCase(sampleResource("server3.yaml"), "tracer").args("--tracing", "--http4sAuthedRoutes"),
   ExampleCase(sampleResource("pathological-parameters.yaml"), "pathological")
 )
 

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/Context.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/Context.scala
@@ -1,7 +1,7 @@
 package com.twilio.guardrail
 
-case class Context(framework: Option[String], tracing: Boolean)
+case class Context(framework: Option[String], tracing: Boolean, http4sAuthedRoutes: Boolean)
 
 object Context {
-  val empty = Context(None, tracing = false)
+  val empty = Context(None, tracing = false, http4sAuthedRoutes = false)
 }

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/core/CoreTermInterp.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/core/CoreTermInterp.scala
@@ -90,6 +90,8 @@ case class CoreTermInterp[L <: LA](defaultFramework: String,
                   Continue((sofar.copy(dtoPackage = value.trim.split('.').to[List]) :: already, xs))
                 case (sofar :: already, "--import" :: value :: xs) =>
                   Continue((sofar.copy(imports = sofar.imports :+ value) :: already, xs))
+                case (sofar :: already, "--http4sAuthedRoutes" :: xs) =>
+                  Continue((sofar.copy(context = sofar.context.copy(http4sAuthedRoutes = true)) :: already, xs))
                 case (_, unknown) =>
                   debug("Unknown argument") >> Bail(UnknownArguments(unknown))
               }

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/EndpointsServerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/EndpointsServerGenerator.scala
@@ -8,14 +8,14 @@ import com.twilio.guardrail.protocol.terms.server._
 object EndpointsServerGenerator {
   object ServerTermInterp extends FunctionK[ServerTerm[ScalaLanguage, ?], Target] {
     def apply[T](term: ServerTerm[ScalaLanguage, T]): Target[T] = term match {
-      case GenerateResponseDefinitions(operationId, responses, protocolElems)                                                                 => ???
-      case BuildTracingFields(operation, resourceName, tracing)                                                                               => ???
-      case GenerateRoutes(tracing, resourceName, basePath, routes, protocolElems, securitySchemes)                                            => ???
-      case RenderHandler(handlerName, methodSigs, handlerDefinitions, responseDefinitions)                                                    => ???
-      case GetExtraRouteParams(tracing)                                                                                                       => ???
-      case GenerateSupportDefinitions(tracing, securitySchemes)                                                                               => ???
-      case RenderClass(resourceName, handlerName, annotations, combinedRouteTerms, extraRouteParams, responseDefinitions, supportDefinitions) => ???
-      case GetExtraImports(tracing)                                                                                                           => ???
+      case GenerateResponseDefinitions(operationId, responses, protocolElems)                                                                           => ???
+      case BuildTracingFields(operation, resourceName, tracing)                                                                                         => ???
+      case GenerateRoutes(tracing, resourceName, basePath, routes, protocolElems, securitySchemes, authedRoutes)                                        => ???
+      case RenderHandler(handlerName, methodSigs, handlerDefinitions, responseDefinitions, securityRequirements)                                        => ???
+      case GetExtraRouteParams(tracing)                                                                                                                 => ???
+      case GenerateSupportDefinitions(tracing, securitySchemes)                                                                                         => ???
+      case RenderClass(resourceName, handlerName, annotations, routeTerms, secureRouteTerms, extraRouteParams, responseDefinitions, supportDefinitions) => ???
+      case GetExtraImports(tracing)                                                                                                                     => ???
     }
   }
 }

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/DropwizardServerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/DropwizardServerGenerator.scala
@@ -288,7 +288,7 @@ object DropwizardServerGenerator {
           Target.pure(Option.empty)
         }
 
-      case GenerateRoutes(tracing, resourceName, basePath, routes, protocolElems, securitySchemes) =>
+      case GenerateRoutes(tracing, resourceName, basePath, routes, protocolElems, securitySchemes, authedRoutes) =>
         for {
           resourceType <- safeParseClassOrInterfaceType(resourceName)
           handlerName = s"${resourceName.replaceAll("Resource$", "")}Handler"
@@ -533,7 +533,7 @@ object DropwizardServerGenerator {
             resourceConstructor
           )
 
-          RenderedRoutes[JavaLanguage](routeMethods, annotations, handlerMethodSigs, supportDefinitions, List.empty)
+          RenderedRoutes[JavaLanguage](routeMethods, List.empty, annotations, handlerMethodSigs, supportDefinitions, List.empty)
         }
 
       case GetExtraRouteParams(tracing) =>
@@ -592,12 +592,12 @@ object DropwizardServerGenerator {
           )
         }
 
-      case RenderClass(className, handlerName, classAnnotations, combinedRouteTerms, extraRouteParams, responseDefinitions, supportDefinitions) =>
+      case RenderClass(className, handlerName, classAnnotations, combinedRouteTerms, _, extraRouteParams, responseDefinitions, supportDefinitions) =>
         safeParseSimpleName(className) >>
           safeParseSimpleName(handlerName) >>
           Target.pure(doRenderClass(className, classAnnotations, supportDefinitions, combinedRouteTerms) :: Nil)
 
-      case RenderHandler(handlerName, methodSigs, handlerDefinitions, responseDefinitions) =>
+      case RenderHandler(handlerName, methodSigs, handlerDefinitions, responseDefinitions, securityRequirements) =>
         val handlerClass = new ClassOrInterfaceDeclaration(util.EnumSet.of(PUBLIC), true, handlerName)
         sortDefinitions(methodSigs ++ responseDefinitions).foreach(handlerClass.addMember)
         Target.pure(handlerClass)

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/server/ServerTerm.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/server/ServerTerm.scala
@@ -14,7 +14,8 @@ case class GenerateRoutes[L <: LA](tracing: Boolean,
                                    basePath: Option[String],
                                    routes: List[(String, Option[TracingField[L]], RouteMeta, ScalaParameters[L], Responses[L])],
                                    protocolElems: List[StrictProtocolElems[L]],
-                                   securitySchemes: Map[String, SecurityScheme[L]])
+                                   securitySchemes: Map[String, SecurityScheme[L]],
+                                   authedRoutes: Boolean)
     extends ServerTerm[L, RenderedRoutes[L]]
 case class GetExtraRouteParams[L <: LA](tracing: Boolean) extends ServerTerm[L, List[L#MethodParameter]]
 case class GenerateResponseDefinitions[L <: LA](operationId: String, responses: Responses[L], protocolElems: List[StrictProtocolElems[L]])
@@ -24,7 +25,8 @@ case class GenerateSupportDefinitions[L <: LA](tracing: Boolean, securitySchemes
 case class RenderClass[L <: LA](className: String,
                                 handlerName: String,
                                 annotations: List[L#Annotation],
-                                combinedRouteTerms: List[L#Term],
+                                routeTerms: List[L#Term],
+                                secureRouteTerms: List[L#Term],
                                 extraRouteParams: List[L#MethodParameter],
                                 responseDefinitions: List[L#Definition],
                                 supportDefinitions: List[L#Definition])
@@ -32,6 +34,7 @@ case class RenderClass[L <: LA](className: String,
 case class RenderHandler[L <: LA](handlerName: String,
                                   methodSigs: List[L#MethodDeclaration],
                                   handlerDefinitions: List[L#Statement],
-                                  responseDefinitions: List[L#Definition])
+                                  responseDefinitions: List[L#Definition],
+                                  securityRequirements: Boolean)
     extends ServerTerm[L, L#Definition]
 case class GetExtraImports[L <: LA](tracing: Boolean) extends ServerTerm[L, List[L#Import]]

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/server/ServerTerms.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/server/ServerTerms.scala
@@ -17,8 +17,9 @@ class ServerTerms[L <: LA, F[_]](implicit I: InjectK[ServerTerm[L, ?], F]) {
                      basePath: Option[String],
                      routes: List[(String, Option[TracingField[L]], RouteMeta, ScalaParameters[L], Responses[L])],
                      protocolElems: List[StrictProtocolElems[L]],
-                     securitySchemes: Map[String, SecurityScheme[L]]): Free[F, RenderedRoutes[L]] =
-    Free.inject[ServerTerm[L, ?], F](GenerateRoutes(tracing, resourceName, basePath, routes, protocolElems, securitySchemes))
+                     securitySchemes: Map[String, SecurityScheme[L]],
+                     authedRoutes: Boolean): Free[F, RenderedRoutes[L]] =
+    Free.inject[ServerTerm[L, ?], F](GenerateRoutes(tracing, resourceName, basePath, routes, protocolElems, securitySchemes, authedRoutes))
   def getExtraRouteParams(tracing: Boolean): Free[F, List[L#MethodParameter]] =
     Free.inject[ServerTerm[L, ?], F](GetExtraRouteParams(tracing))
   def generateResponseDefinitions(operationId: String, responses: Responses[L], protocolElems: List[StrictProtocolElems[L]]): Free[F, List[L#Definition]] =
@@ -28,18 +29,20 @@ class ServerTerms[L <: LA, F[_]](implicit I: InjectK[ServerTerm[L, ?], F]) {
   def renderClass(resourceName: String,
                   handlerName: String,
                   annotations: List[L#Annotation],
-                  combinedRouteTerms: List[L#Term],
+                  routeTerms: List[L#Term],
+                  secureRouteTerms: List[L#Term],
                   extraRouteParams: List[L#MethodParameter],
                   responseDefinitions: List[L#Definition],
                   supportDefinitions: List[L#Definition]): Free[F, List[L#Definition]] =
     Free.inject[ServerTerm[L, ?], F](
-      RenderClass(resourceName, handlerName, annotations, combinedRouteTerms, extraRouteParams, responseDefinitions, supportDefinitions)
+      RenderClass(resourceName, handlerName, annotations, routeTerms, secureRouteTerms, extraRouteParams, responseDefinitions, supportDefinitions)
     )
   def renderHandler(handlerName: String,
                     methodSigs: List[L#MethodDeclaration],
                     handlerDefinitions: List[L#Statement],
-                    responseDefinitions: List[L#Definition]): Free[F, L#Definition] =
-    Free.inject[ServerTerm[L, ?], F](RenderHandler(handlerName, methodSigs, handlerDefinitions, responseDefinitions))
+                    responseDefinitions: List[L#Definition],
+                    securityRequirements: Boolean): Free[F, L#Definition] =
+    Free.inject[ServerTerm[L, ?], F](RenderHandler(handlerName, methodSigs, handlerDefinitions, responseDefinitions, securityRequirements))
   def getExtraImports(tracing: Boolean): Free[F, List[L#Import]] =
     Free.inject[ServerTerm[L, ?], F](GetExtraImports(tracing))
 }

--- a/modules/sample-http4s/src/test/scala/core/Http4s/Http4sAuthedRoutesTracerTest.scala
+++ b/modules/sample-http4s/src/test/scala/core/Http4s/Http4sAuthedRoutesTracerTest.scala
@@ -1,0 +1,91 @@
+package core.Http4s
+
+import _root_.tracer.client.http4s.secure.addresses.AddressesClient
+import _root_.tracer.client.{ http4s => cdefs }
+import _root_.tracer.server.http4s.Http4sImplicits.TraceBuilder
+import _root_.tracer.server.http4s.secure.addresses.{ AddressesHandler, AddressesResource, GetSecureAddressResponse, GetSecureAddressesResponse }
+import _root_.tracer.server.{ http4s => sdefs }
+import cats.data.{ Kleisli, OptionT }
+import cats.effect.IO
+import org.http4s.client.{ Client, UnexpectedStatus }
+import org.http4s.headers.Authorization
+import org.http4s.implicits._
+import org.http4s.server.AuthMiddleware
+import org.http4s.syntax.StringSyntax
+import org.http4s.{ AuthedRoutes, BasicCredentials, Header, Request, Status }
+import org.scalatest.{ EitherValues, FunSuite, Matchers }
+import tracer.client.http4s.secure.addresses
+
+class Http4sAuthedRoutesTracerTest extends FunSuite with Matchers with EitherValues with StringSyntax {
+
+  val traceHeaderKey          = "tracer-label"
+  def log(line: String): Unit = ()
+
+  def trace: String => Request[IO] => TraceBuilder[IO] = { name => request =>
+    // In a real environment, this would be where you could establish a new
+    // tracing context and inject that fresh header value.
+    log(s"Expecting all requests to have ${traceHeaderKey} header.")
+    traceBuilder(request.headers.get(traceHeaderKey.ci).get.value)
+  }
+
+  def traceBuilder(parentValue: String): TraceBuilder[IO] = { name => httpClient =>
+    Client { req =>
+      httpClient.run(req.putHeaders(Header(traceHeaderKey, parentValue)))
+    }
+  }
+
+  test("full tracer: passing headers through multiple levels using authed routes") {
+    // Establish the "Address" server
+    case class User(name: String)
+    val server3: AuthedRoutes[User, IO] =
+      new AddressesResource(trace).authedRoutes(new AddressesHandler[IO, User] {
+        def getSecureAddress(respond: GetSecureAddressResponse.type)(
+            id: String,
+            user: User
+        )(traceBuilder: TraceBuilder[IO]): IO[GetSecureAddressResponse] =
+          IO.pure {
+            if (id == "addressId") {
+              respond.Ok(
+                sdefs.definitions
+                  .SecureAddress(Some(s"${user.name}"), Some("line2"), Some("line3"))
+              )
+            } else respond.NotFound
+          }
+
+        def getSecureAddresses(
+            respond: GetSecureAddressesResponse.type
+        )(user: User)(traceBuilder: TraceBuilder[IO]): IO[GetSecureAddressesResponse] =
+          IO.pure(GetSecureAddressesResponse.NotFound)
+      })
+    val johnDoeBasicAuth = Authorization(BasicCredentials("john-doe", "secret"))
+    val authUser: Kleisli[OptionT[IO, ?], Request[IO], User] = Kleisli(
+      req =>
+        OptionT.fromOption {
+          req.headers.collectFirst {
+            case auth: Authorization if auth == johnDoeBasicAuth =>
+              User("John Doe")
+          }
+      }
+    )
+    val middleware          = AuthMiddleware(authUser)
+    val httpApp             = middleware(server3).orNotFound
+    val secureAddressClient = AddressesClient.httpClient(Client.fromHttpApp(httpApp))
+    val testTrace           = traceBuilder("top-level-request")
+
+    val johnDoeResponse: addresses.GetSecureAddressResponse =
+      secureAddressClient.getSecureAddress(testTrace, "addressId", headers = List(johnDoeBasicAuth)).unsafeRunSync()
+
+    johnDoeResponse shouldBe addresses.GetSecureAddressResponse
+      .Ok(cdefs.definitions.SecureAddress(Some("John Doe"), Some("line2"), Some("line3")))
+
+    val anonymousResponse =
+      secureAddressClient
+        .getSecureAddress(testTrace, "addressId", headers = List.empty)
+        .attempt
+        .unsafeRunSync()
+        .left
+        .value
+
+    anonymousResponse shouldBe UnexpectedStatus(Status.Unauthorized)
+  }
+}

--- a/modules/sample/src/main/resources/server3.yaml
+++ b/modules/sample/src/main/resources/server3.yaml
@@ -1,0 +1,73 @@
+swagger: "2.0"
+info:
+  title: Whatever
+  version: 1.0.0
+host: localhost:1234
+schemes:
+  - http
+definitions:
+  SecureAddress:
+    type: object
+    properties:
+      line1:
+        type: string
+      line2:
+        type: string
+      line3:
+        type: string
+#  UnauthorizedError:
+#    headers:
+#      WWW_Authenticate:
+#          type: string
+
+paths:
+  /secure/address:
+    get:
+      operationId: getSecureAddresses
+      x-jvm-package: secure.addresses
+      security:
+        - basicAuth: []
+      produces:
+        - application/json
+      responses:
+        '200':
+          type: array
+          items:
+            $ref: '#/definitions/SecureAddress'
+#        '401':
+#          description: Unauthorized
+#          $ref: '#/definitions/UnauthorizedError'
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found
+
+  /secure/address/{id}:
+    get:
+      operationId: getSecureAddress
+      x-jvm-package: secure.addresses
+      security:
+        - basicAuth: []
+      produces:
+        - application/json
+      parameters:
+      - name: id
+        in: path
+        required: true
+        type: string
+      responses:
+        '200':
+          schema:
+            $ref: '#/definitions/SecureAddress'
+#        '401':
+#          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found
+
+components:
+  securitySchemes:
+    basicAuth:
+      type: http
+      scheme: basic


### PR DESCRIPTION
http4s include a middleware for authenticating users. To enable this feature you need to add the `security` configuration to the openApi specification (see server3 for an example) and include the `--http4sAuthedRoutes` argument when generating the code. Note, this is only the server side
implementation. The client already has the option to pass headers.

Upgraded http4s since `AuthedRoutes` isn't available in `0.20.0`. I also bumped into https://github.com/twilio/guardrail/issues/179 so that's why some of the code is commented out.

Signed-off-by: Ingar Abrahamsen <ingar.abrahamsen@tapad.com>

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
