### PR TITLE
Tracker deprecation

### DIFF
--- a/modules/codegen/src/main/scala/com/twilio/guardrail/ProtocolGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/ProtocolGenerator.scala
@@ -86,7 +86,7 @@ object ProtocolGenerator {
   private[this] def getRequiredFieldsRec(root: Tracker[Schema[_]]): List[String] = {
     @scala.annotation.tailrec
     def work(values: List[Tracker[Schema[_]]], acc: List[String]): List[String] = {
-      val required = values.flatMap(value => value.downField("required", _.getRequired()).get)
+      val required: List[String] = values.flatMap(_.downField("required", _.getRequired()).unwrapTracker)
       val next: List[Tracker[Schema[_]]] =
         for {
           a <- values
@@ -142,7 +142,7 @@ object ProtocolGenerator {
     val tpeName = swagger.downField("type", _.getType()).map(_.filterNot(_ == "object").orElse(Option("string")))
 
     for {
-      enum          <- extractEnum(swagger.get)
+      enum          <- extractEnum(swagger)
       customTpeName <- SwaggerUtil.customTypeName(swagger)
       tpe           <- SwaggerUtil.typeName(tpeName, swagger.downField("format", _.getFormat()), customTpeName)
       fullType      <- selectType(NonEmptyList.fromList(dtoPackage :+ clsName).getOrElse(NonEmptyList.of(clsName)))

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/LanguageParameter.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/LanguageParameter.scala
@@ -62,7 +62,7 @@ object LanguageParameter {
 
     def paramMeta(param: Tracker[Parameter]): F[SwaggerUtil.ResolvedType[L]] = {
       def getDefault[U <: Parameter: Default.GetDefault](_type: String, fmt: Tracker[Option[String]], p: Tracker[U]): F[Option[L#Term]] =
-        (_type, fmt.get) match {
+        (_type, fmt.unwrapTracker) match {
           case ("string", None) =>
             Default(p).extract[String].traverse(litString(_))
           case ("number", Some("float")) =>
@@ -84,16 +84,18 @@ object LanguageParameter {
           schema = param.downField("schema", _.getSchema)
           fmt    = schema.flatDownField("format", _.getFormat)
           customParamTypeName  <- SwaggerUtil.customTypeName(param)
-          customSchemaTypeName <- schema.get.flatTraverse(SwaggerUtil.customTypeName(_: Schema[_]))
+          customSchemaTypeName <- schema.unwrapTracker.flatTraverse(SwaggerUtil.customTypeName(_: Schema[_]))
           customTypeName = customSchemaTypeName.orElse(customParamTypeName)
           res <- (SwaggerUtil.typeName[L, F](tpeName.map(Option(_)), fmt, customTypeName), getDefault(tpeName.unwrapTracker, fmt, param))
-            .mapN(SwaggerUtil.Resolved[L](_, None, _, Some(tpeName.unwrapTracker), fmt.get))
+            .mapN(SwaggerUtil.Resolved[L](_, None, _, Some(tpeName.unwrapTracker), fmt.unwrapTracker))
         } yield res
 
       def paramHasRefSchema(p: Parameter): Boolean = Option(p.getSchema).exists(s => Option(s.get$ref()).nonEmpty)
 
       param
-        .refine[F[SwaggerUtil.ResolvedType[L]]]({ case r: Parameter if r.isRef => r })(r => getRefParameterRef(r).map(_.get).map(SwaggerUtil.Deferred(_)))
+        .refine[F[SwaggerUtil.ResolvedType[L]]]({ case r: Parameter if r.isRef => r })(
+          r => getRefParameterRef(r).map(_.unwrapTracker).map(SwaggerUtil.Deferred(_))
+        )
         .orRefine({ case r: Parameter if paramHasRefSchema(r) => r })(r => getSimpleRef(r.downField("schema", _.getSchema)).map(SwaggerUtil.Deferred(_)))
         .orRefine({ case x: Parameter if x.isInBody => x })(
           x =>
@@ -113,7 +115,7 @@ object LanguageParameter {
       meta                                                                     <- paramMeta(parameter)
       SwaggerUtil.Resolved(paramType, _, baseDefaultValue, rawType, rawFormat) <- SwaggerUtil.ResolvedType.resolve[L, F](meta, protocolElems)
 
-      required = Option[java.lang.Boolean](parameter.get.getRequired()).fold(false)(identity)
+      required = parameter.downField("required", _.getRequired()).map(_.getOrElse(false)).unwrapTracker
       declType <- if (!required) {
         liftOptionalType(paramType)
       } else {
@@ -140,7 +142,7 @@ object LanguageParameter {
         enumDefaultValue.pure[F]
       }
 
-      name <- getParameterName(parameter.get)
+      name <- getParameterName(parameter)
 
       paramName     <- formatMethodArgName(name)
       paramTermName <- pureTermName(paramName)
@@ -150,14 +152,14 @@ object LanguageParameter {
       isFileType <- typesEqual(paramType, ftpe)
     } yield {
       new LanguageParameter[L](
-        Option(parameter.get.getIn),
+        parameter.downField("in", _.getIn()).unwrapTracker,
         param,
         paramTermName,
         RawParameterName(name),
         declType,
         RawParameterType(rawType, rawFormat),
         required,
-        FileHashAlgorithm(parameter.get),
+        FileHashAlgorithm(parameter),
         isFileType
       )
     })

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/CirceProtocolGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/CirceProtocolGenerator.scala
@@ -41,8 +41,8 @@ object CirceProtocolGenerator {
   def EnumProtocolTermInterp(implicit Cl: CollectionsLibTerms[ScalaLanguage, Target]): EnumProtocolTerms[ScalaLanguage, Target] = new EnumProtocolTermInterp
   class EnumProtocolTermInterp(implicit Cl: CollectionsLibTerms[ScalaLanguage, Target]) extends EnumProtocolTerms[ScalaLanguage, Target] {
     implicit def MonadF: Monad[Target] = Target.targetInstances
-    def extractEnum(swagger: Schema[_]) = {
-      val enumEntries: Option[List[String]] = swagger match {
+    def extractEnum(swagger: Tracker[Schema[_]]) = {
+      val enumEntries: Option[List[String]] = swagger.get match {
         case x: StringSchema =>
           Option[java.util.List[String]](x.getEnum()).map(_.asScala.toList)
         case x =>

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/SwaggerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/SwaggerGenerator.scala
@@ -12,7 +12,6 @@ import com.twilio.guardrail.terms._
 import io.swagger.v3.oas.models.Operation
 import io.swagger.v3.oas.models.parameters.{ Parameter, RequestBody }
 import java.net.URI
-import scala.collection.JavaConverters._
 import scala.util.Try
 import io.swagger.v3.oas.models.Components
 import io.swagger.v3.oas.models.security.{ SecurityScheme => SwSecurityScheme }
@@ -36,8 +35,8 @@ object SwaggerGenerator {
         (parts.drop(1).toList, parts.last)
       }
 
-      def extractCommonRequestBodies(components: Option[Components]): Target[Map[String, RequestBody]] =
-        Target.pure(components.flatMap(c => Option(c.getRequestBodies)).fold(Map.empty[String, RequestBody])(_.asScala.toMap))
+      def extractCommonRequestBodies(components: Tracker[Option[Components]]): Target[Map[String, RequestBody]] =
+        Target.pure(components.flatDownField("requestBodies", _.getRequestBodies).unwrapTracker.value.toMap)
 
       def extractOperations(
           paths: Tracker[Mappish[List, String, PathItem]],

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/EnumProtocolTerms.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/protocol/EnumProtocolTerms.scala
@@ -3,12 +3,13 @@ package com.twilio.guardrail.protocol.terms.protocol
 import _root_.io.swagger.v3.oas.models.media.Schema
 import cats.Monad
 import com.twilio.guardrail.StaticDefns
+import com.twilio.guardrail.core.Tracker
 import com.twilio.guardrail.languages.LA
 import com.twilio.guardrail.terms.CollectionsLibTerms
 
 abstract class EnumProtocolTerms[L <: LA, F[_]](implicit Cl: CollectionsLibTerms[L, F]) {
   def MonadF: Monad[F]
-  def extractEnum(swagger: Schema[_]): F[Either[String, List[String]]]
+  def extractEnum(swagger: Tracker[Schema[_]]): F[Either[String, List[String]]]
   def renderMembers(clsName: String, elems: List[(String, L#TermName, L#TermSelect)]): F[Option[L#ObjectDefinition]]
   def encodeEnum(clsName: String): F[Option[L#Definition]]
   def decodeEnum(clsName: String): F[Option[L#Definition]]
@@ -24,7 +25,7 @@ abstract class EnumProtocolTerms[L <: LA, F[_]](implicit Cl: CollectionsLibTerms
 
   def copy(
       newMonadF: Monad[F] = MonadF,
-      newExtractEnum: Schema[_] => F[Either[String, List[String]]] = extractEnum _,
+      newExtractEnum: Tracker[Schema[_]] => F[Either[String, List[String]]] = extractEnum _,
       newRenderMembers: (String, List[(String, L#TermName, L#TermSelect)]) => F[Option[L#ObjectDefinition]] = renderMembers _,
       newEncodeEnum: String => F[Option[L#Definition]] = encodeEnum _,
       newDecodeEnum: String => F[Option[L#Definition]] = decodeEnum _,
@@ -34,7 +35,7 @@ abstract class EnumProtocolTerms[L <: LA, F[_]](implicit Cl: CollectionsLibTerms
       newBuildAccessor: (String, String) => F[L#TermSelect] = buildAccessor _
   ) = new EnumProtocolTerms[L, F] {
     def MonadF                                                                                     = newMonadF
-    def extractEnum(swagger: Schema[_])                                                            = newExtractEnum(swagger)
+    def extractEnum(swagger: Tracker[Schema[_]])                                                   = newExtractEnum(swagger)
     def renderMembers(clsName: String, elems: List[(String, L#TermName, L#TermSelect)])            = newRenderMembers(clsName, elems)
     def encodeEnum(clsName: String): F[Option[L#Definition]]                                       = newEncodeEnum(clsName)
     def decodeEnum(clsName: String): F[Option[L#Definition]]                                       = newDecodeEnum(clsName)

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/terms/SwaggerTerms.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/terms/SwaggerTerms.scala
@@ -25,7 +25,7 @@ abstract class SwaggerLogAdapter[F[_]] {
 abstract class SwaggerTerms[L <: LA, F[_]] {
   def MonadF: Monad[F]
 
-  def extractCommonRequestBodies(components: Option[Components]): F[Map[String, RequestBody]]
+  def extractCommonRequestBodies(components: Tracker[Option[Components]]): F[Map[String, RequestBody]]
   def extractOperations(
       paths: Tracker[Mappish[List, String, PathItem]],
       commonRequestBodies: Map[String, RequestBody],

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/terms/SwaggerTerms.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/terms/SwaggerTerms.scala
@@ -36,7 +36,7 @@ abstract class SwaggerTerms[L <: LA, F[_]] {
   def extractOpenIdConnectSecurityScheme(schemeName: String, securityScheme: SwSecurityScheme, tpe: Option[L#Type]): F[OpenIdConnectSecurityScheme[L]]
   def extractOAuth2SecurityScheme(schemeName: String, securityScheme: SwSecurityScheme, tpe: Option[L#Type]): F[OAuth2SecurityScheme[L]]
   def getClassName(operation: Tracker[Operation], vendorPrefixes: List[String]): F[List[String]]
-  def getParameterName(parameter: Parameter): F[String]
+  def getParameterName(parameter: Tracker[Parameter]): F[String]
   def getBodyParameterSchema(parameter: Tracker[Parameter]): F[Tracker[Schema[_]]]
   def getHeaderParameterType(parameter: Tracker[Parameter]): F[Tracker[String]]
   def getPathParameterType(parameter: Tracker[Parameter]): F[Tracker[String]]


### PR DESCRIPTION
Resolving some dangling `(_: Tracker[A]).get` warnings. `.get` was only intended to be a stopgap, either replaced by `.unwrapTracker` or something else that uses the information stored in `Tracker[A]` more effectively, both for errors as well as safety.