### PR TITLE
Scala deprecation updates

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -92,7 +92,22 @@ lazy val root = modules.root.project
   .customDependsOn(microsite)
   .customDependsOn(cli)
   .aggregate(allDeps, microsite)
-  .aggregate(allModules: _*)
+  .aggregate(
+    cli,
+    core,
+    guardrail,
+
+    javaSupport,
+    javaAsyncHttp,
+    javaDropwizard,
+    javaSpringMvc,
+
+    scalaSupport,
+    scalaAkkaHttp,
+    scalaEndpoints,
+    scalaHttp4s,
+    scalaDropwizard,
+  )
 
 lazy val allDeps = modules.allDeps.project
   .settings(publish / skip := true)
@@ -152,23 +167,6 @@ lazy val scalaHttp4s = modules.scalaHttp4s.project
 lazy val scalaDropwizardSample = modules.scalaDropwizard.sample
 lazy val scalaDropwizard = modules.scalaDropwizard.project
   .customDependsOn(scalaSupport)
-
-lazy val allModules = Seq[sbt.ProjectReference](
-  cli,
-  core,
-  guardrail,
-
-  javaSupport,
-  javaAsyncHttp,
-  javaDropwizard,
-  javaSpringMvc,
-
-  scalaSupport,
-  scalaAkkaHttp,
-  scalaEndpoints,
-  scalaHttp4s,
-  scalaDropwizard,
-)
 
 lazy val microsite = baseModule("microsite", "microsite", file("modules/microsite"))
   .settings(

--- a/modules/microsite/docs/scala/akka-http/generating-a-server.md
+++ b/modules/microsite/docs/scala/akka-http/generating-a-server.md
@@ -102,7 +102,7 @@ val userRoutes: Route = UserResource.routes(new UserHandler {
     }
   }
 })
-val userHttpClient: HttpRequest => Future[HttpResponse] = Route.asyncHandler(userRoutes)
+val userHttpClient: HttpRequest => Future[HttpResponse] = Route.toFunction(userRoutes)
 val userClient: UserClient = UserClient.httpCLient(userHttpClient)
 val getUserResponse: EitherT[Future, Either[Throwable, HttpResponse], User] = userClient.getUserByName("foo").map(_.fold(user => user))
 val user: User = getUserResponse.value.futureValue.right.value // Unwraps `User(id=Some(1234L), username=Some("foo"))` using scalatest's `ScalaFutures` and `EitherValues` unwrappers.

--- a/modules/sample-akkaHttp/src/test/scala/core/AkkaHttp/AkkaHttpFullTracerTest.scala
+++ b/modules/sample-akkaHttp/src/test/scala/core/AkkaHttp/AkkaHttpFullTracerTest.scala
@@ -53,7 +53,7 @@ class AkkaHttpFullTracerTest extends AnyFunSuite with Matchers with EitherValues
 
   test("full tracer: passing headers through multiple levels") {
     // Establish the "Address" server
-    val server2: HttpRequest => Future[HttpResponse] = Route.asyncHandler(
+    val server2: HttpRequest => Future[HttpResponse] = Route.toFunction(
       AddressesResource.routes(
         new AddressesHandler {
           def getAddress(respond: AddressesResource.GetAddressResponse.type)(id: String)(traceBuilder: TraceBuilder) =
@@ -68,7 +68,7 @@ class AkkaHttpFullTracerTest extends AnyFunSuite with Matchers with EitherValues
     )
 
     // Establish the "User" server
-    val server1: HttpRequest => Future[HttpResponse] = Route.asyncHandler(
+    val server1: HttpRequest => Future[HttpResponse] = Route.toFunction(
       UsersResource.routes(
         new UsersHandler {
           // ... using the "Address" server explicitly in the addressesClient

--- a/modules/sample-akkaHttp/src/test/scala/core/AkkaHttp/AkkaHttpRoundTripTest.scala
+++ b/modules/sample-akkaHttp/src/test/scala/core/AkkaHttp/AkkaHttpRoundTripTest.scala
@@ -44,7 +44,7 @@ class AkkaHttpRoundTripTest extends AnyFunSuite with Matchers with EitherValues 
   val petStatus: Option[String]    = Some("pending")
 
   test("round-trip: definition query, unit response") {
-    val httpClient = Route.asyncHandler(PetResource.routes(new PetHandler {
+    val httpClient = Route.toFunction(PetResource.routes(new PetHandler {
       def addPet(respond: PetResource.AddPetResponse.type)(body: sdefs.Pet): Future[PetResource.AddPetResponse] =
         body match {
           case sdefs.Pet(
@@ -99,7 +99,7 @@ class AkkaHttpRoundTripTest extends AnyFunSuite with Matchers with EitherValues 
   }
 
   test("round-trip: enum query, Vector of definition response") {
-    val httpClient = Route.asyncHandler(PetResource.routes(new PetHandler {
+    val httpClient = Route.toFunction(PetResource.routes(new PetHandler {
       def findPetsByStatusEnum(
           respond: PetResource.FindPetsByStatusEnumResponse.type
       )(_status: sdefs.PetStatus): Future[PetResource.FindPetsByStatusEnumResponse] =
@@ -164,7 +164,7 @@ class AkkaHttpRoundTripTest extends AnyFunSuite with Matchers with EitherValues 
   }
 
   test("round-trip: 404 response") {
-    val httpClient = Route.asyncHandler(PetResource.routes(new PetHandler {
+    val httpClient = Route.toFunction(PetResource.routes(new PetHandler {
       def findPetsByStatus(respond: PetResource.FindPetsByStatusResponse.type)(status: Iterable[String]): Future[PetResource.FindPetsByStatusResponse] =
         Future.successful(respond.NotFound)
 
@@ -203,7 +203,7 @@ class AkkaHttpRoundTripTest extends AnyFunSuite with Matchers with EitherValues 
   test("round-trip: Raw type parameters") {
     val petId: Long    = 123L
     val apiKey: String = "foobar"
-    val httpClient = Route.asyncHandler(PetResource.routes(new PetHandler {
+    val httpClient = Route.toFunction(PetResource.routes(new PetHandler {
       def deletePet(respond: PetResource.DeletePetResponse.type)(
           _petId: Long,
           includeChildren: Option[Boolean],
@@ -251,7 +251,7 @@ class AkkaHttpRoundTripTest extends AnyFunSuite with Matchers with EitherValues 
   test("round-trip: File uploads") {
     val petId: Long    = 123L
     val apiKey: String = "foobar"
-    val httpClient = Route.asyncHandler(PetResource.routes(new PetHandler {
+    val httpClient = Route.toFunction(PetResource.routes(new PetHandler {
       def addPet(respond: PetResource.AddPetResponse.type)(body: sdefs.Pet) = ???
       def deletePet(
           respond: PetResource.DeletePetResponse.type

--- a/modules/sample-akkaHttp/src/test/scala/core/issues/Issue143.scala
+++ b/modules/sample-akkaHttp/src/test/scala/core/issues/Issue143.scala
@@ -65,7 +65,7 @@ class Issue143 extends AnyFunSuite with Matchers with EitherValues with ScalaFut
 
     // The following workaround seems to work:
 
-    val resp = Route.asyncHandler(route).apply(req).futureValue
+    val resp = Route.toFunction(route).apply(req).futureValue
     resp.status should equal(StatusCodes.RequestEntityTooLarge)
     eventually {
       tempDest.exists() should equal(false)

--- a/modules/sample-akkaHttp/src/test/scala/core/issues/Issue143.scala
+++ b/modules/sample-akkaHttp/src/test/scala/core/issues/Issue143.scala
@@ -59,14 +59,14 @@ class Issue143 extends AnyFunSuite with Matchers with EitherValues with ScalaFut
     // (fails in TravisCI, passes in OSX; may be related to filesystem or
     //  other system particulars)
     // req ~> route ~> check {
-    //   status should equal(StatusCodes.RequestEntityTooLarge)
+    //   status should equal(StatusCodes.PayloadTooLarge)
     //   tempDest.exists() should equal(false)
     // }
 
     // The following workaround seems to work:
 
     val resp = Route.toFunction(route).apply(req).futureValue
-    resp.status should equal(StatusCodes.RequestEntityTooLarge)
+    resp.status should equal(StatusCodes.PayloadTooLarge)
     eventually {
       tempDest.exists() should equal(false)
     }

--- a/modules/sample-akkaHttp/src/test/scala/core/issues/Issue315.scala
+++ b/modules/sample-akkaHttp/src/test/scala/core/issues/Issue315.scala
@@ -201,7 +201,7 @@ class Issue315Suite extends AnyFunSuite with Matchers with EitherValues with Sca
       import _root_.issues.issue315.legacylegacy.server.akkaHttp.definitions._
       import _root_.issues.issue315.legacylegacy.server.akkaHttp.support.Presence
       import _root_.issues.issue315.legacylegacy.server.akkaHttp.{ Handler, Resource }
-      Route.asyncHandler(Resource.routes(new Handler {
+      Route.toFunction(Resource.routes(new Handler {
         def postTest(respond: Resource.PostTestResponse.type)(body: TestObject) =
           body match {
             case TestObject("foo", None, Presence.Absent, Presence.Absent, None) => respond.OK.pure[Future]
@@ -214,7 +214,7 @@ class Issue315Suite extends AnyFunSuite with Matchers with EitherValues with Sca
       import _root_.issues.issue315.legacyoptional.server.akkaHttp.definitions._
       import _root_.issues.issue315.legacyoptional.server.akkaHttp.support.Presence
       import _root_.issues.issue315.legacyoptional.server.akkaHttp.{ Handler, Resource }
-      Route.asyncHandler(Resource.routes(new Handler {
+      Route.toFunction(Resource.routes(new Handler {
         def postTest(respond: Resource.PostTestResponse.type)(body: TestObject) =
           body match {
             case TestObject("foo", None, Presence.Absent, Presence.Absent, None) => respond.OK.pure[Future]
@@ -227,7 +227,7 @@ class Issue315Suite extends AnyFunSuite with Matchers with EitherValues with Sca
       import _root_.issues.issue315.legacyrequiredNullable.server.akkaHttp.definitions._
       import _root_.issues.issue315.legacyrequiredNullable.server.akkaHttp.support.Presence
       import _root_.issues.issue315.legacyrequiredNullable.server.akkaHttp.{ Handler, Resource }
-      Route.asyncHandler(Resource.routes(new Handler {
+      Route.toFunction(Resource.routes(new Handler {
         def postTest(respond: Resource.PostTestResponse.type)(body: TestObject) =
           body match {
             case TestObject("foo", None, Presence.Absent, Presence.Absent, None) => respond.OK.pure[Future]
@@ -240,7 +240,7 @@ class Issue315Suite extends AnyFunSuite with Matchers with EitherValues with Sca
       import _root_.issues.issue315.optionallegacy.server.akkaHttp.definitions._
       import _root_.issues.issue315.optionallegacy.server.akkaHttp.support.Presence
       import _root_.issues.issue315.optionallegacy.server.akkaHttp.{ Handler, Resource }
-      Route.asyncHandler(Resource.routes(new Handler {
+      Route.toFunction(Resource.routes(new Handler {
         def postTest(respond: Resource.PostTestResponse.type)(body: TestObject) =
           body match {
             case TestObject("foo", None, Presence.Absent, Presence.Absent, None) => respond.OK.pure[Future]
@@ -253,7 +253,7 @@ class Issue315Suite extends AnyFunSuite with Matchers with EitherValues with Sca
       import _root_.issues.issue315.optionaloptional.server.akkaHttp.definitions._
       import _root_.issues.issue315.optionaloptional.server.akkaHttp.support.Presence
       import _root_.issues.issue315.optionaloptional.server.akkaHttp.{ Handler, Resource }
-      Route.asyncHandler(Resource.routes(new Handler {
+      Route.toFunction(Resource.routes(new Handler {
         def postTest(respond: Resource.PostTestResponse.type)(body: TestObject) =
           body match {
             case TestObject("foo", None, Presence.Absent, Presence.Absent, Presence.Absent) => respond.OK.pure[Future]
@@ -266,7 +266,7 @@ class Issue315Suite extends AnyFunSuite with Matchers with EitherValues with Sca
       import _root_.issues.issue315.optionalrequiredNullable.server.akkaHttp.definitions._
       import _root_.issues.issue315.optionalrequiredNullable.server.akkaHttp.support.Presence
       import _root_.issues.issue315.optionalrequiredNullable.server.akkaHttp.{ Handler, Resource }
-      Route.asyncHandler(Resource.routes(new Handler {
+      Route.toFunction(Resource.routes(new Handler {
         def postTest(respond: Resource.PostTestResponse.type)(body: TestObject) =
           body match {
             case TestObject("foo", None, Presence.Absent, Presence.Absent, None) => respond.OK.pure[Future]
@@ -279,7 +279,7 @@ class Issue315Suite extends AnyFunSuite with Matchers with EitherValues with Sca
       import _root_.issues.issue315.requiredNullablelegacy.server.akkaHttp.definitions._
       import _root_.issues.issue315.requiredNullablelegacy.server.akkaHttp.support.Presence
       import _root_.issues.issue315.requiredNullablelegacy.server.akkaHttp.{ Handler, Resource }
-      Route.asyncHandler(Resource.routes(new Handler {
+      Route.toFunction(Resource.routes(new Handler {
         def postTest(respond: Resource.PostTestResponse.type)(body: TestObject) =
           body match {
             case TestObject("foo", None, Presence.Absent, Presence.Absent, None) => respond.OK.pure[Future]
@@ -292,7 +292,7 @@ class Issue315Suite extends AnyFunSuite with Matchers with EitherValues with Sca
       import _root_.issues.issue315.requiredNullableoptional.server.akkaHttp.definitions._
       import _root_.issues.issue315.requiredNullableoptional.server.akkaHttp.support.Presence
       import _root_.issues.issue315.requiredNullableoptional.server.akkaHttp.{ Handler, Resource }
-      Route.asyncHandler(Resource.routes(new Handler {
+      Route.toFunction(Resource.routes(new Handler {
         def postTest(respond: Resource.PostTestResponse.type)(body: TestObject) =
           body match {
             case TestObject("foo", None, Presence.Absent, Presence.Absent, None) => respond.OK.pure[Future]
@@ -305,7 +305,7 @@ class Issue315Suite extends AnyFunSuite with Matchers with EitherValues with Sca
       import _root_.issues.issue315.requiredNullablerequiredNullable.server.akkaHttp.definitions._
       import _root_.issues.issue315.requiredNullablerequiredNullable.server.akkaHttp.support.Presence
       import _root_.issues.issue315.requiredNullablerequiredNullable.server.akkaHttp.{ Handler, Resource }
-      Route.asyncHandler(Resource.routes(new Handler {
+      Route.toFunction(Resource.routes(new Handler {
         def postTest(respond: Resource.PostTestResponse.type)(body: TestObject) =
           body match {
             case TestObject("foo", None, Presence.Absent, Presence.Absent, None) => respond.OK.pure[Future]

--- a/modules/sample-akkaHttp/src/test/scala/generators/AkkaHttp/Client/contentType/AkkaHttpTextPlainTest.scala
+++ b/modules/sample-akkaHttp/src/test/scala/generators/AkkaHttp/Client/contentType/AkkaHttpTextPlainTest.scala
@@ -30,7 +30,7 @@ class AkkaHttpTextPlainTest extends AnyFunSuite with Matchers with EitherValues 
         }
       })
     }
-    val client: HttpRequest => Future[HttpResponse] = Route.asyncHandler(route)
+    val client: HttpRequest => Future[HttpResponse] = Route.toFunction(route)
     val fooClient                                   = FooClient.httpClient(client)
     fooClient.doFoo("sample").rightValue.futureValue shouldBe DoFooResponse.Created("response")
   }
@@ -45,7 +45,7 @@ class AkkaHttpTextPlainTest extends AnyFunSuite with Matchers with EitherValues 
         }
       })
     }
-    val client: HttpRequest => Future[HttpResponse] = Route.asyncHandler(route)
+    val client: HttpRequest => Future[HttpResponse] = Route.toFunction(route)
     val fooClient                                   = FooClient.httpClient(client)
     fooClient.doBar(Some("sample")).rightValue.futureValue shouldBe DoBarResponse.Created("response")
   }
@@ -68,7 +68,7 @@ class AkkaHttpTextPlainTest extends AnyFunSuite with Matchers with EitherValues 
       ): scala.concurrent.Future[tests.contentTypes.textPlain.server.akkaHttp.foo.FooResource.DoBazResponse] = ???
     })
 
-    val client: HttpRequest => Future[HttpResponse] = Route.asyncHandler(route)
+    val client: HttpRequest => Future[HttpResponse] = Route.toFunction(route)
     val fooClient                                   = FooClient.httpClient(client)
     fooClient.doFoo("sample").rightValue.futureValue shouldBe DoFooResponse.Created("response")
   }
@@ -91,7 +91,7 @@ class AkkaHttpTextPlainTest extends AnyFunSuite with Matchers with EitherValues 
       ): scala.concurrent.Future[tests.contentTypes.textPlain.server.akkaHttp.foo.FooResource.DoBazResponse] = ???
     })
 
-    val client: HttpRequest => Future[HttpResponse] = Route.asyncHandler(route)
+    val client: HttpRequest => Future[HttpResponse] = Route.toFunction(route)
     val fooClient                                   = FooClient.httpClient(client)
     fooClient.doBar(Some("sample")).rightValue.futureValue shouldBe DoBarResponse.Created("response")
   }
@@ -114,7 +114,7 @@ class AkkaHttpTextPlainTest extends AnyFunSuite with Matchers with EitherValues 
       ): scala.concurrent.Future[tests.contentTypes.textPlain.server.akkaHttp.foo.FooResource.DoBazResponse] = ???
     })
 
-    val client: HttpRequest => Future[HttpResponse] = Route.asyncHandler(route)
+    val client: HttpRequest => Future[HttpResponse] = Route.toFunction(route)
     val fooClient                                   = FooClient.httpClient(client)
     fooClient.doBar(None).rightValue.futureValue shouldBe DoBarResponse.Created("response")
   }

--- a/modules/sample-akkaHttp/src/test/scala/generators/AkkaHttp/RoundTrip/AkkaHttpCustomHeadersTest.scala
+++ b/modules/sample-akkaHttp/src/test/scala/generators/AkkaHttp/RoundTrip/AkkaHttpCustomHeadersTest.scala
@@ -28,7 +28,7 @@ class AkkaHttpCustomHeadersTest extends AnyFlatSpec with Matchers with ScalaFutu
   it should "round-trip encoded values" in {
     implicit val as  = ActorSystem()
     implicit val mat = ActorMaterializer()
-    val client = Client.httpClient(Route.asyncHandler(Resource.routes(new Handler {
+    val client = Client.httpClient(Route.toFunction(Resource.routes(new Handler {
       def getFoo(respond: Resource.GetFooResponse.type)(
           header: String,
           longHeader: Long,

--- a/modules/sample-akkaHttp/src/test/scala/generators/AkkaHttp/RoundTrip/AkkaHttpCustomHeadersTest.scala
+++ b/modules/sample-akkaHttp/src/test/scala/generators/AkkaHttp/RoundTrip/AkkaHttpCustomHeadersTest.scala
@@ -2,7 +2,6 @@ package generators.AkkaHttp.RoundTrip
 
 import akka.actor.ActorSystem
 import akka.http.scaladsl.server.{ Route }
-import akka.stream.ActorMaterializer
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.time.SpanSugar._
 import org.scalatest.EitherValues
@@ -26,8 +25,7 @@ class AkkaHttpCustomHeadersTest extends AnyFlatSpec with Matchers with ScalaFutu
   }
 
   it should "round-trip encoded values" in {
-    implicit val as  = ActorSystem()
-    implicit val mat = ActorMaterializer()
+    implicit val as = ActorSystem()
     val client = Client.httpClient(Route.toFunction(Resource.routes(new Handler {
       def getFoo(respond: Resource.GetFooResponse.type)(
           header: String,

--- a/modules/sample-akkaHttpJackson/src/test/scala/core/AkkaHttpJackson/AkkaHttpFullTracerTest.scala
+++ b/modules/sample-akkaHttpJackson/src/test/scala/core/AkkaHttpJackson/AkkaHttpFullTracerTest.scala
@@ -62,7 +62,7 @@ class AkkaHttpFullTracerTest
 
   test("full tracer: passing headers through multiple levels") {
     // Establish the "Address" server
-    val server2: HttpRequest => Future[HttpResponse] = Route.asyncHandler(
+    val server2: HttpRequest => Future[HttpResponse] = Route.toFunction(
       AddressesResource.routes(
         new AddressesHandler {
           def getAddress(respond: AddressesResource.GetAddressResponse.type)(id: String)(traceBuilder: TraceBuilder) =
@@ -77,7 +77,7 @@ class AkkaHttpFullTracerTest
     )
 
     // Establish the "User" server
-    val server1: HttpRequest => Future[HttpResponse] = Route.asyncHandler(
+    val server1: HttpRequest => Future[HttpResponse] = Route.toFunction(
       UsersResource.routes(
         new UsersHandler {
           // ... using the "Address" server explicitly in the addressesClient

--- a/modules/sample-akkaHttpJackson/src/test/scala/core/AkkaHttpJackson/AkkaHttpJacksonRoundTripTest.scala
+++ b/modules/sample-akkaHttpJackson/src/test/scala/core/AkkaHttpJackson/AkkaHttpJacksonRoundTripTest.scala
@@ -33,7 +33,7 @@ class AkkaHttpJacksonRoundTripTest extends AnyFunSuite with TestImplicits with M
   val petStatus: Option[String]    = Some("pending")
 
   test("round-trip: definition query, unit response") {
-    val httpClient = Route.asyncHandler(PetResource.routes(new PetHandler {
+    val httpClient = Route.toFunction(PetResource.routes(new PetHandler {
       def addPet(respond: PetResource.AddPetResponse.type)(body: sdefs.Pet): Future[PetResource.AddPetResponse] =
         body match {
           case sdefs.Pet(
@@ -88,7 +88,7 @@ class AkkaHttpJacksonRoundTripTest extends AnyFunSuite with TestImplicits with M
   }
 
   test("round-trip: enum query, Vector of definition response") {
-    val httpClient = Route.asyncHandler(PetResource.routes(new PetHandler {
+    val httpClient = Route.toFunction(PetResource.routes(new PetHandler {
       def findPetsByStatusEnum(
           respond: PetResource.FindPetsByStatusEnumResponse.type
       )(_status: sdefs.PetStatus): Future[PetResource.FindPetsByStatusEnumResponse] =
@@ -153,7 +153,7 @@ class AkkaHttpJacksonRoundTripTest extends AnyFunSuite with TestImplicits with M
   }
 
   test("round-trip: 404 response") {
-    val httpClient = Route.asyncHandler(PetResource.routes(new PetHandler {
+    val httpClient = Route.toFunction(PetResource.routes(new PetHandler {
       def findPetsByStatus(respond: PetResource.FindPetsByStatusResponse.type)(status: Iterable[String]): Future[PetResource.FindPetsByStatusResponse] =
         Future.successful(respond.NotFound)
 
@@ -192,7 +192,7 @@ class AkkaHttpJacksonRoundTripTest extends AnyFunSuite with TestImplicits with M
   test("round-trip: Raw type parameters") {
     val petId: Long    = 123L
     val apiKey: String = "foobar"
-    val httpClient = Route.asyncHandler(PetResource.routes(new PetHandler {
+    val httpClient = Route.toFunction(PetResource.routes(new PetHandler {
       def deletePet(respond: PetResource.DeletePetResponse.type)(
           _petId: Long,
           includeChildren: Option[Boolean],
@@ -240,7 +240,7 @@ class AkkaHttpJacksonRoundTripTest extends AnyFunSuite with TestImplicits with M
   test("round-trip: File uploads") {
     val petId: Long    = 123L
     val apiKey: String = "foobar"
-    val httpClient = Route.asyncHandler(PetResource.routes(new PetHandler {
+    val httpClient = Route.toFunction(PetResource.routes(new PetHandler {
       def addPet(respond: PetResource.AddPetResponse.type)(body: sdefs.Pet) = ???
       def deletePet(
           respond: PetResource.DeletePetResponse.type

--- a/modules/sample-akkaHttpJackson/src/test/scala/core/issues/Issue143.scala
+++ b/modules/sample-akkaHttpJackson/src/test/scala/core/issues/Issue143.scala
@@ -58,14 +58,14 @@ class Issue143 extends AnyFunSuite with TestImplicits with Matchers with EitherV
     // (fails in TravisCI, passes in OSX; may be related to filesystem or
     //  other system particulars)
     // req ~> route ~> check {
-    //   status should equal(StatusCodes.RequestEntityTooLarge)
+    //   status should equal(StatusCodes.PayloadTooLarge)
     //   tempDest.exists() should equal(false)
     // }
 
     // The following workaround seems to work:
 
     val resp = Route.toFunction(route).apply(req).futureValue
-    resp.status should equal(StatusCodes.RequestEntityTooLarge)
+    resp.status should equal(StatusCodes.PayloadTooLarge)
     eventually {
       tempDest.exists() should equal(false)
     }

--- a/modules/sample-akkaHttpJackson/src/test/scala/core/issues/Issue143.scala
+++ b/modules/sample-akkaHttpJackson/src/test/scala/core/issues/Issue143.scala
@@ -64,7 +64,7 @@ class Issue143 extends AnyFunSuite with TestImplicits with Matchers with EitherV
 
     // The following workaround seems to work:
 
-    val resp = Route.asyncHandler(route).apply(req).futureValue
+    val resp = Route.toFunction(route).apply(req).futureValue
     resp.status should equal(StatusCodes.RequestEntityTooLarge)
     eventually {
       tempDest.exists() should equal(false)

--- a/modules/sample-akkaHttpJackson/src/test/scala/core/issues/Issue315.scala
+++ b/modules/sample-akkaHttpJackson/src/test/scala/core/issues/Issue315.scala
@@ -202,7 +202,7 @@ class Issue315Suite extends AnyFunSuite with TestImplicits with Matchers with Ei
       import _root_.issues.issue315.legacylegacy.server.akkaHttpJackson.definitions._
       import _root_.issues.issue315.legacylegacy.server.akkaHttpJackson.support.Presence
       import _root_.issues.issue315.legacylegacy.server.akkaHttpJackson.{ Handler, Resource }
-      Route.asyncHandler(Resource.routes(new Handler {
+      Route.toFunction(Resource.routes(new Handler {
         def postTest(respond: Resource.PostTestResponse.type)(body: TestObject) =
           body match {
             case TestObject("foo", None, Presence.Absent, Presence.Absent, None) => respond.OK.pure[Future]
@@ -215,7 +215,7 @@ class Issue315Suite extends AnyFunSuite with TestImplicits with Matchers with Ei
       import _root_.issues.issue315.legacyoptional.server.akkaHttpJackson.definitions._
       import _root_.issues.issue315.legacyoptional.server.akkaHttpJackson.support.Presence
       import _root_.issues.issue315.legacyoptional.server.akkaHttpJackson.{ Handler, Resource }
-      Route.asyncHandler(Resource.routes(new Handler {
+      Route.toFunction(Resource.routes(new Handler {
         def postTest(respond: Resource.PostTestResponse.type)(body: TestObject) =
           body match {
             case TestObject("foo", None, Presence.Absent, Presence.Absent, None) => respond.OK.pure[Future]
@@ -228,7 +228,7 @@ class Issue315Suite extends AnyFunSuite with TestImplicits with Matchers with Ei
       import _root_.issues.issue315.legacyrequiredNullable.server.akkaHttpJackson.definitions._
       import _root_.issues.issue315.legacyrequiredNullable.server.akkaHttpJackson.support.Presence
       import _root_.issues.issue315.legacyrequiredNullable.server.akkaHttpJackson.{ Handler, Resource }
-      Route.asyncHandler(Resource.routes(new Handler {
+      Route.toFunction(Resource.routes(new Handler {
         def postTest(respond: Resource.PostTestResponse.type)(body: TestObject) =
           body match {
             case TestObject("foo", None, Presence.Absent, Presence.Absent, None) => respond.OK.pure[Future]
@@ -241,7 +241,7 @@ class Issue315Suite extends AnyFunSuite with TestImplicits with Matchers with Ei
       import _root_.issues.issue315.optionallegacy.server.akkaHttpJackson.definitions._
       import _root_.issues.issue315.optionallegacy.server.akkaHttpJackson.support.Presence
       import _root_.issues.issue315.optionallegacy.server.akkaHttpJackson.{ Handler, Resource }
-      Route.asyncHandler(Resource.routes(new Handler {
+      Route.toFunction(Resource.routes(new Handler {
         def postTest(respond: Resource.PostTestResponse.type)(body: TestObject) =
           body match {
             case TestObject("foo", None, Presence.Absent, Presence.Absent, None) => respond.OK.pure[Future]
@@ -254,7 +254,7 @@ class Issue315Suite extends AnyFunSuite with TestImplicits with Matchers with Ei
       import _root_.issues.issue315.optionaloptional.server.akkaHttpJackson.definitions._
       import _root_.issues.issue315.optionaloptional.server.akkaHttpJackson.support.Presence
       import _root_.issues.issue315.optionaloptional.server.akkaHttpJackson.{ Handler, Resource }
-      Route.asyncHandler(Resource.routes(new Handler {
+      Route.toFunction(Resource.routes(new Handler {
         def postTest(respond: Resource.PostTestResponse.type)(body: TestObject) =
           body match {
             case TestObject("foo", None, Presence.Absent, Presence.Absent, Presence.Absent) => respond.OK.pure[Future]
@@ -267,7 +267,7 @@ class Issue315Suite extends AnyFunSuite with TestImplicits with Matchers with Ei
       import _root_.issues.issue315.optionalrequiredNullable.server.akkaHttpJackson.definitions._
       import _root_.issues.issue315.optionalrequiredNullable.server.akkaHttpJackson.support.Presence
       import _root_.issues.issue315.optionalrequiredNullable.server.akkaHttpJackson.{ Handler, Resource }
-      Route.asyncHandler(Resource.routes(new Handler {
+      Route.toFunction(Resource.routes(new Handler {
         def postTest(respond: Resource.PostTestResponse.type)(body: TestObject) =
           body match {
             case TestObject("foo", None, Presence.Absent, Presence.Absent, None) => respond.OK.pure[Future]
@@ -280,7 +280,7 @@ class Issue315Suite extends AnyFunSuite with TestImplicits with Matchers with Ei
       import _root_.issues.issue315.requiredNullablelegacy.server.akkaHttpJackson.definitions._
       import _root_.issues.issue315.requiredNullablelegacy.server.akkaHttpJackson.support.Presence
       import _root_.issues.issue315.requiredNullablelegacy.server.akkaHttpJackson.{ Handler, Resource }
-      Route.asyncHandler(Resource.routes(new Handler {
+      Route.toFunction(Resource.routes(new Handler {
         def postTest(respond: Resource.PostTestResponse.type)(body: TestObject) =
           body match {
             case TestObject("foo", None, Presence.Absent, Presence.Absent, None) => respond.OK.pure[Future]
@@ -293,7 +293,7 @@ class Issue315Suite extends AnyFunSuite with TestImplicits with Matchers with Ei
       import _root_.issues.issue315.requiredNullableoptional.server.akkaHttpJackson.definitions._
       import _root_.issues.issue315.requiredNullableoptional.server.akkaHttpJackson.support.Presence
       import _root_.issues.issue315.requiredNullableoptional.server.akkaHttpJackson.{ Handler, Resource }
-      Route.asyncHandler(Resource.routes(new Handler {
+      Route.toFunction(Resource.routes(new Handler {
         def postTest(respond: Resource.PostTestResponse.type)(body: TestObject) =
           body match {
             case TestObject("foo", None, Presence.Absent, Presence.Absent, None) => respond.OK.pure[Future]
@@ -306,7 +306,7 @@ class Issue315Suite extends AnyFunSuite with TestImplicits with Matchers with Ei
       import _root_.issues.issue315.requiredNullablerequiredNullable.server.akkaHttpJackson.definitions._
       import _root_.issues.issue315.requiredNullablerequiredNullable.server.akkaHttpJackson.support.Presence
       import _root_.issues.issue315.requiredNullablerequiredNullable.server.akkaHttpJackson.{ Handler, Resource }
-      Route.asyncHandler(Resource.routes(new Handler {
+      Route.toFunction(Resource.routes(new Handler {
         def postTest(respond: Resource.PostTestResponse.type)(body: TestObject) =
           body match {
             case TestObject("foo", None, Presence.Absent, Presence.Absent, None) => respond.OK.pure[Future]

--- a/modules/sample-akkaHttpJackson/src/test/scala/generators/AkkaHttp/Client/contentType/AkkaHttpTextPlainTest.scala
+++ b/modules/sample-akkaHttpJackson/src/test/scala/generators/AkkaHttp/Client/contentType/AkkaHttpTextPlainTest.scala
@@ -40,7 +40,7 @@ class AkkaHttpTextPlainTest
         }
       })
     }
-    val client: HttpRequest => Future[HttpResponse] = Route.asyncHandler(route)
+    val client: HttpRequest => Future[HttpResponse] = Route.toFunction(route)
     val fooClient                                   = FooClient.httpClient(client)
     fooClient.doFoo("sample").rightValue.futureValue shouldBe DoFooResponse.Created("response")
   }
@@ -55,7 +55,7 @@ class AkkaHttpTextPlainTest
         }
       })
     }
-    val client: HttpRequest => Future[HttpResponse] = Route.asyncHandler(route)
+    val client: HttpRequest => Future[HttpResponse] = Route.toFunction(route)
     val fooClient                                   = FooClient.httpClient(client)
     fooClient.doBar(Some("sample")).rightValue.futureValue shouldBe DoBarResponse.Created("response")
   }
@@ -78,7 +78,7 @@ class AkkaHttpTextPlainTest
       ): scala.concurrent.Future[tests.contentTypes.textPlain.server.akkaHttpJackson.foo.FooResource.DoBazResponse] = ???
     })
 
-    val client: HttpRequest => Future[HttpResponse] = Route.asyncHandler(route)
+    val client: HttpRequest => Future[HttpResponse] = Route.toFunction(route)
     val fooClient                                   = FooClient.httpClient(client)
     fooClient.doFoo("sample").rightValue.futureValue shouldBe DoFooResponse.Created("response")
   }
@@ -101,7 +101,7 @@ class AkkaHttpTextPlainTest
       ): scala.concurrent.Future[tests.contentTypes.textPlain.server.akkaHttpJackson.foo.FooResource.DoBazResponse] = ???
     })
 
-    val client: HttpRequest => Future[HttpResponse] = Route.asyncHandler(route)
+    val client: HttpRequest => Future[HttpResponse] = Route.toFunction(route)
     val fooClient                                   = FooClient.httpClient(client)
     fooClient.doBar(Some("sample")).rightValue.futureValue shouldBe DoBarResponse.Created("response")
   }
@@ -124,7 +124,7 @@ class AkkaHttpTextPlainTest
       ): scala.concurrent.Future[tests.contentTypes.textPlain.server.akkaHttpJackson.foo.FooResource.DoBazResponse] = ???
     })
 
-    val client: HttpRequest => Future[HttpResponse] = Route.asyncHandler(route)
+    val client: HttpRequest => Future[HttpResponse] = Route.toFunction(route)
     val fooClient                                   = FooClient.httpClient(client)
     fooClient.doBar(None).rightValue.futureValue shouldBe DoBarResponse.Created("response")
   }

--- a/modules/sample-akkaHttpJackson/src/test/scala/generators/AkkaHttp/RoundTrip/AkkaHttpCustomHeadersTest.scala
+++ b/modules/sample-akkaHttpJackson/src/test/scala/generators/AkkaHttp/RoundTrip/AkkaHttpCustomHeadersTest.scala
@@ -31,7 +31,7 @@ class AkkaHttpCustomHeadersTest extends AnyFlatSpec with TestImplicits with Matc
   it should "round-trip encoded values" in {
     implicit val as  = ActorSystem()
     implicit val mat = ActorMaterializer()
-    val client = Client.httpClient(Route.asyncHandler(Resource.routes(new Handler {
+    val client = Client.httpClient(Route.toFunction(Resource.routes(new Handler {
       def getFoo(respond: Resource.GetFooResponse.type)(
           header: String,
           longHeader: Long,

--- a/modules/sample-akkaHttpJackson/src/test/scala/generators/AkkaHttp/RoundTrip/AkkaHttpCustomHeadersTest.scala
+++ b/modules/sample-akkaHttpJackson/src/test/scala/generators/AkkaHttp/RoundTrip/AkkaHttpCustomHeadersTest.scala
@@ -2,7 +2,6 @@ package generators.AkkaHttp.RoundTrip
 
 import akka.actor.ActorSystem
 import akka.http.scaladsl.server.Route
-import akka.stream.ActorMaterializer
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
@@ -29,8 +28,7 @@ class AkkaHttpCustomHeadersTest extends AnyFlatSpec with TestImplicits with Matc
   }
 
   it should "round-trip encoded values" in {
-    implicit val as  = ActorSystem()
-    implicit val mat = ActorMaterializer()
+    implicit val as = ActorSystem()
     val client = Client.httpClient(Route.toFunction(Resource.routes(new Handler {
       def getFoo(respond: Resource.GetFooResponse.type)(
           header: String,

--- a/modules/scala-akka-http/src/main/scala/dev/guardrail/generators/scala/akkaHttp/AkkaHttpGenerator.scala
+++ b/modules/scala-akka-http/src/main/scala/dev/guardrail/generators/scala/akkaHttp/AkkaHttpGenerator.scala
@@ -404,7 +404,7 @@ class AkkaHttpGenerator private (modelGeneratorType: ModelGeneratorType)(implici
       case "410" => Target.pure((410, q"Gone"))
       case "411" => Target.pure((411, q"LengthRequired"))
       case "412" => Target.pure((412, q"PreconditionFailed"))
-      case "413" => Target.pure((413, q"RequestEntityTooLarge"))
+      case "413" => Target.pure((413, q"PayloadTooLarge"))
       case "414" => Target.pure((414, q"RequestUriTooLong"))
       case "415" => Target.pure((415, q"UnsupportedMediaType"))
       case "416" => Target.pure((416, q"RequestedRangeNotSatisfiable"))

--- a/modules/scala-akka-http/src/main/scala/dev/guardrail/generators/scala/akkaHttp/AkkaHttpServerGenerator.scala
+++ b/modules/scala-akka-http/src/main/scala/dev/guardrail/generators/scala/akkaHttp/AkkaHttpServerGenerator.scala
@@ -666,7 +666,7 @@ class AkkaHttpServerGenerator private (modelGeneratorType: ModelGeneratorType)(i
                     case None     => s"Aggregated data length of request entity exceeds the configured limit of $$limit bytes"
                   }
                   val info = new ErrorInfo(summary, "Consider increasing the value of akka.http.server.parsing.max-content-length")
-                  val status = StatusCodes.RequestEntityTooLarge
+                  val status = StatusCodes.PayloadTooLarge
                   val msg = if (settings.verboseErrorMessages) info.formatPretty else info.summary
                   complete(HttpResponse(status, entity = msg))
               }

--- a/modules/scala-akka-http/src/test/scala/core/issues/Issue127.scala
+++ b/modules/scala-akka-http/src/test/scala/core/issues/Issue127.scala
@@ -123,7 +123,7 @@ class Issue127 extends AnyFunSuite with Matchers with SwaggerSpecRunner {
                           s"Aggregated data length of request entity exceeds the configured limit of $$limit bytes"
                       }
                       val info = new ErrorInfo(summary, "Consider increasing the value of akka.http.server.parsing.max-content-length")
-                      val status = StatusCodes.RequestEntityTooLarge
+                      val status = StatusCodes.PayloadTooLarge
                       val msg = if (settings.verboseErrorMessages) info.formatPretty else info.summary
                       complete(HttpResponse(status, entity = msg))
                   })

--- a/modules/scala-akka-http/src/test/scala/tests/generators/akkaHttp/server/FormFieldsTest.scala
+++ b/modules/scala-akka-http/src/test/scala/tests/generators/akkaHttp/server/FormFieldsTest.scala
@@ -158,7 +158,7 @@ class FormFieldsServerTest extends AnyFunSuite with Matchers with SwaggerSpecRun
                           s"Aggregated data length of request entity exceeds the configured limit of $$limit bytes"
                       }
                       val info = new ErrorInfo(summary, "Consider increasing the value of akka.http.server.parsing.max-content-length")
-                      val status = StatusCodes.RequestEntityTooLarge
+                      val status = StatusCodes.PayloadTooLarge
                       val msg = if (settings.verboseErrorMessages) info.formatPretty else info.summary
                       complete(HttpResponse(status, entity = msg))
                   })

--- a/modules/scala-support/src/main/scala/dev/guardrail/generators/scala/ResponseADTHelper.scala
+++ b/modules/scala-support/src/main/scala/dev/guardrail/generators/scala/ResponseADTHelper.scala
@@ -68,12 +68,12 @@ object ResponseADTHelper {
       tpe match {
         case t"Option[$_]" => q"""
                   decodeBy(MediaType.text.plain) { msg =>
-                    msg.contentLength.filter(_ > 0).fold[DecodeResult[F, $tpe]](DecodeResult.successT(None)){ _ =>
-                      DecodeResult.success(decodeText(msg)).flatMap { str =>
+                    msg.contentLength.filter(_ > 0).fold[DecodeResult[F, $tpe]](DecodeResult.success(None)){ _ =>
+                      DecodeResult.success(decodeString(msg)).flatMap { str =>
                         Json.fromString(str).as[$tpe]
                           .fold(failure =>
-                            DecodeResult.failureT(InvalidMessageBodyFailure(s"Could not decode response: $$str", Some(failure))),
-                            DecodeResult.successT(_)
+                            DecodeResult.failure(InvalidMessageBodyFailure(s"Could not decode response: $$str", Some(failure))),
+                            DecodeResult.success(_)
                           )
                       }
                     }

--- a/modules/scala-support/src/main/scala/dev/guardrail/generators/scala/ResponseADTHelper.scala
+++ b/modules/scala-support/src/main/scala/dev/guardrail/generators/scala/ResponseADTHelper.scala
@@ -68,12 +68,12 @@ object ResponseADTHelper {
       tpe match {
         case t"Option[$_]" => q"""
                   decodeBy(MediaType.text.plain) { msg =>
-                    msg.contentLength.filter(_ > 0).fold[DecodeResult[F, $tpe]](DecodeResult.success(None)){ _ =>
-                      DecodeResult.success(decodeText(msg)).flatMap { str =>
+                    msg.contentLength.filter(_ > 0).fold[DecodeResult[F, $tpe]](DecodeResult.successT(None)){ _ =>
+                      DecodeResult.successT(decodeText(msg)).flatMap { str =>
                         Json.fromString(str).as[$tpe]
                           .fold(failure =>
                             DecodeResult.failure(InvalidMessageBodyFailure(s"Could not decode response: $$str", Some(failure))),
-                            DecodeResult.success(_)
+                            DecodeResult.successT(_)
                           )
                       }
                     }

--- a/modules/scala-support/src/main/scala/dev/guardrail/generators/scala/ResponseADTHelper.scala
+++ b/modules/scala-support/src/main/scala/dev/guardrail/generators/scala/ResponseADTHelper.scala
@@ -69,7 +69,7 @@ object ResponseADTHelper {
         case t"Option[$_]" => q"""
                   decodeBy(MediaType.text.plain) { msg =>
                     msg.contentLength.filter(_ > 0).fold[DecodeResult[F, $tpe]](DecodeResult.success(None)){ _ =>
-                      DecodeResult.success(decodeString(msg)).flatMap { str =>
+                      DecodeResult.success(decodeText(msg)).flatMap { str =>
                         Json.fromString(str).as[$tpe]
                           .fold(failure =>
                             DecodeResult.failure(InvalidMessageBodyFailure(s"Could not decode response: $$str", Some(failure))),


### PR DESCRIPTION
Addressing deprecation warnings for akka-http and http4s:
- akka-http: `Route.asyncHandler` -> `Route.toFunction`
- akka-http: `StatusCode.RequestEntityTooLarge` -> `PayloadTooLarge`
- akka-http: Remove `ActorMaterializer.apply()`
- http4s: `decodeString` -> `decodeText`

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.