### PR TITLE
First naive pass at using Bean Validation in Jackson objects

### DIFF
--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/JacksonGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/JacksonGenerator.scala
@@ -38,6 +38,19 @@ import com.twilio.guardrail.protocol.terms.protocol._
 import com.twilio.guardrail.terms.CollectionsLibTerms
 
 import scala.collection.JavaConverters._
+import com.github.javaparser.StaticJavaParser
+import com.github.javaparser.ast.{ Node, NodeList }
+import com.github.javaparser.ast.stmt._
+import com.github.javaparser.ast.Modifier.Keyword.{ FINAL, PRIVATE, PROTECTED, PUBLIC }
+import com.github.javaparser.ast.Modifier._
+import com.github.javaparser.ast.body._
+import com.github.javaparser.ast.expr._
+import java.math.BigInteger
+import java.util.Locale
+
+import com.twilio.guardrail.protocol.terms.protocol.PropertyConstraint.{ Maximum, Minimum }
+
+import scala.util.Try
 
 object JacksonGenerator {
   private val BUILDER_TYPE        = StaticJavaParser.parseClassOrInterfaceType("Builder")
@@ -51,7 +64,8 @@ object JacksonGenerator {
       parameterType: Type,
       rawType: RawParameterType,
       defaultValue: Option[Expression],
-      dataRedacted: RedactionBehaviour
+      dataRedacted: RedactionBehaviour,
+      constraints: Set[PropertyConstraint]
   )
 
   // returns a tuple of (requiredTerms, optionalTerms)
@@ -71,7 +85,16 @@ object JacksonGenerator {
         }
         val defaultValue = defaultValueToExpression(param.defaultValue)
 
-        ParameterTerm(param.name.value, param.term.getNameAsString, param.term.getType.unbox, parameterType, param.rawType, defaultValue, param.dataRedaction)
+        ParameterTerm(
+          param.name.value,
+          param.term.getNameAsString,
+          param.term.getType.unbox,
+          parameterType,
+          param.rawType,
+          defaultValue,
+          param.dataRedaction,
+          param.constraints
+        )
       })
       .partition(
         pt => !Cl.isOptionalType(pt.fieldType) && pt.defaultValue.isEmpty
@@ -438,9 +461,13 @@ object JacksonGenerator {
         _ = addParents(dtoClass, parentOpt)
 
         _ = terms.foreach({
-          case ParameterTerm(propertyName, parameterName, fieldType, _, _, _, _) =>
+          case ParameterTerm(propertyName, parameterName, fieldType, _, _, _, _, constraints) =>
             val field: FieldDeclaration = dtoClass.addField(fieldType, parameterName, PRIVATE, FINAL)
             field.addSingleMemberAnnotation("JsonProperty", new StringLiteralExpr(propertyName))
+            for (constraint <- constraints) yield (constraint) match {
+              case Minimum(value) => field.addSingleMemberAnnotation("Min", new IntegerLiteralExpr(value.toString))
+              case Maximum(value) => field.addSingleMemberAnnotation("Max", new IntegerLiteralExpr(value.toString))
+            }
         })
 
         primaryConstructor = dtoClass
@@ -449,7 +476,7 @@ object JacksonGenerator {
           .setParameters(
             new NodeList(
               withoutDiscriminators(parentTerms ++ terms).map({
-                case ParameterTerm(propertyName, parameterName, fieldType, _, _, _, _) =>
+                case ParameterTerm(propertyName, parameterName, fieldType, _, _, _, _, _) =>
                   new Parameter(new NodeList(finalModifier), fieldType, new SimpleName(parameterName))
                     .addAnnotation(new SingleMemberAnnotationExpr(new Name("JsonProperty"), new StringLiteralExpr(propertyName)))
               }): _*
@@ -588,11 +615,11 @@ object JacksonGenerator {
         builderClass = new ClassOrInterfaceDeclaration(new NodeList(publicModifier, staticModifier), false, "Builder")
 
         _ = withoutDiscriminators(parentRequiredTerms ++ requiredTerms).foreach({
-          case ParameterTerm(_, parameterName, fieldType, _, _, _, _) =>
+          case ParameterTerm(_, parameterName, fieldType, _, _, _, _, _) =>
             builderClass.addField(fieldType, parameterName, PRIVATE)
         })
         _ <- withoutDiscriminators(parentOptionalTerms ++ optionalTerms).traverse({
-          case ParameterTerm(_, parameterName, fieldType, _, _, defaultValue, _) =>
+          case ParameterTerm(_, parameterName, fieldType, _, _, defaultValue, _, _) =>
             for {
               initializer <- defaultValue.fold[Target[Expression]](
                 Cl.emptyOptionalTerm().flatMap(_.toExpression)
@@ -613,7 +640,7 @@ object JacksonGenerator {
           .setParameters(
             new NodeList(
               withoutDiscriminators(parentRequiredTerms ++ requiredTerms).map({
-                case ParameterTerm(_, parameterName, _, parameterType, _, _, _) =>
+                case ParameterTerm(_, parameterName, _, parameterType, _, _, _, _) =>
                   new Parameter(new NodeList(finalModifier), parameterType, new SimpleName(parameterName))
               }): _*
             )
@@ -622,7 +649,7 @@ object JacksonGenerator {
             new BlockStmt(
               new NodeList(
                 withoutDiscriminators(parentRequiredTerms ++ requiredTerms).map({
-                  case ParameterTerm(_, parameterName, fieldType, _, _, _, _) =>
+                  case ParameterTerm(_, parameterName, fieldType, _, _, _, _, _) =>
                     new ExpressionStmt(
                       new AssignExpr(
                         new FieldAccessExpr(new ThisExpr, parameterName),
@@ -645,7 +672,7 @@ object JacksonGenerator {
             new BlockStmt(
               withoutDiscriminators(parentTerms ++ terms)
                 .map({
-                  case term @ ParameterTerm(_, parameterName, _, _, _, _, _) =>
+                  case term @ ParameterTerm(_, parameterName, _, _, _, _, _, _) =>
                     new ExpressionStmt(
                       new AssignExpr(
                         new FieldAccessExpr(new ThisExpr, parameterName),
@@ -660,7 +687,7 @@ object JacksonGenerator {
 
         // TODO: leave out with${name}() if readOnlyKey?
         _ <- withoutDiscriminators(parentTerms ++ terms).traverse({
-          case ParameterTerm(_, parameterName, fieldType, parameterType, _, _, _) =>
+          case ParameterTerm(_, parameterName, fieldType, parameterType, _, _, _, _) =>
             val methodName = s"with${parameterName.unescapeIdentifier.capitalize}"
             for {
               fieldInitializer <- (fieldType, parameterType) match {
@@ -800,6 +827,7 @@ object JacksonGenerator {
         property: Schema[_],
         meta: SwaggerUtil.ResolvedType[JavaLanguage],
         requirement: PropertyRequirement,
+        constraints: Set[PropertyConstraint],
         isCustomType: Boolean,
         defaultValue: Option[com.github.javaparser.ast.Node]
     ) =
@@ -869,7 +897,8 @@ object JacksonGenerator {
           emptyToNull,
           dataRedaction,
           requirement,
-          finalDefaultValue
+          finalDefaultValue,
+          constraints
         )
       }
 
@@ -934,7 +963,9 @@ object JacksonGenerator {
         "com.fasterxml.jackson.annotation.JsonCreator",
         "com.fasterxml.jackson.annotation.JsonIgnoreProperties",
         "com.fasterxml.jackson.annotation.JsonProperty",
-        "com.fasterxml.jackson.annotation.JsonValue"
+        "com.fasterxml.jackson.annotation.JsonValue",
+        "javax.validation.constraints.Max",
+        "javax.validation.constraints.Min"
       ).map(safeParseRawImport) ++ List(
             "java.util.Objects.requireNonNull"
           ).map(safeParseRawStaticImport)).sequence

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/CirceProtocolGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/CirceProtocolGenerator.scala
@@ -154,6 +154,7 @@ object CirceProtocolGenerator {
         property: Schema[_],
         meta: ResolvedType[ScalaLanguage],
         requirement: PropertyRequirement,
+        constraints: Set[PropertyConstraint],
         isCustomType: Boolean,
         defaultValue: Option[scala.meta.Term]
     ): Target[ProtocolParameter[ScalaLanguage]] =
@@ -216,7 +217,8 @@ object CirceProtocolGenerator {
           emptyToNull,
           dataRedaction,
           requirement,
-          finalDefaultValue
+          finalDefaultValue,
+          constraints
         )
       }
 

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/ModelProtocolTerm.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/ModelProtocolTerm.scala
@@ -17,3 +17,9 @@ object PropertyRequirement {
 
   final case class Configured(encoder: OptionalRequirement, decoder: OptionalRequirement) extends PropertyRequirement
 }
+
+sealed trait PropertyConstraint
+object PropertyConstraint {
+  case class Maximum(value: BigDecimal) extends PropertyConstraint
+  case class Minimum(value: BigDecimal) extends PropertyConstraint
+}

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/ModelProtocolTerms.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/ModelProtocolTerms.scala
@@ -22,6 +22,7 @@ abstract class ModelProtocolTerms[L <: LA, F[_]](implicit Cl: CollectionsLibTerm
       prop: Schema[_],
       meta: ResolvedType[L],
       requirement: PropertyRequirement,
+      constraints: Set[PropertyConstraint],
       isCustomType: Boolean,
       defaultValue: Option[L#Term]
   ): F[ProtocolParameter[L]]
@@ -49,7 +50,8 @@ abstract class ModelProtocolTerms[L <: LA, F[_]](implicit Cl: CollectionsLibTerm
           List[String],
           List[String],
           List[PropMeta[L]]
-      ) => (String, String, Schema[_], ResolvedType[L], PropertyRequirement, Boolean, Option[L#Term]) => F[ProtocolParameter[L]] = transformProperty _,
+      ) => (String, String, Schema[_], ResolvedType[L], PropertyRequirement, Set[PropertyConstraint], Boolean, Option[L#Term]) => F[ProtocolParameter[L]] =
+        transformProperty _,
       newRenderDTOClass: (String, List[String], List[ProtocolParameter[L]], List[SuperClass[L]]) => F[L#ClassDefinition] = renderDTOClass _,
       newDecodeModel: (String, List[String], List[String], List[ProtocolParameter[L]], List[SuperClass[L]]) => F[Option[L#ValueDefinition]] = decodeModel _,
       newEncodeModel: (String, List[String], List[ProtocolParameter[L]], List[SuperClass[L]]) => F[Option[L#ValueDefinition]] = encodeModel _,
@@ -68,6 +70,7 @@ abstract class ModelProtocolTerms[L <: LA, F[_]](implicit Cl: CollectionsLibTerm
         prop: Schema[_],
         meta: ResolvedType[L],
         requirement: PropertyRequirement,
+        constraints: Set[PropertyConstraint],
         isCustomType: Boolean,
         defaultValue: Option[L#Term]
     ) =
@@ -77,6 +80,7 @@ abstract class ModelProtocolTerms[L <: LA, F[_]](implicit Cl: CollectionsLibTerm
         prop,
         meta,
         requirement,
+        constraints,
         isCustomType,
         defaultValue
       )


### PR DESCRIPTION
A naive implementation allowing for validation (#231) in Dropwizard projects by using Bean Validation on the Jackson protocol objects. Right now only implemented `@Min`/`@Max` to support `minimum`/`maximum`. 

I say naive as this is missing a few pieces for "full" support (apart from supporting all available constraints OpenAPI allows). Including testing, of which there is none.

The other key piece is determining how this validation actually works alongside Dropwizard. Dropwizard Validation will validate beans before the request ever makes it to the handler, meaning we'll be returning responses to the client that aren't necessarily documented or even follow a documented error response format.

Couple thoughts I've had:
- Create a new ExceptionMapper for `JerseyViolationMapper` which can map constraint violations to response objects generated by Guardrail -- would likely need to generate an abstract class with a method per operation. Developer would need to create an implementation of that class and register it using `environment.jersey().register()` (see: https://www.dropwizard.io/en/latest/manual/validation.html#extending)
- Attempt to bypass any validation by Dropwizard and amend the handler code to include built-in validation by calling Bean Validation directly (possibly through abstract class so a handler implementation can call `super` to use it or write their own)
- Something else I haven't though of

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [X] I acknowledge that all my contributions will be made under the project's license.
