### PR TITLE
Ignoring default response code

### DIFF
--- a/modules/codegen/src/main/scala/com/twilio/guardrail/ProtocolGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/ProtocolGenerator.scala
@@ -345,15 +345,15 @@ object ProtocolGenerator {
               widenClass          <- widenClassDefinition(classDefinition.cls)
               companionTerm       <- pureTermName(classDefinition.name)
               companionDefinition <- wrapToObject(companionTerm, classDefinition.staticDefns.extraImports, classDefinition.staticDefns.definitions)
-              widenCompanion      <- widenObjectDefinition(companionDefinition)
-            } yield List(widenClass, widenCompanion)
+              widenCompanion      <- companionDefinition.traverse(widenObjectDefinition)
+            } yield List(widenClass) ++ widenCompanion
           case enumDefinition: EnumDefinition[L] =>
             for {
               widenClass          <- widenClassDefinition(enumDefinition.cls)
               companionTerm       <- pureTermName(enumDefinition.name)
               companionDefinition <- wrapToObject(companionTerm, enumDefinition.staticDefns.extraImports, enumDefinition.staticDefns.definitions)
-              widenCompanion      <- widenObjectDefinition(companionDefinition)
-            } yield List(widenClass, widenCompanion)
+              widenCompanion      <- companionDefinition.traverse(widenObjectDefinition)
+            } yield List(widenClass) ++ widenCompanion
         }
         nestedClasses.map { v =>
           val finalStaticDefns = staticDefns.copy(definitions = staticDefns.definitions ++ v)

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/AsyncHttpClientClientGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/AsyncHttpClientClientGenerator.scala
@@ -51,16 +51,20 @@ object AsyncHttpClientClientGenerator {
       } else {
         Option(RouteMeta.UrlencodedFormData)
       }
-    } else if (parameters.bodyParams.isDefined) {
-      val validTypes = Seq(RouteMeta.ApplicationJson, RouteMeta.TextPlain)
-      operation.consumes
-        .collectFirst({ case ContentType(value) if validTypes.contains(value) => value })
-        .orElse({
-          println(s"WARNING: no supported body param type for operation '${operation.getOperationId}'; falling back to application/json")
-          Option(RouteMeta.ApplicationJson)
-        })
     } else {
-      Option.empty
+      parameters.bodyParams.flatMap { param =>
+        val validTypes = Seq(RouteMeta.ApplicationJson, RouteMeta.TextPlain)
+        operation.consumes
+          .collectFirst({ case ContentType(value) if validTypes.contains(value) => value })
+          .orElse({
+            if (param.isFile) {
+              Option(RouteMeta.OctetStream)
+            } else {
+              println(s"WARNING: no supported body param type for operation '${operation.getOperationId}'; falling back to application/json")
+              Option(RouteMeta.ApplicationJson)
+            }
+          })
+      }
     }
 
   def getBestProduces(operation: Operation, response: Response[JavaLanguage]): Option[ContentType] = {

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/AsyncHttpClientClientGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/AsyncHttpClientClientGenerator.scala
@@ -171,14 +171,18 @@ object AsyncHttpClientClientGenerator {
       Option(
         new ExpressionStmt(
           wrapSetBody(
-            new ObjectCreationExpr(
-              null,
-              FILE_PART_TYPE,
-              new NodeList(
-                new StringLiteralExpr(param.argName.value),
-                new NameExpr(param.paramName.asString)
+            if (contentType.contains(RouteMeta.OctetStream)) {
+              new NameExpr(param.paramName.asString)
+            } else {
+              new ObjectCreationExpr(
+                null,
+                FILE_PART_TYPE,
+                new NodeList(
+                  new StringLiteralExpr(param.argName.value),
+                  new NameExpr(param.paramName.asString)
+                )
               )
-            )
+            }
           )
         )
       )

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/JacksonGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/JacksonGenerator.scala
@@ -878,6 +878,7 @@ object JacksonGenerator {
           "com.fasterxml.jackson.annotation.JsonCreator",
           "com.fasterxml.jackson.annotation.JsonIgnoreProperties",
           "com.fasterxml.jackson.annotation.JsonProperty",
+          "com.fasterxml.jackson.annotation.JsonValue",
           "java.util.Optional"
         ).map(safeParseRawImport) ++ List(
               "java.util.Objects.requireNonNull"

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/JavaGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/JavaGenerator.scala
@@ -306,6 +306,7 @@ object JavaGenerator {
               cu.setPackageDeclaration(pkgDecl)
               imports.foreach(cu.addImport)
               staticDefns.extraImports.foreach(cu.addImport)
+              cu.addImport(showerImport)
               val clsCopy = cls.clone()
               staticDefns.definitions.foreach(clsCopy.addMember)
               cu.addType(clsCopy)

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/JavaGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/JavaGenerator.scala
@@ -374,7 +374,7 @@ object JavaGenerator {
         } yield handlerTree +: serverTrees
 
       case WrapToObject(_, _, _) =>
-        Target.raiseError("Currently not supported for Java")
+        Target.pure(Option.empty) // Unnecessary in Java, due to static members
     }
   }
 }

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/ScalaGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/ScalaGenerator.scala
@@ -420,12 +420,12 @@ object ScalaGenerator {
           )
         )
       case WrapToObject(name, imports, definitions) =>
-        Target.pure(q"""
+        Target.pure(Option(q"""
              object $name {
                  ..$imports
                  ..$definitions
              }
-           """)
+           """))
     }
   }
 }

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/Responses.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/Responses.scala
@@ -32,35 +32,33 @@ object Responses {
     for {
       responses <- Sw.getResponses(operationId, operation)
 
-      instances <- responses
-        .foldLeft[List[Free[F, Response[L]]]](List.empty)({
-          case (acc, (key, resp)) =>
-            acc :+ (for {
-                  httpCode <- lookupStatusCode(key)
-                  (statusCode, statusCodeName) = httpCode
-                  valueTypes <- (for {
-                    (_, content) <- resp.downField("content", _.getContent()).indexedDistribute.value
-                    schema       <- content.downField("schema", _.getSchema()).indexedDistribute.toList
-                  } yield schema).traverse { prop =>
-                    for {
-                      meta     <- SwaggerUtil.propMeta[L, F](prop)
-                      resolved <- SwaggerUtil.ResolvedType.resolve[L, F](meta, protocolElems)
-                      SwaggerUtil.Resolved(baseType, _, baseDefaultValue, _, _) = resolved
+      instances <- responses.toList.traverse {
+        case (key, resp) =>
+          for {
+            httpCode <- lookupStatusCode(key)
+            (statusCode, statusCodeName) = httpCode
+            valueTypes <- (for {
+              (_, content) <- resp.downField("content", _.getContent()).indexedDistribute.value
+              schema       <- content.downField("schema", _.getSchema()).indexedDistribute.toList
+            } yield schema).traverse { prop =>
+              for {
+                meta     <- SwaggerUtil.propMeta[L, F](prop)
+                resolved <- SwaggerUtil.ResolvedType.resolve[L, F](meta, protocolElems)
+                SwaggerUtil.Resolved(baseType, _, baseDefaultValue, _, _) = resolved
 
-                    } yield (baseType, baseDefaultValue)
-                  }
-                  headers <- resp.downField("headers", _.getHeaders).indexedDistribute.value.traverse {
-                    case (name, header) =>
-                      for {
-                        termName <- pureTermName(s"${name}Header".toCamelCase)
-                        typeName <- pureTypeName("String").flatMap(widenTypeName)
-                        required = header.downField("required", _.getRequired).unwrapTracker.getOrElse(false)
-                        resultType <- if (required) Free.pure[F, L#Type](typeName) else liftOptionalType(typeName)
-                      } yield new Header(name, required, resultType, termName)
-                  }
-                } yield new Response[L](statusCodeName, statusCode, valueTypes.headOption, new Headers(headers))) // FIXME: headOption
-        })
-        .sequence
+              } yield (baseType, baseDefaultValue)
+            }
+            headers <- resp.downField("headers", _.getHeaders).indexedDistribute.value.traverse {
+              case (name, header) =>
+                for {
+                  termName <- pureTermName(s"${name}Header".toCamelCase)
+                  typeName <- pureTypeName("String").flatMap(widenTypeName)
+                  required = header.downField("required", _.getRequired).unwrapTracker.getOrElse(false)
+                  resultType <- if (required) Free.pure[F, L#Type](typeName) else liftOptionalType(typeName)
+                } yield new Header(name, required, resultType, termName)
+            }
+          } yield new Response[L](statusCodeName, statusCode, valueTypes.headOption, new Headers(headers)) // FIXME: headOption
+      }
     } yield new Responses[L](instances)
   }
 

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/terms/ScalaTerm.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/terms/ScalaTerm.scala
@@ -124,4 +124,4 @@ case class WriteServer[L <: LA](
     server: Server[L]
 ) extends ScalaTerm[L, List[WriteTree]]
 
-case class WrapToObject[L <: LA](name: L#TermName, imports: List[L#Import], definitions: List[L#Definition]) extends ScalaTerm[L, L#ObjectDefinition]
+case class WrapToObject[L <: LA](name: L#TermName, imports: List[L#Import], definitions: List[L#Definition]) extends ScalaTerm[L, Option[L#ObjectDefinition]]

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/terms/ScalaTerms.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/terms/ScalaTerms.scala
@@ -139,7 +139,7 @@ class ScalaTerms[L <: LA, F[_]](implicit I: InjectK[ScalaTerm[L, ?], F]) {
   ): Free[F, List[WriteTree]] =
     Free.inject[ScalaTerm[L, ?], F](WriteServer(pkgPath, pkgName, customImports, frameworkImplicitName, dtoComponents, server))
 
-  def wrapToObject(name: L#TermName, imports: List[L#Import], definitions: List[L#Definition]): Free[F, L#ObjectDefinition] =
+  def wrapToObject(name: L#TermName, imports: List[L#Import], definitions: List[L#Definition]): Free[F, Option[L#ObjectDefinition]] =
     Free.inject[ScalaTerm[L, ?], F](WrapToObject(name, imports, definitions))
 }
 object ScalaTerms {

--- a/modules/sample/src/main/resources/petstore-openapi-3.0.2.yaml
+++ b/modules/sample/src/main/resources/petstore-openapi-3.0.2.yaml
@@ -35,6 +35,7 @@ tags:
 paths:
   /pet:
     post:
+      x-jvm-package: pet
       tags:
         - pet
       summary: Add a new pet to the store
@@ -70,6 +71,7 @@ paths:
             schema:
               $ref: '#/components/schemas/Pet'
     put:
+      x-jvm-package: pet
       tags:
         - pet
       summary: Update an existing pet
@@ -110,6 +112,7 @@ paths:
               $ref: '#/components/schemas/Pet'
   /pet/findByStatus:
     get:
+      x-jvm-package: pet
       tags:
         - pet
       summary: Finds Pets by status
@@ -150,6 +153,7 @@ paths:
             - 'read:pets'
   /pet/findByTags:
     get:
+      x-jvm-package: pet
       tags:
         - pet
       summary: Finds Pets by tags
@@ -189,6 +193,7 @@ paths:
             - 'read:pets'
   '/pet/{petId}':
     get:
+      x-jvm-package: pet
       tags:
         - pet
       summary: Find pet by ID
@@ -222,6 +227,7 @@ paths:
             - 'write:pets'
             - 'read:pets'
     post:
+      x-jvm-package: pet
       tags:
         - pet
       summary: Updates a pet in the store with form data
@@ -253,6 +259,7 @@ paths:
             - 'write:pets'
             - 'read:pets'
     delete:
+      x-jvm-package: pet
       tags:
         - pet
       summary: Deletes a pet
@@ -281,6 +288,7 @@ paths:
             - 'read:pets'
   '/pet/{petId}/uploadImage':
     post:
+      x-jvm-package: pet
       tags:
         - pet
       summary: uploads an image
@@ -319,6 +327,7 @@ paths:
               format: binary
   /store/inventory:
     get:
+      x-jvm-package: store
       tags:
         - store
       summary: Returns pet inventories by status
@@ -339,6 +348,7 @@ paths:
         - api_key: []
   /store/order:
     post:
+      x-jvm-package: store
       tags:
         - store
       summary: Place an order for a pet
@@ -367,6 +377,7 @@ paths:
               $ref: '#/components/schemas/Order'
   '/store/order/{orderId}':
     get:
+      x-jvm-package: store
       tags:
         - store
       summary: Find purchase order by ID
@@ -398,6 +409,7 @@ paths:
         '404':
           description: Order not found
     delete:
+      x-jvm-package: store
       tags:
         - store
       summary: Delete purchase order by ID
@@ -421,6 +433,7 @@ paths:
           description: Order not found
   /user:
     post:
+      x-jvm-package: user
       tags:
         - user
       summary: Create user
@@ -450,6 +463,7 @@ paths:
         description: Created user object
   /user/createWithList:
     post:
+      x-jvm-package: user
       tags:
         - user
       summary: Creates list of users with given input array
@@ -477,6 +491,7 @@ paths:
                 $ref: '#/components/schemas/User'
   /user/login:
     get:
+      x-jvm-package: user
       tags:
         - user
       summary: Logs user into the system
@@ -520,6 +535,7 @@ paths:
           description: Invalid username/password supplied
   /user/logout:
     get:
+      x-jvm-package: user
       tags:
         - user
       summary: Logs out current logged in user session
@@ -531,6 +547,7 @@ paths:
           description: successful operation
   '/user/{username}':
     get:
+      x-jvm-package: user
       tags:
         - user
       summary: Get user by user name
@@ -558,6 +575,7 @@ paths:
         '404':
           description: User not found
     put:
+      x-jvm-package: user
       tags:
         - user
       summary: Update user
@@ -587,6 +605,7 @@ paths:
             schema:
               $ref: '#/components/schemas/User'
     delete:
+      x-jvm-package: user
       tags:
         - user
       summary: Delete user

--- a/modules/sample/src/main/resources/petstore-openapi-3.0.2.yaml
+++ b/modules/sample/src/main/resources/petstore-openapi-3.0.2.yaml
@@ -440,7 +440,7 @@ paths:
       description: This can only be done by the logged in user.
       operationId: createUser
       responses:
-        default:
+        200:
           description: successful operation
           content:
             application/json:
@@ -543,7 +543,7 @@ paths:
       operationId: logoutUser
       parameters: []
       responses:
-        default:
+        200:
           description: successful operation
   '/user/{username}':
     get:
@@ -590,7 +590,7 @@ paths:
           schema:
             type: string
       responses:
-        default:
+        200:
           description: successful operation
       requestBody:
         description: Update an existent user in the store


### PR DESCRIPTION
- Removing `Currently not supported for Java` in favor of just trusting the generated static class
- Removing `Unknown HTTP status code: default` in favor of ignoring it and emitting a warning

Unfortunately, while StructuredLogger is disabled, this effectively removes any capacity to actually emit these logs, while the performance refactoring is going on.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.