### PR TITLE
Reducing warnings (pt1)

### DIFF
--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/AsyncHttpClientClientGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/AsyncHttpClientClientGenerator.scala
@@ -26,6 +26,7 @@ import java.net.URI
 import java.util.concurrent.CompletionStage
 import scala.annotation.tailrec
 
+@SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements", "org.wartremover.warts.Null"))
 object AsyncHttpClientClientGenerator {
   private val URI_TYPE                       = StaticJavaParser.parseClassOrInterfaceType("URI")
   private val OBJECT_MAPPER_TYPE             = StaticJavaParser.parseClassOrInterfaceType("ObjectMapper")

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/DropwizardServerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/DropwizardServerGenerator.scala
@@ -28,6 +28,7 @@ import scala.compat.java8.OptionConverters._
 import scala.concurrent.Future
 import scala.language.existentials
 
+@SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements", "org.wartremover.warts.Null"))
 object DropwizardServerGenerator {
   private implicit class ContentTypeExt(private val ct: ContentType) extends AnyVal {
     def toJaxRsAnnotationName: Expression = ct match {

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/JacksonGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/JacksonGenerator.scala
@@ -38,6 +38,7 @@ import com.twilio.guardrail.terms.CollectionsLibTerms
 import com.twilio.guardrail.terms.collections.CollectionsAbstraction
 import scala.collection.JavaConverters._
 
+@SuppressWarnings(Array("org.wartremover.warts.Null"))
 object JacksonGenerator {
   private val BUILDER_TYPE        = StaticJavaParser.parseClassOrInterfaceType("Builder")
   private val BIG_INTEGER_FQ_TYPE = StaticJavaParser.parseClassOrInterfaceType("java.math.BigInteger")

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/SpringMvcServerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/SpringMvcServerGenerator.scala
@@ -28,6 +28,7 @@ import scala.compat.java8.OptionConverters._
 import scala.language.existentials
 import scala.util.Try
 
+@SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements", "org.wartremover.warts.Null"))
 object SpringMvcServerGenerator {
   private implicit class ContentTypeExt(private val ct: ContentType) extends AnyVal {
     def toSpringMediaType: Expression =

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/JavaGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/JavaGenerator.scala
@@ -29,6 +29,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 import scala.language.existentials
 
+@SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements", "org.wartremover.warts.Null"))
 object JavaGenerator {
   def buildPkgDecl(parts: List[String]): Target[PackageDeclaration] =
     safeParseName(parts.mkString(".")).map(new PackageDeclaration(_))

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/DropwizardServerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/DropwizardServerGenerator.scala
@@ -4,7 +4,7 @@ import cats.Monad
 import cats.data.NonEmptyList
 import cats.syntax.all._
 import com.twilio.guardrail.core.Tracker
-import com.twilio.guardrail.generators.{ LanguageParameter, RawParameterName, ScalaGenerator }
+import com.twilio.guardrail.generators.{ LanguageParameter, RawParameterName }
 import com.twilio.guardrail.generators.helpers.DropwizardHelpers._
 import com.twilio.guardrail.languages.ScalaLanguage
 import com.twilio.guardrail.protocol.terms.server.{ GenerateRouteMeta, ServerTerms }
@@ -17,6 +17,9 @@ import io.swagger.v3.oas.models.Operation
 import scala.meta._
 
 object DropwizardServerGenerator {
+  val buildTermSelect: List[String] => Term.Ref =
+    _.map(Term.Name.apply _).reduceLeft(Term.Select.apply _)
+
   private val PLAIN_TYPES =
     Set("Boolean", "Byte", "Char", "Short", "Int", "Long", "BigInt", "Float", "Double", "BigDecimal", "String", "OffsetDateTime", "LocalDateTime")
   private val CONTAINER_TYPES = Seq("Vector", "List", "Seq", "IndexedSeq", "Iterable", "Map")
@@ -151,7 +154,7 @@ object DropwizardServerGenerator {
           q"import scala.annotation.meta.{field, param}",
           q"import scala.concurrent.{ExecutionContext, Future}",
           q"import scala.util.{Failure, Success}",
-          q"import ${ScalaGenerator.ScalaInterp.buildPkgTerm(supportPackage)}.GuardrailJerseySupport"
+          q"import ${buildTermSelect(supportPackage)}.GuardrailJerseySupport"
         )
       )
 

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/EndpointsClientGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/EndpointsClientGenerator.scala
@@ -1,19 +1,23 @@
 package com.twilio.guardrail.generators.Scala
 
-import _root_.io.swagger.v3.oas.models.PathItem.HttpMethod
+// import _root_.io.swagger.v3.oas.models.PathItem.HttpMethod
 import cats.Monad
-import cats.data.{ Ior, NonEmptyList }
-import com.twilio.guardrail.{ RenderedClientOperation, StaticDefns, StrictProtocolElems, SupportDefinition, SwaggerUtil, Target }
-import com.twilio.guardrail.generators.{ LanguageParameter, LanguageParameters, RawParameterName }
-import com.twilio.guardrail.generators.syntax.Scala._
-import com.twilio.guardrail.generators.syntax._
+// import cats.data.Ior
+import cats.data.NonEmptyList
+// import com.twilio.guardrail.SwaggerUtil
+import com.twilio.guardrail.{ RenderedClientOperation, StaticDefns, StrictProtocolElems, SupportDefinition, Target }
+import com.twilio.guardrail.generators.LanguageParameters
+// import com.twilio.guardrail.generators.{ LanguageParameter, LanguageParameters, RawParameterName }
+// import com.twilio.guardrail.generators.syntax.Scala._
+// import com.twilio.guardrail.generators.syntax._
 import com.twilio.guardrail.languages.ScalaLanguage
-import com.twilio.guardrail.protocol.terms.{ ContentType, MultipartFormData, Responses, TextPlain }
+import com.twilio.guardrail.protocol.terms.Responses
+// import com.twilio.guardrail.protocol.terms.{ ContentType, MultipartFormData, Responses, TextPlain }
 import com.twilio.guardrail.protocol.terms.client._
 import com.twilio.guardrail.terms.{ CollectionsLibTerms, RouteMeta, SecurityScheme }
-import com.twilio.guardrail.shims._
+// import com.twilio.guardrail.shims._
 import java.net.URI
-import scala.meta._
+// import scala.meta._
 
 object EndpointsClientGenerator {
   def ClientTermInterp(implicit Cl: CollectionsLibTerms[ScalaLanguage, Target]): ClientTerms[ScalaLanguage, Target] =

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/JacksonProtocolGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/JacksonProtocolGenerator.scala
@@ -15,7 +15,6 @@ import scala.meta._
 object JacksonProtocolGenerator {
   def EnumProtocolTermInterp(implicit Cl: CollectionsLibTerms[ScalaLanguage, Target]): EnumProtocolTerms[ScalaLanguage, Target] = {
     val baseInterp = new CirceProtocolGenerator.EnumProtocolTermInterp
-    import baseInterp.MonadF
     baseInterp.copy(
       newRenderClass = (className, tpe, elems) =>
         for {
@@ -233,7 +232,6 @@ object JacksonProtocolGenerator {
 
   def ProtocolSupportTermInterp(implicit Cl: CollectionsLibTerms[ScalaLanguage, Target]): ProtocolSupportTerms[ScalaLanguage, Target] = {
     val baseInterp = new CirceProtocolGenerator.ProtocolSupportTermInterp
-    import baseInterp.MonadF
     baseInterp.copy(
       newProtocolImports = () =>
         Target.pure(
@@ -562,7 +560,6 @@ object JacksonProtocolGenerator {
 
   def PolyProtocolTermInterp(implicit Cl: CollectionsLibTerms[ScalaLanguage, Target]): PolyProtocolTerms[ScalaLanguage, Target] = {
     val baseInterp = new CirceProtocolGenerator.PolyProtocolTermInterp
-    import baseInterp.MonadF
     baseInterp.copy(
       newRenderSealedTrait = (className, params, discriminator, parents, children) =>
         for {

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/ScalaGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/ScalaGenerator.scala
@@ -23,6 +23,9 @@ object ScalaGenerator {
       Target.pure((GENERATED_CODE_COMMENT + source.syntax).getBytes(StandardCharsets.UTF_8))
     })
 
+  val buildTermSelect: List[String] => Term.Ref =
+    _.map(Term.Name.apply _).reduceLeft(Term.Select.apply _)
+
   object ScalaInterp extends LanguageTerms[ScalaLanguage, Target] {
     // TODO: Very interesting bug. 2.11.12 barfs if these two definitions are
     // defined inside `apply`. Once 2.11 is dropped, these can be moved back.
@@ -30,9 +33,6 @@ object ScalaGenerator {
       case x: Defn.Val if (x match { case q"implicit val $_: $_ = $_" => true; case _ => false }) => x
     }
     val partitionImplicits: PartialFunction[Stat, Boolean] = matchImplicit.andThen(_ => true).orElse({ case _ => false })
-
-    val buildPkgTerm: List[String] => Term.Ref =
-      _.map(Term.Name.apply _).reduceLeft(Term.Select.apply _)
 
     implicit def MonadF: Monad[Target] = Target.targetInstances
 
@@ -262,7 +262,7 @@ object ScalaGenerator {
     ): Target[WriteTree] = {
       val pkg: Term.Ref            = pkgName.map(Term.Name.apply _).reduceLeft(Term.Select.apply _)
       val implicitsRef: Term.Ref   = (pkgName.map(Term.Name.apply _) ++ List(q"Implicits")).foldLeft[Term.Ref](q"_root_")(Term.Select.apply _)
-      val frameworkImplicitImports = frameworkImplicitImportNames.map(name => q"import ${buildPkgTerm(List("_root_") ++ pkgName ++ List(name.value))}._")
+      val frameworkImplicitImports = frameworkImplicitImportNames.map(name => q"import ${buildTermSelect(List("_root_") ++ pkgName ++ List(name.value))}._")
       val frameworkImplicitsFile   = source"""
             package $pkg
 
@@ -308,7 +308,7 @@ object ScalaGenerator {
         packageObjectContents: List[scala.meta.Stat],
         extraTypes: List[scala.meta.Stat]
     ): Target[Option[WriteTree]] = {
-      val pkgImplicitsImport = q"import ${buildPkgTerm("_root_" +: pkgComponents)}.Implicits._"
+      val pkgImplicitsImport = q"import ${buildTermSelect("_root_" +: pkgComponents)}.Implicits._"
       dtoComponents.traverse({
         case dtoComponents @ NonEmptyList(dtoHead, dtoRest) =>
           for (dtoRestNel <- Target.fromOption(NonEmptyList.fromList(dtoRest), UserError("DTO Components not quite long enough"))) yield {
@@ -353,7 +353,7 @@ object ScalaGenerator {
         elem: StrictProtocolElems[ScalaLanguage]
     ): Target[(List[WriteTree], List[scala.meta.Stat])] = {
       val implicitImports = (List("Implicits") ++ protoImplicitName.map(_.value))
-        .map(name => q"import ${buildPkgTerm(List("_root_") ++ pkgName ++ List(name))}._")
+        .map(name => q"import ${buildTermSelect(List("_root_") ++ pkgName ++ List(name))}._")
       Target.pure(elem match {
         case EnumDefinition(_, _, _, _, cls, staticDefns) =>
           (
@@ -361,7 +361,7 @@ object ScalaGenerator {
               sourceToBytes(
                 resolveFile(outputPath)(dtoComponents).resolve(s"${cls.name.value}.scala"),
                 source"""
-              package ${buildPkgTerm(dtoComponents)}
+              package ${buildTermSelect(dtoComponents)}
                 ..$imports
                 ..$implicitImports
                 $cls
@@ -377,7 +377,7 @@ object ScalaGenerator {
               sourceToBytes(
                 resolveFile(outputPath)(dtoComponents).resolve(s"${cls.name.value}.scala"),
                 source"""
-              package ${buildPkgTerm(dtoComponents)}
+              package ${buildTermSelect(dtoComponents)}
                 ..$imports
                 ..$implicitImports
                 $cls
@@ -394,7 +394,7 @@ object ScalaGenerator {
               sourceToBytes(
                 resolveFile(outputPath)(dtoComponents).resolve(s"$name.scala"),
                 source"""
-                    package ${buildPkgTerm(dtoComponents)}
+                    package ${buildTermSelect(dtoComponents)}
                     ..$imports
                     ..$implicitImports
                     $polyImports
@@ -424,10 +424,10 @@ object ScalaGenerator {
           sourceToBytes(
             resolveFile(pkgPath)(pkg :+ (s"$clientName.scala")),
             source"""
-              package ${buildPkgTerm(pkgName ++ pkg)}
-              import ${buildPkgTerm(List("_root_") ++ pkgName ++ List("Implicits"))}._
-              ..${frameworkImplicitNames.map(name => q"import ${buildPkgTerm(List("_root_") ++ pkgName)}.$name._")}
-              ..${dtoComponents.map(x => q"import ${buildPkgTerm(List("_root_") ++ x)}._")}
+              package ${buildTermSelect(pkgName ++ pkg)}
+              import ${buildTermSelect(List("_root_") ++ pkgName ++ List("Implicits"))}._
+              ..${frameworkImplicitNames.map(name => q"import ${buildTermSelect(List("_root_") ++ pkgName)}.$name._")}
+              ..${dtoComponents.map(x => q"import ${buildTermSelect(List("_root_") ++ x)}._")}
               ..$customImports;
               ..$imports;
               ${companionForStaticDefns(staticDefns)};
@@ -452,11 +452,11 @@ object ScalaGenerator {
           sourceToBytes(
             resolveFile(pkgPath)(pkg.toList :+ "Routes.scala"),
             source"""
-              package ${buildPkgTerm(pkgName ++ pkg.toList)}
+              package ${buildTermSelect(pkgName ++ pkg.toList)}
               ..$extraImports
-              import ${buildPkgTerm(List("_root_") ++ pkgName ++ List("Implicits"))}._
-              ..${frameworkImplicitNames.map(name => q"import ${buildPkgTerm(List("_root_") ++ pkgName)}.$name._")}
-              ..${dtoComponents.map(x => q"import ${buildPkgTerm(List("_root_") ++ x)}._")}
+              import ${buildTermSelect(List("_root_") ++ pkgName ++ List("Implicits"))}._
+              ..${frameworkImplicitNames.map(name => q"import ${buildTermSelect(List("_root_") ++ pkgName)}.$name._")}
+              ..${dtoComponents.map(x => q"import ${buildTermSelect(List("_root_") ++ x)}._")}
               ..$customImports
               $handlerDefinition
               ..$serverDefinitions

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/ScalaGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/ScalaGenerator.scala
@@ -165,7 +165,7 @@ object ScalaGenerator {
         jsonImports: List[scala.meta.Import],
         customImports: List[scala.meta.Import]
     ): Target[Option[WriteTree]] = {
-      val pkg: Term.Ref = pkgName.map(Term.Name.apply _).reduceLeft(Term.Select.apply _)
+      val pkg: Term.Ref = buildTermSelect(pkgName)
       val implicits     = source"""
             package $pkg
 
@@ -260,7 +260,7 @@ object ScalaGenerator {
         frameworkImplicits: scala.meta.Defn.Object,
         frameworkImplicitName: scala.meta.Term.Name
     ): Target[WriteTree] = {
-      val pkg: Term.Ref            = pkgName.map(Term.Name.apply _).reduceLeft(Term.Select.apply _)
+      val pkg: Term.Ref            = buildTermSelect(pkgName)
       val implicitsRef: Term.Ref   = (pkgName.map(Term.Name.apply _) ++ List(q"Implicits")).foldLeft[Term.Ref](q"_root_")(Term.Select.apply _)
       val frameworkImplicitImports = frameworkImplicitImportNames.map(name => q"import ${buildTermSelect(List("_root_") ++ pkgName ++ List(name.value))}._")
       val frameworkImplicitsFile   = source"""
@@ -287,7 +287,7 @@ object ScalaGenerator {
         frameworkDefinitions: List[scala.meta.Defn],
         frameworkDefinitionsName: scala.meta.Term.Name
     ): Target[WriteTree] = {
-      val pkg: Term.Ref            = pkgName.map(Term.Name.apply _).reduceLeft(Term.Select.apply _)
+      val pkg: Term.Ref            = buildTermSelect(pkgName)
       val frameworkDefinitionsFile = source"""
             package $pkg
 

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/collections/JavaCollectionsGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/collections/JavaCollectionsGenerator.scala
@@ -10,7 +10,7 @@ import com.twilio.guardrail.{ SwaggerUtil, Target }
 import com.twilio.guardrail.generators.syntax.Java._
 import com.twilio.guardrail.languages.JavaLanguage
 import com.twilio.guardrail.terms.CollectionsLibTerms
-
+@SuppressWarnings(Array("org.wartremover.warts.Null"))
 object JavaCollectionsGenerator {
 
   class JavaCollectionsInterp extends CollectionsLibTerms[JavaLanguage, Target] {

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/Responses.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/Responses.scala
@@ -7,7 +7,6 @@ import com.twilio.guardrail.terms.framework.FrameworkTerms
 import com.twilio.guardrail.terms.{ CollectionsLibTerms, LanguageTerms, SwaggerTerms }
 import com.twilio.guardrail.{ StrictProtocolElems, SwaggerUtil, monadForFrameworkTerms }
 import io.swagger.v3.oas.models.Operation
-import scala.collection.JavaConverters._
 
 class Response[L <: LA](
     val statusCodeName: L#TermName,

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/terms/SwaggerTerm.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/terms/SwaggerTerm.scala
@@ -49,6 +49,7 @@ case class SecurityRequirements(
     location: SecurityRequirements.Location
 )
 
+@SuppressWarnings(Array("org.wartremover.warts.Null"))
 case class RouteMeta(path: Tracker[String], method: HttpMethod, operation: Tracker[Operation], securityRequirements: Option[SecurityRequirements]) {
   override def toString(): String =
     s"RouteMeta(${path.unwrapTracker}, $method, ${operation.unwrapTracker.showNotNull} (${operation.showHistory}), $securityRequirements)"

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/terms/collections/JavaStdLibCollections.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/terms/collections/JavaStdLibCollections.scala
@@ -27,6 +27,7 @@ object JavaStdLibCollectionsHelpers {
   }
 }
 
+@SuppressWarnings(Array("org.wartremover.warts.Null", "org.wartremover.warts.Throw"))
 trait JavaStdLibCollections extends CollectionsAbstraction[JavaLanguage] {
   override implicit val optionInstances: OptionF[JavaLanguage] = new OptionF[JavaLanguage] {
     override def liftType(tpe: Type): Type  = StaticJavaParser.parseClassOrInterfaceType("java.util.Optional").setTypeArguments(tpe)

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/terms/collections/JavaVavrCollections.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/terms/collections/JavaVavrCollections.scala
@@ -11,6 +11,7 @@ import java.util.concurrent.CompletionStage
 import scala.concurrent.Future
 import scala.reflect.ClassTag
 
+@SuppressWarnings(Array("org.wartremover.warts.Null"))
 trait JavaVavrCollections extends CollectionsAbstraction[JavaLanguage] {
   override implicit val optionInstances: OptionF[JavaLanguage] = new OptionF[JavaLanguage] {
     override def liftType(tpe: Type): Type  = StaticJavaParser.parseClassOrInterfaceType("io.vavr.control.Option").setTypeArguments(tpe)


### PR DESCRIPTION
- Suppressing `Null`/`NonUnitStatements` warnings in Java generators
- Remove unused imports
- Reducing warnings by consolidating calls to reduceLeft