### PR TITLE
Add Java POJO support to form data

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -66,6 +66,7 @@ val exampleCases: List[ExampleCase] = List(
   ExampleCase(sampleResource("custom-header-type.yaml"), "tests.customTypes.customHeader"),
   ExampleCase(sampleResource("date-time.yaml"), "dateTime"),
   ExampleCase(sampleResource("edgecases/defaults.yaml"), "edgecases.defaults"),
+  ExampleCase(sampleResource("form-pojos.yaml"), "formPojos").frameworks(Set("dropwizard")),
   ExampleCase(sampleResource("formData.yaml"), "form"),
   ExampleCase(sampleResource("issues/issue45.yaml"), "issues.issue45"),
   ExampleCase(sampleResource("issues/issue121.yaml"), "issues.issue121"),
@@ -366,7 +367,6 @@ lazy val dropwizardSample = (project in file("modules/sample-dropwizard"))
       "org.glassfish.jersey.test-framework.providers" % "jersey-test-framework-provider-grizzly2" % jerseyVersion % Test
     ),
     unmanagedSourceDirectories in Compile += baseDirectory.value / "target" / "generated",
-    crossPaths := false,  // strangely needed to get the JUnit tests to run at all
     skip in publish := true,
     scalafmtOnCompile := false
   )

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/DropwizardServerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/DropwizardServerGenerator.scala
@@ -628,9 +628,10 @@ object DropwizardServerGenerator {
             "javax.ws.rs.HttpMethod"
           ).traverse(safeParseRawImport)
 
-          shower <- SerializationHelpers.showerSupportDef
-
-          jersey <- SerializationHelpers.guardrailJerseySupportDef
+          shower                  <- SerializationHelpers.showerSupportDef
+          jersey                  <- SerializationHelpers.guardrailJerseySupportDef
+          jacksonFormUtils        <- SerializationHelpers.jacksonFormUtils
+          jacksonFormReaderWriter <- SerializationHelpers.jacksonFormMessageReaderWriterDef
         } yield {
           def httpMethodAnnotation(name: String): SupportDefinition[JavaLanguage] = {
             val annotationDecl = new AnnotationDeclaration(new NodeList(publicModifier), name)
@@ -648,6 +649,8 @@ object DropwizardServerGenerator {
           List(
             shower,
             jersey,
+            jacksonFormUtils,
+            jacksonFormReaderWriter,
             httpMethodAnnotation("PATCH"),
             httpMethodAnnotation("TRACE")
           )

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/JacksonGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/JacksonGenerator.scala
@@ -764,7 +764,7 @@ object JacksonGenerator {
           )
           .getOrElse(Target.pure(List.empty[(String, Tracker[Schema[_]])]))
 
-      case TransformProperty(clsName, name, property, meta, needCamelSnakeConversion, concreteTypes, isRequired, isCustomType, defaultValue) =>
+      case TransformProperty(clsName, name, property, meta, _, concreteTypes, isRequired, isCustomType, defaultValue) =>
         Target.log.function("transformProperty") {
           val readOnlyKey = Option(name).filter(_ => Option(property.getReadOnly).contains(true))
           val emptyToNull = (property match {
@@ -805,7 +805,7 @@ object JacksonGenerator {
             }
             (tpe, classDep) = tpeClassDep
 
-            argName = if (needCamelSnakeConversion) name.toCamelCase else name
+            argName = name.toCamelCase
             rawType = RawParameterType(Option(property.getType), Option(property.getFormat))
 
             expressionDefaultValue <- defaultValue match {

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/SerializationHelpers.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/SerializationHelpers.scala
@@ -280,4 +280,230 @@ object SerializationHelpers {
       }
     """
   )
+
+  def jacksonFormUtils: Target[SupportDefinition[JavaLanguage]] = loadSupportDefinitionFromString(
+    "GuardrailJacksonFormUtils",
+    """
+      import com.fasterxml.jackson.databind.BeanDescription;
+      import com.fasterxml.jackson.databind.JavaType;
+      import com.fasterxml.jackson.databind.JsonNode;
+      import com.fasterxml.jackson.databind.ObjectMapper;
+      import com.fasterxml.jackson.databind.introspect.BasicClassIntrospector;
+      import com.fasterxml.jackson.databind.introspect.BeanPropertyDefinition;
+      import com.fasterxml.jackson.databind.introspect.ClassIntrospector;
+      import com.fasterxml.jackson.databind.introspect.SimpleMixInResolver;
+      import com.fasterxml.jackson.databind.node.ArrayNode;
+      import com.fasterxml.jackson.databind.node.ObjectNode;
+      import com.fasterxml.jackson.databind.node.TextNode;
+
+      import java.lang.reflect.Type;
+      import java.util.ArrayList;
+      import java.util.Collections;
+      import java.util.HashMap;
+      import java.util.Iterator;
+      import java.util.List;
+      import java.util.Map;
+      import java.util.Optional;
+      import java.util.function.Function;
+      import java.util.function.Supplier;
+      import java.util.stream.Collectors;
+
+      public class GuardrailJacksonFormUtils {
+          public static <T> T readUrlEncodedForm(final ObjectMapper mapper,
+                                                 final Type outputType,
+                                                 final Supplier<Map<String, List<String>>> formDataReader)
+          {
+              final JavaType jType = mapper.constructType(outputType);
+              final Map<String, BeanPropertyDefinition> properties = getProperties(mapper, jType);
+              final Map<String, List<String>> formData = formDataReader.get();
+              final JsonNode root = createFormDataNode(mapper, formData, properties);
+              return mapper.convertValue(root, jType);
+          }
+
+          public static <T> Map<String, List<String>> writeUrlEncodedForm(final ObjectMapper mapper, final T data) {
+              final JavaType jType = mapper.constructType(data.getClass());
+              final Map<String, BeanPropertyDefinition> properties = getProperties(mapper, jType);
+              final JsonNode root = mapper.convertValue(data, JsonNode.class);
+              return createFormDataMap(root, properties);
+          }
+
+          private static Map<String, BeanPropertyDefinition> getProperties(final ObjectMapper mapper, final JavaType jType) {
+              final ClassIntrospector classIntrospector = new BasicClassIntrospector();
+              final BeanDescription desc = classIntrospector.forDeserialization(mapper.getDeserializationConfig(), jType, new SimpleMixInResolver(null));
+              return desc.findProperties().stream().collect(Collectors.toMap(BeanPropertyDefinition::getName, Function.identity()));
+          }
+
+          private static JsonNode createFormDataNode(final ObjectMapper mapper,
+                                                     final Map<String, List<String>> formData,
+                                                     final Map<String, BeanPropertyDefinition> properties)
+          {
+              final ObjectNode root = mapper.createObjectNode();
+              for (final Map.Entry<String, List<String>> entry : formData.entrySet()) {
+                  if (properties.containsKey(entry.getKey())) {
+                      final BeanPropertyDefinition defn = properties.get(entry.getKey());
+                      final JavaType propType = propType(defn);
+
+                      if (propType.isCollectionLikeType()) {
+                          if (propType.getRawClass() == List.class) {
+                              if (!root.has(entry.getKey())) {
+                                  root.set(entry.getKey(), mapper.createArrayNode());
+                              }
+                              final ArrayNode array = (ArrayNode) root.get(entry.getKey());
+                              array.addAll(entry.getValue().stream().map(TextNode::new).collect(Collectors.toList()));
+                          } else {
+                              throw new IllegalArgumentException("Unsupported form-data type " + propType.getRawClass().getName() + " for property '" + entry.getKey() + "'");
+                          }
+                      } else if (!entry.getValue().isEmpty()) {
+                          root.set(entry.getKey(), new TextNode(entry.getValue().get(0)));
+                      }
+                  }
+              }
+
+              return root;
+          }
+
+          private static Map<String, List<String>> createFormDataMap(final JsonNode root,
+                                                                     final Map<String, BeanPropertyDefinition> properties)
+          {
+              if (!root.isObject()) {
+                  throw new IllegalArgumentException("Form-data POJO is not serializable");
+              }
+
+              final Map<String, List<String>> map = new HashMap<>();
+              final Iterator<String> fieldNames = root.fieldNames();
+              while (fieldNames.hasNext()) {
+                  final String fieldName = fieldNames.next();
+                  if (properties.containsKey(fieldName)) {
+                      final JsonNode field = root.get(fieldName);
+
+                      if (!field.isNull()) {
+                          final BeanPropertyDefinition defn = properties.get(fieldName);
+                          final JavaType propType = propType(defn);
+
+                          if (field.isArray()) {
+                              final List<String> array = new ArrayList<>();
+                              for (final JsonNode element : field) {
+                                  array.add(element.asText());
+                              }
+                              map.put(fieldName, array);
+                          } else if (field.isObject()) {
+                              throw new IllegalArgumentException("Unsupported form-data type " + propType.getRawClass().getName() + " for property '" + fieldName + "'");
+                          } else {
+                              map.put(fieldName, Collections.singletonList(field.asText()));
+                          }
+                      }
+                  }
+              }
+
+              return map;
+          }
+
+          private static JavaType propType(final BeanPropertyDefinition defn) {
+              if (defn.getPrimaryType().getRawClass() == Optional.class) {
+                  return defn.getPrimaryType().containedType(0);
+              } else {
+                  return defn.getPrimaryType();
+              }
+          }
+      }
+    """
+  )
+
+  def jacksonFormMessageReaderWriterDef: Target[SupportDefinition[JavaLanguage]] = loadSupportDefinitionFromString(
+    "GuardrailJacksonFormMessageReaderWriter",
+    """
+      import com.fasterxml.jackson.databind.ObjectMapper;
+      import org.glassfish.jersey.message.internal.AbstractFormProvider;
+
+      import javax.inject.Singleton;
+      import javax.validation.ValidationException;
+      import javax.ws.rs.Consumes;
+      import javax.ws.rs.Produces;
+      import javax.ws.rs.WebApplicationException;
+      import javax.ws.rs.core.MediaType;
+      import javax.ws.rs.core.MultivaluedHashMap;
+      import javax.ws.rs.core.MultivaluedMap;
+      import java.io.IOException;
+      import java.io.InputStream;
+      import java.io.OutputStream;
+      import java.io.UncheckedIOException;
+      import java.lang.annotation.Annotation;
+      import java.lang.reflect.ParameterizedType;
+      import java.lang.reflect.Type;
+      import java.util.ArrayList;
+      import java.util.List;
+      import java.util.Map;
+      import java.util.Optional;
+      import java.util.regex.Matcher;
+      import java.util.regex.Pattern;
+      import java.util.stream.Collectors;
+
+      @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+      @Produces(MediaType.APPLICATION_FORM_URLENCODED)
+      @Singleton
+      public class GuardrailJacksonFormMessageReaderWriter extends AbstractFormProvider<Object> {
+          private final ObjectMapper mapper;
+
+          public GuardrailJacksonFormMessageReaderWriter(final ObjectMapper mapper) {
+              this.mapper = mapper;
+          }
+
+          @Override
+          public boolean isReadable(final Class<?> type, final Type genericType, final Annotation[] annotations, final MediaType mediaType) {
+              return this.mapper.canDeserialize(this.mapper.constructType(genericType));
+          }
+
+          @Override
+          public boolean isWriteable(final Class<?> type, final Type genericType, final Annotation[] annotations, final MediaType mediaType) {
+              return this.mapper.canSerialize(type);
+          }
+
+          @Override
+          public Object readFrom(final Class<Object> type, final Type genericType, final Annotation[] annotations, final MediaType mediaType, final MultivaluedMap<String, String> httpHeaders, final InputStream entityStream) throws WebApplicationException, IOException {
+              try {
+                  final Type containedType = unwrapOptionalType(genericType);
+                  final Object result = GuardrailJacksonFormUtils.readUrlEncodedForm(this.mapper, containedType, () -> {
+                      try {
+                          return readFrom(new MultivaluedHashMap<>(), mediaType, true, entityStream);
+                      } catch (final IOException e) {
+                          throw new UncheckedIOException(e);
+                      }
+                  });
+                  return containedType == genericType ? result : Optional.ofNullable(result);
+              } catch (final UncheckedIOException e) {
+                  throw e.getCause();
+              } catch (final IllegalArgumentException e) {
+                  throw new ValidationException("Invalid or missing form data", e.getCause() != null ? e.getCause() : e);
+              }
+          }
+
+          @Override
+          public void writeTo(final Object t, final Class<?> type, final Type genericType, final Annotation[] annotations, final MediaType mediaType, MultivaluedMap<String, Object> httpHeaders, final OutputStream entityStream) throws IOException, WebApplicationException {
+              final Map<String, List<String>> map = GuardrailJacksonFormUtils.writeUrlEncodedForm(this.mapper, t);
+              final MultivaluedMap<String, String> mvmap = map.entrySet().stream().collect(Collectors.toMap(
+                      Map.Entry::getKey,
+                      Map.Entry::getValue,
+                      (a, b) -> {
+                          final List<String> combined = new ArrayList<>(a.size() + b.size());
+                          combined.addAll(a);
+                          combined.addAll(b);
+                          return combined;
+                      },
+                      MultivaluedHashMap::new
+              ));
+              writeTo(mvmap, mediaType, entityStream);
+          }
+
+          private Type unwrapOptionalType(final Type genericType) {
+              if (genericType instanceof ParameterizedType && ((ParameterizedType) genericType).getRawType() == Optional.class) {
+                  final Type[] typeArgs = ((ParameterizedType) genericType).getActualTypeArguments();
+                  if (typeArgs.length == 1) {
+                      return typeArgs[0];
+                  }
+              }
+              return genericType;
+          }
+      }
+    """
+  )
 }

--- a/modules/sample-dropwizard/src/test/java/core/Dropwizard/DropwizardFormPojosTest.java
+++ b/modules/sample-dropwizard/src/test/java/core/Dropwizard/DropwizardFormPojosTest.java
@@ -1,0 +1,103 @@
+package core.Dropwizard;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import formPojos.client.dropwizard.definitions.SomeEnum;
+import formPojos.client.dropwizard.formPojos.DoFormOptResponse;
+import formPojos.client.dropwizard.formPojos.DoFormReqResponse;
+import formPojos.client.dropwizard.formPojos.FormPojosClient;
+import formPojos.server.dropwizard.GuardrailJacksonFormMessageReaderWriter;
+import formPojos.server.dropwizard.definitions.FormBody;
+import formPojos.server.dropwizard.formPojos.FormPojosHandler;
+import formPojos.server.dropwizard.formPojos.FormPojosResource;
+import io.dropwizard.testing.junit.ResourceTestRule;
+import org.glassfish.jersey.test.TestProperties;
+import org.glassfish.jersey.test.grizzly.GrizzlyTestContainerFactory;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ExecutionException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class DropwizardFormPojosTest {
+    static {
+        System.setProperty(TestProperties.CONTAINER_PORT, "0");
+    }
+
+    private static final ObjectMapper mapper = new ObjectMapper()
+            .registerModule(new JavaTimeModule())
+            .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
+    private static final FormPojosHandler handler = new FormPojosHandler() {
+        @Override
+        public CompletionStage<DoFormOptResponse> doFormOpt(final Optional<FormBody> body) {
+            assertThat(body).isNotEmpty();
+            return CompletableFuture.completedFuture(DoFormOptResponse.Ok(body.get()));
+        }
+
+        @Override
+        public CompletionStage<DoFormReqResponse> doFormReq(final FormBody body) {
+            return CompletableFuture.completedFuture(DoFormReqResponse.Ok(body));
+        }
+    };
+
+    @ClassRule
+    public static ResourceTestRule resources = new ResourceTestRule.Builder()
+            .setTestContainerFactory(new GrizzlyTestContainerFactory())
+            .addProvider(new GuardrailJacksonFormMessageReaderWriter(mapper))
+            .addResource(new FormPojosResource(handler))
+            .build();
+
+    private static FormPojosClient createClient() throws URISyntaxException {
+        final URI uri = resources.target("").getUriBuilder().build();
+        return new FormPojosClient.Builder(new URI(uri.toString().substring(0, uri.toString().length() - 1)))
+                .withObjectMapper(mapper)
+                .build();
+    }
+
+    private formPojos.client.dropwizard.definitions.FormBody createFormBody() {
+        return new formPojos.client.dropwizard.definitions.FormBody.Builder(
+                "some string",
+                42,
+                false,
+                OffsetDateTime.ofInstant(Instant.EPOCH, ZoneId.of("UTC")),
+                SomeEnum.ANOTHER_VALUE
+        )
+                .withReqList(Arrays.asList("list item one", "list item two", "list item three"))
+                .withOptString("another string")
+                .withOptInt(9876)
+                .withOptBoolean(true)
+                .withOptDateTime(OffsetDateTime.ofInstant(Instant.EPOCH, ZoneId.of("UTC")))
+                .withOptEnum(SomeEnum.YET_ANOTHER_VALUE)
+                .build();
+    }
+
+    @Test
+    public void testReqRoundTrip() throws ExecutionException, InterruptedException, URISyntaxException {
+        final FormPojosClient client = createClient();
+        final formPojos.client.dropwizard.definitions.FormBody body = createFormBody();
+        final DoFormReqResponse response = client.doFormReq(body).call().toCompletableFuture().get();
+        assertThat(response).isInstanceOf(DoFormReqResponse.Ok.class);
+        assertThat(((DoFormReqResponse.Ok) response).getValue()).isEqualToComparingFieldByField(body);
+    }
+
+    @Test
+    public void testOptRoundTrip() throws ExecutionException, InterruptedException, URISyntaxException {
+        final FormPojosClient client = createClient();
+        final formPojos.client.dropwizard.definitions.FormBody body = createFormBody();
+        final DoFormOptResponse response = client.doFormOpt().withBody(body).call().toCompletableFuture().get();
+        assertThat(response).isInstanceOf(DoFormOptResponse.Ok.class);
+        assertThat(((DoFormOptResponse.Ok) response).getValue()).isEqualToComparingFieldByField(body);
+    }
+}

--- a/modules/sample/src/main/resources/form-pojos.yaml
+++ b/modules/sample/src/main/resources/form-pojos.yaml
@@ -1,0 +1,83 @@
+openapi: 3.0.2
+info:
+  title: Using model objects as form data
+  version: 1.0.0
+paths:
+  /reqBody:
+    post:
+      x-jvm-package: formPojos
+      operationId: doFormReq
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: "#/components/schemas/FormBody"
+      responses:
+        200:
+          content:
+            application/x-www-form-urlencoded:
+              schema:
+                $ref: "#/components/schemas/FormBody"
+  /optBody:
+    post:
+      x-jvm-package: formPojos
+      operationId: doFormOpt
+      requestBody:
+        required: false
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: "#/components/schemas/FormBody"
+      responses:
+        200:
+          content:
+            application/x-www-form-urlencoded:
+              schema:
+                $ref: "#/components/schemas/FormBody"
+components:
+  schemas:
+    SomeEnum:
+      type: string
+      enum:
+        - some-value
+        - another-value
+        - yet-another-value
+    FormBody:
+      type: object
+      required:
+        - ReqString
+        - ReqInt
+        - ReqBoolean
+        - ReqDateTime
+        - ReqEnum
+        - ReqList
+      properties:
+        ReqString:
+          type: string
+        ReqInt:
+          type: integer
+          format: int32
+        ReqBoolean:
+          type: boolean
+        ReqDateTime:
+          type: string
+          format: date-time
+        ReqEnum:
+          $ref: "#/components/schemas/SomeEnum"
+        ReqList:
+          type: array
+          items:
+            type: string
+        OptString:
+          type: string
+        OptInt:
+          type: integer
+          format: int32
+        OptBoolean:
+          type: boolean
+        OptDateTime:
+          type: string
+          format: date-time
+        OptEnum:
+          $ref: "#/components/schemas/SomeEnum"


### PR DESCRIPTION
OpenAPI v3 allows you to use `$ref`s when specifying form data, which means you end up with a model object as your body parameter, instead of a parameter for each form field.  The latter has always been supported, but until now I lacked a decent way to use the model objects for
anything but JSON.

On the server side, I've implemented a MessageBodyReader and MessageBodyWriter which can be registered with Jersey and will handle ser/deser.

On the client side, I've inserted generated code for marshalling requests and unmarshalling responses to do the ser/deser.

Underlying all this is some (fortunately mostly common) code that uses Jackson's introspection capabilities to figure out the properties in the POJO and map to and from form data fields.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
