### PR TITLE
Format generated source with scalafmt before writing to disk

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -280,6 +280,7 @@ lazy val codegen = (project in file("modules/codegen"))
       codegenSettings,
     libraryDependencies ++= testDependencies ++ Seq(
       "org.scalameta"               %% "scalameta"                    % "4.3.20",
+      "org.scalameta"               %% "scalafmt-dynamic"             % "2.6.4",
       "com.github.javaparser"       % "javaparser-symbol-solver-core" % javaparserVersion,
       "org.eclipse.jdt"             % "org.eclipse.jdt.core"          % "3.22.0",
       "org.eclipse.platform"        % "org.eclipse.equinox.app"       % "1.4.500",

--- a/modules/codegen/src/main/resources/scalafmt.conf
+++ b/modules/codegen/src/main/resources/scalafmt.conf
@@ -1,0 +1,10 @@
+version=2.4.2
+edition = 2019-09
+
+style = defaultWithAlign
+
+danglingParentheses        = true
+maxColumn                  = 160
+rewrite.rules              = [AsciiSortImports, RedundantBraces, RedundantParens, PreferCurlyFors ]
+spaces.inImportCurlyBraces = true
+unindentTopLevelOperators  = true


### PR DESCRIPTION
Scalameta's code formatter generated unreadable code.  Scalafmt's (ironically, written by the same people) is much better.

I **do not** recommend merging this, as it makes the generation run take a **lot** longer.  But posting this here for posterity, or if there's a way to speed up the scalafmt run considerably, someone can take it.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
