### PR TITLE
List -> NonEmptyList conversions

### DIFF
--- a/modules/codegen/src/main/scala/com/twilio/guardrail/Common.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/Common.scala
@@ -143,12 +143,20 @@ object Common {
         .filter(_ => protocolElems.exists({ case _: RandomType[_] => false; case _ => true }))
 
       protoOut <- protocolElems.traverse(
-        writeProtocolDefinition(outputPath, formattedPkgName, definitions, dtoComponents, customImports ++ protocolImports, protoImplicitName, _)
+        writeProtocolDefinition(
+          outputPath,
+          NonEmptyList.fromList(formattedPkgName).get,
+          definitions,
+          NonEmptyList.fromList(dtoComponents).get,
+          customImports ++ protocolImports,
+          protoImplicitName,
+          _
+        )
       )
       (protocolDefinitions, extraTypes) = protoOut.foldLeft((List.empty[WriteTree], List.empty[L#Statement]))(_ |+| _)
       packageObject <- writePackageObject(
         dtoPackagePath,
-        formattedPkgName,
+        NonEmptyList.fromList(formattedPkgName).get,
         filteredDtoComponents,
         customImports,
         packageObjectImports,

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/Common.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/Common.scala
@@ -26,7 +26,7 @@ object Common {
       context: Context,
       swagger: Tracker[OpenAPI],
       dtoPackage: List[String],
-      supportPackage: List[String]
+      supportPackage: NonEmptyList[String]
   )(
       implicit
       C: ClientTerms[L, F],

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/ProtocolGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/ProtocolGenerator.scala
@@ -685,7 +685,7 @@ object ProtocolGenerator {
   def fromSwagger[L <: LA, F[_]](
       swagger: Tracker[OpenAPI],
       dtoPackage: List[String],
-      supportPackage: List[String],
+      supportPackage: NonEmptyList[String],
       defaultPropertyRequirement: PropertyRequirement
   )(
       implicit E: EnumProtocolTerms[L, F],
@@ -707,7 +707,7 @@ object ProtocolGenerator {
       (hierarchies, definitionsWithoutPoly) <- groupHierarchies(definitions)
 
       concreteTypes <- SwaggerUtil.extractConcreteTypes[L, F](definitions.value)
-      polyADTs      <- hierarchies.traverse(fromPoly(_, concreteTypes, definitions.value, dtoPackage, supportPackage, defaultPropertyRequirement))
+      polyADTs      <- hierarchies.traverse(fromPoly(_, concreteTypes, definitions.value, dtoPackage, supportPackage.toList, defaultPropertyRequirement))
       elems <- definitionsWithoutPoly.traverse {
         case (clsName, model) =>
           model
@@ -723,7 +723,7 @@ object ProtocolGenerator {
                     concreteTypes,
                     definitions.value,
                     dtoPackage,
-                    supportPackage,
+                    supportPackage.toList,
                     defaultPropertyRequirement
                   )
                   alias <- modelTypeAlias(clsName, m)
@@ -733,7 +733,7 @@ object ProtocolGenerator {
               comp =>
                 for {
                   formattedClsName <- formatTypeName(clsName)
-                  parents          <- extractParents(comp, definitions.value, concreteTypes, dtoPackage, supportPackage, defaultPropertyRequirement)
+                  parents          <- extractParents(comp, definitions.value, concreteTypes, dtoPackage, supportPackage.toList, defaultPropertyRequirement)
                   model <- fromModel(
                     NonEmptyList.of(formattedClsName),
                     comp,
@@ -741,7 +741,7 @@ object ProtocolGenerator {
                     concreteTypes,
                     definitions.value,
                     dtoPackage,
-                    supportPackage,
+                    supportPackage.toList,
                     defaultPropertyRequirement
                   )
                   alias <- modelTypeAlias(formattedClsName, comp)
@@ -766,7 +766,7 @@ object ProtocolGenerator {
                     concreteTypes,
                     definitions.value,
                     dtoPackage,
-                    supportPackage,
+                    supportPackage.toList,
                     defaultPropertyRequirement
                   )
                   alias <- modelTypeAlias(formattedClsName, m)

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/ServerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/ServerGenerator.scala
@@ -1,4 +1,5 @@
 package com.twilio.guardrail
+import cats.data.NonEmptyList
 import cats.syntax.all._
 import com.twilio.guardrail.generators.LanguageParameter
 import com.twilio.guardrail.languages.LA
@@ -20,7 +21,7 @@ case class RenderedRoutes[L <: LA](
 )
 
 object ServerGenerator {
-  def fromSwagger[L <: LA, F[_]](context: Context, supportPackage: List[String], basePath: Option[String], frameworkImports: List[L#Import])(
+  def fromSwagger[L <: LA, F[_]](context: Context, supportPackage: NonEmptyList[String], basePath: Option[String], frameworkImports: List[L#Import])(
       groupedRoutes: List[(List[String], List[RouteMeta])]
   )(
       protocolElems: List[StrictProtocolElems[L]],

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/core/CoreTermInterp.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/core/CoreTermInterp.scala
@@ -215,7 +215,7 @@ class CoreTermInterp[L <: LA](
               for {
                 _                  <- Sw.log.debug("Running guardrail codegen")
                 formattedPkgName   <- Sc.formatPackageName(pkgName)
-                definitionsPkgName <- Sc.fullyQualifyPackageName(formattedPkgName)
+                definitionsPkgName <- Sc.fullyQualifyPackageName(formattedPkgName.toList)
                 (proto, codegen) <- Common
                   .prepareDefinitions[L, Target](
                     kind,
@@ -226,7 +226,7 @@ class CoreTermInterp[L <: LA](
                   )
                 protocolSupport <- Ps.generateSupportDefinitions()
                 result <- Common
-                  .writePackage[L, Target](proto, codegen, context)(Paths.get(outputPath), formattedPkgName, dtoPackage, customImports, protocolSupport)
+                  .writePackage[L, Target](proto, codegen, context)(Paths.get(outputPath), formattedPkgName.toList, dtoPackage, customImports, protocolSupport)
               } yield result
             } catch {
               case NonFatal(ex) =>

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/core/CoreTermInterp.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/core/CoreTermInterp.scala
@@ -215,13 +215,13 @@ class CoreTermInterp[L <: LA](
               for {
                 _                  <- Sw.log.debug("Running guardrail codegen")
                 formattedPkgName   <- Sc.formatPackageName(pkgName)
-                definitionsPkgName <- Sc.fullyQualifyPackageName(formattedPkgName.toList)
+                definitionsPkgName <- Sc.fullyQualifyPackageName(formattedPkgName)
                 (proto, codegen) <- Common
                   .prepareDefinitions[L, Target](
                     kind,
                     context,
                     Tracker(swagger),
-                    definitionsPkgName ++ ("definitions" :: dtoPackage),
+                    definitionsPkgName.toList ++ ("definitions" :: dtoPackage),
                     definitionsPkgName :+ "support"
                   )
                 protocolSupport <- Ps.generateSupportDefinitions()

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/DropwizardServerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/DropwizardServerGenerator.scala
@@ -202,7 +202,7 @@ object DropwizardServerGenerator {
 
     implicit def MonadF: Monad[Target] = Target.targetInstances
 
-    override def getExtraImports(tracing: Boolean, supportPackage: List[String]): Target[List[ImportDeclaration]] =
+    override def getExtraImports(tracing: Boolean, supportPackage: NonEmptyList[String]): Target[List[ImportDeclaration]] =
       List(
         "javax.inject.Inject",
         "javax.validation.constraints.NotNull",

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/SpringMvcServerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Java/SpringMvcServerGenerator.scala
@@ -274,7 +274,7 @@ object SpringMvcServerGenerator {
 
     implicit def MonadF: Monad[Target] = Target.targetInstances
 
-    def getExtraImports(tracing: Boolean, supportPackage: List[String]) =
+    def getExtraImports(tracing: Boolean, supportPackage: NonEmptyList[String]) =
       List(
         "java.util.Optional",
         "java.util.concurrent.CompletionStage",

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/JavaGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/JavaGenerator.scala
@@ -116,7 +116,7 @@ object JavaGenerator {
     def litLong(value: Long): Target[com.github.javaparser.ast.Node]       = Target.pure(new LongLiteralExpr(value.toString))
     def litBoolean(value: Boolean): Target[com.github.javaparser.ast.Node] = Target.pure(new BooleanLiteralExpr(value))
 
-    def fullyQualifyPackageName(rawPkgName: List[String]): Target[List[String]] = Target.pure(rawPkgName)
+    def fullyQualifyPackageName(rawPkgName: NonEmptyList[String]): Target[NonEmptyList[String]] = Target.pure(rawPkgName)
 
     def lookupEnumDefaultValue(
         tpe: JavaTypeName,

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/JavaGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/JavaGenerator.scala
@@ -31,6 +31,8 @@ import scala.language.existentials
 
 @SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements", "org.wartremover.warts.Null"))
 object JavaGenerator {
+  def buildPkgDeclNel(parts: NonEmptyList[String]): Target[PackageDeclaration] =
+    buildPkgDecl(parts.toList)
   def buildPkgDecl(parts: List[String]): Target[PackageDeclaration] =
     safeParseName(parts.mkString(".")).map(new PackageDeclaration(_))
 
@@ -248,14 +250,14 @@ object JavaGenerator {
 
     def renderImplicits(
         pkgPath: Path,
-        pkgName: List[String],
+        pkgName: NonEmptyList[String],
         frameworkImports: List[com.github.javaparser.ast.ImportDeclaration],
         jsonImports: List[com.github.javaparser.ast.ImportDeclaration],
         customImports: List[com.github.javaparser.ast.ImportDeclaration]
     ): Target[Option[WriteTree]] = Target.pure(None)
     def renderFrameworkImplicits(
         pkgPath: Path,
-        pkgName: List[String],
+        pkgName: NonEmptyList[String],
         frameworkImports: List[com.github.javaparser.ast.ImportDeclaration],
         frameworkImplicitImportNames: List[com.github.javaparser.ast.expr.Name],
         jsonImports: List[com.github.javaparser.ast.ImportDeclaration],
@@ -264,13 +266,13 @@ object JavaGenerator {
     ): Target[WriteTree] = Target.raiseUserError("Java does not support Framework Implicits")
     def renderFrameworkDefinitions(
         pkgPath: Path,
-        pkgName: List[String],
+        pkgName: NonEmptyList[String],
         frameworkImports: List[com.github.javaparser.ast.ImportDeclaration],
         frameworkDefinitions: List[com.github.javaparser.ast.body.BodyDeclaration[_ <: com.github.javaparser.ast.body.BodyDeclaration[_]]],
         frameworkDefinitionsName: com.github.javaparser.ast.expr.Name
     ): Target[WriteTree] =
       for {
-        pkgDecl <- buildPkgDecl(pkgName)
+        pkgDecl <- buildPkgDeclNel(pkgName)
         cu = {
           val cu = new CompilationUnit()
           cu.setPackageDeclaration(pkgDecl)

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/JavaGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/JavaGenerator.scala
@@ -288,7 +288,7 @@ object JavaGenerator {
 
     def writePackageObject(
         dtoPackagePath: Path,
-        pkgComponents: List[String],
+        pkgComponents: NonEmptyList[String],
         dtoComponents: Option[NonEmptyList[String]],
         customImports: List[com.github.javaparser.ast.ImportDeclaration],
         packageObjectImports: List[com.github.javaparser.ast.ImportDeclaration],
@@ -317,16 +317,16 @@ object JavaGenerator {
 
     def writeProtocolDefinition(
         outputPath: Path,
-        pkgName: List[String],
+        pkgName: NonEmptyList[String],
         definitions: List[String],
-        dtoComponents: List[String],
+        dtoComponents: NonEmptyList[String],
         imports: List[com.github.javaparser.ast.ImportDeclaration],
         protoImplicitName: Option[com.github.javaparser.ast.expr.Name],
         elem: StrictProtocolElems[JavaLanguage]
     ): Target[(List[WriteTree], List[com.github.javaparser.ast.Node])] =
       for {
-        pkgDecl      <- buildPkgDecl(dtoComponents)
-        showerImport <- safeParseRawImport((pkgName :+ "Shower").mkString("."))
+        pkgDecl      <- buildPkgDecl(dtoComponents.toList)
+        showerImport <- safeParseRawImport((pkgName :+ "Shower").toList.mkString("."))
         nameAndCompilationUnit = elem match {
           case EnumDefinition(_, _, _, _, cls, staticDefns) =>
             val cu = new CompilationUnit()
@@ -361,7 +361,9 @@ object JavaGenerator {
           case RandomType(_, _) =>
             Option.empty
         }
-        writeTree <- nameAndCompilationUnit.traverse { case (name, cu) => prettyPrintSource(resolveFile(outputPath)(dtoComponents).resolve(s"$name.java"), cu) }
+        writeTree <- nameAndCompilationUnit.traverse {
+          case (name, cu) => prettyPrintSource(resolveFile(outputPath)(dtoComponents.toList).resolve(s"$name.java"), cu)
+        }
       } yield (writeTree.toList, List.empty[Statement])
     def writeClient(
         pkgPath: Path,

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/AkkaHttpServerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/AkkaHttpServerGenerator.scala
@@ -260,7 +260,7 @@ object AkkaHttpServerGenerator {
           }
         """)
       }
-    def getExtraImports(tracing: Boolean, supportPackage: List[String]) =
+    def getExtraImports(tracing: Boolean, supportPackage: NonEmptyList[String]) =
       for {
         _ <- Target.log.debug(s"getExtraImports(${tracing})")
       } yield {

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/DropwizardServerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/DropwizardServerGenerator.scala
@@ -17,8 +17,10 @@ import io.swagger.v3.oas.models.Operation
 import scala.meta._
 
 object DropwizardServerGenerator {
-  val buildTermSelect: List[String] => Term.Ref =
-    _.map(Term.Name.apply _).reduceLeft(Term.Select.apply _)
+  val buildTermSelect: NonEmptyList[String] => Term.Ref = {
+    case NonEmptyList(head, tail) =>
+      tail.map(Term.Name.apply _).foldLeft[Term.Ref](Term.Name(head))(Term.Select.apply _)
+  }
 
   private val PLAIN_TYPES =
     Set("Boolean", "Byte", "Char", "Short", "Int", "Long", "BigInt", "Float", "Double", "BigDecimal", "String", "OffsetDateTime", "LocalDateTime")
@@ -139,7 +141,7 @@ object DropwizardServerGenerator {
   class ServerTermInterp(implicit Cl: CollectionsLibTerms[ScalaLanguage, Target]) extends ServerTerms[ScalaLanguage, Target] {
     override def MonadF: Monad[Target] = Target.targetInstances
 
-    override def getExtraImports(tracing: Boolean, supportPackage: List[String]): Target[List[Import]] =
+    override def getExtraImports(tracing: Boolean, supportPackage: NonEmptyList[String]): Target[List[Import]] =
       Target.pure(
         List(
           q"import io.dropwizard.jersey.PATCH",

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/EndpointsServerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/EndpointsServerGenerator.scala
@@ -1,6 +1,7 @@
 package com.twilio.guardrail.generators.Scala
 
 import _root_.io.swagger.v3.oas.models.Operation
+import cats.data.NonEmptyList
 import cats.Monad
 import com.twilio.guardrail.core.Tracker
 import com.twilio.guardrail.languages.ScalaLanguage
@@ -56,7 +57,7 @@ object EndpointsServerGenerator {
         customExtraction: Boolean
     ) =
       Target.raiseUserError("endpoints server generation is not currently supported")
-    def getExtraImports(tracing: Boolean, supportPackage: List[String]) =
+    def getExtraImports(tracing: Boolean, supportPackage: NonEmptyList[String]) =
       Target.raiseUserError("endpoints server generation is not currently supported")
   }
 }

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/Http4sServerGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/Http4sServerGenerator.scala
@@ -180,7 +180,7 @@ object Http4sServerGenerator {
         }
       """ +: responseDefinitions)
 
-    def getExtraImports(tracing: Boolean, supportPackage: List[String]) =
+    def getExtraImports(tracing: Boolean, supportPackage: NonEmptyList[String]) =
       Target.log.function("getExtraImports")(
         for {
           _ <- Target.log.debug(s"Args: ${tracing}")

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/ScalaGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/ScalaGenerator.scala
@@ -44,7 +44,7 @@ object ScalaGenerator {
     def litLong(value: Long): Target[scala.meta.Term]       = Target.pure(Lit.Long(value))
     def litBoolean(value: Boolean): Target[scala.meta.Term] = Target.pure(Lit.Boolean(value))
 
-    def fullyQualifyPackageName(rawPkgName: List[String]): Target[List[String]] = Target.pure("_root_" +: rawPkgName)
+    def fullyQualifyPackageName(rawPkgName: NonEmptyList[String]): Target[NonEmptyList[String]] = Target.pure("_root_" :: rawPkgName)
 
     def lookupEnumDefaultValue(
         tpe: scala.meta.Type.Name,

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/server/ServerTerms.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/protocol/terms/server/ServerTerms.scala
@@ -1,6 +1,7 @@
 package com.twilio.guardrail.protocol.terms.server
 
 import cats.Monad
+import cats.data.NonEmptyList
 import com.twilio.guardrail.core.Tracker
 import com.twilio.guardrail.generators.LanguageParameters
 import com.twilio.guardrail.languages.LA
@@ -53,7 +54,7 @@ abstract class ServerTerms[L <: LA, F[_]](implicit Cl: CollectionsLibTerms[L, F]
       responseDefinitions: List[L#Definition],
       customExtraction: Boolean
   ): F[L#Definition]
-  def getExtraImports(tracing: Boolean, supportPackage: List[String]): F[List[L#Import]]
+  def getExtraImports(tracing: Boolean, supportPackage: NonEmptyList[String]): F[List[L#Import]]
 
   def copy(
       newMonadF: Monad[F] = MonadF,
@@ -82,7 +83,7 @@ abstract class ServerTerms[L <: LA, F[_]](implicit Cl: CollectionsLibTerms[L, F]
           Boolean
       ) => F[List[L#Definition]] = renderClass _,
       newRenderHandler: (String, List[L#MethodDeclaration], List[L#Statement], List[L#Definition], Boolean) => F[L#Definition] = renderHandler _,
-      newGetExtraImports: (Boolean, List[String]) => F[List[L#Import]] = getExtraImports _
+      newGetExtraImports: (Boolean, NonEmptyList[String]) => F[List[L#Import]] = getExtraImports _
   ) = new ServerTerms[L, F] {
     def MonadF = newMonadF
     def buildCustomExtractionFields(operation: Tracker[Operation], resourceName: List[String], customExtraction: Boolean) =
@@ -119,7 +120,7 @@ abstract class ServerTerms[L <: LA, F[_]](implicit Cl: CollectionsLibTerms[L, F]
         handlerDefinitions: List[L#Statement],
         responseDefinitions: List[L#Definition],
         customExtraction: Boolean
-    )                                                                   = newRenderHandler(handlerName, methodSigs, handlerDefinitions, responseDefinitions, customExtraction)
-    def getExtraImports(tracing: Boolean, supportPackage: List[String]) = newGetExtraImports(tracing, supportPackage)
+    )                                                                           = newRenderHandler(handlerName, methodSigs, handlerDefinitions, responseDefinitions, customExtraction)
+    def getExtraImports(tracing: Boolean, supportPackage: NonEmptyList[String]) = newGetExtraImports(tracing, supportPackage)
   }
 }

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/terms/LanguageTerms.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/terms/LanguageTerms.scala
@@ -22,7 +22,7 @@ abstract class LanguageTerms[L <: LA, F[_]] {
 
   def lookupEnumDefaultValue(tpe: L#TypeName, defaultValue: L#Term, values: List[(String, L#TermName, L#TermSelect)]): F[L#TermSelect]
 
-  def formatPackageName(packageName: List[String]): F[List[String]]
+  def formatPackageName(packageName: List[String]): F[NonEmptyList[String]]
   def formatTypeName(typeName: String, suffix: Option[String] = None): F[String]
   def formatFieldName(fieldName: String): F[String]
   def formatMethodName(methodName: String): F[String]
@@ -111,18 +111,18 @@ abstract class LanguageTerms[L <: LA, F[_]] {
   ): F[(List[WriteTree], List[L#Statement])]
   def writeClient(
       pkgPath: Path,
-      pkgName: List[String],
+      pkgName: NonEmptyList[String],
       customImports: List[L#Import],
       frameworkImplicitNames: List[L#TermName],
-      dtoComponents: Option[List[String]],
+      dtoComponents: Option[NonEmptyList[String]],
       client: Client[L]
   ): F[List[WriteTree]]
   def writeServer(
       pkgPath: Path,
-      pkgName: List[String],
+      pkgName: NonEmptyList[String],
       customImports: List[L#Import],
       frameworkImplicitNames: List[L#TermName],
-      dtoComponents: Option[List[String]],
+      dtoComponents: Option[NonEmptyList[String]],
       server: Server[L]
   ): F[List[WriteTree]]
 
@@ -138,7 +138,7 @@ abstract class LanguageTerms[L <: LA, F[_]] {
       newLitBoolean: Boolean => F[L#Term] = litBoolean _,
       newFullyQualifyPackageName: List[String] => F[List[String]] = fullyQualifyPackageName _,
       newLookupEnumDefaultValue: (L#TypeName, L#Term, List[(String, L#TermName, L#TermSelect)]) => F[L#TermSelect] = lookupEnumDefaultValue _,
-      newFormatPackageName: List[String] => F[List[String]] = formatPackageName _,
+      newFormatPackageName: List[String] => F[NonEmptyList[String]] = formatPackageName _,
       newFormatTypeName: (String, Option[String]) => F[String] = formatTypeName _,
       newFormatFieldName: String => F[String] = formatFieldName _,
       newFormatMethodName: String => F[String] = formatMethodName _,
@@ -207,8 +207,10 @@ abstract class LanguageTerms[L <: LA, F[_]] {
           Option[L#TermName],
           StrictProtocolElems[L]
       ) => F[(List[WriteTree], List[L#Statement])] = writeProtocolDefinition _,
-      newWriteClient: (Path, List[String], List[L#Import], List[L#TermName], Option[List[String]], Client[L]) => F[List[WriteTree]] = writeClient _,
-      newWriteServer: (Path, List[String], List[L#Import], List[L#TermName], Option[List[String]], Server[L]) => F[List[WriteTree]] = writeServer _,
+      newWriteClient: (Path, NonEmptyList[String], List[L#Import], List[L#TermName], Option[NonEmptyList[String]], Client[L]) => F[List[WriteTree]] =
+        writeClient _,
+      newWriteServer: (Path, NonEmptyList[String], List[L#Import], List[L#TermName], Option[NonEmptyList[String]], Server[L]) => F[List[WriteTree]] =
+        writeServer _,
       newWrapToObject: (L#TermName, List[L#Import], List[L#Definition]) => F[Option[L#ObjectDefinition]] = wrapToObject _
   ) = new LanguageTerms[L, F] {
     def MonadF                                            = newMonadF
@@ -221,7 +223,7 @@ abstract class LanguageTerms[L <: LA, F[_]] {
     def fullyQualifyPackageName(rawPkgName: List[String]) = newFullyQualifyPackageName(rawPkgName)
     def lookupEnumDefaultValue(tpe: L#TypeName, defaultValue: L#Term, values: List[(String, L#TermName, L#TermSelect)]) =
       newLookupEnumDefaultValue(tpe, defaultValue, values)
-    def formatPackageName(packageName: List[String]): F[List[String]]                 = newFormatPackageName(packageName)
+    def formatPackageName(packageName: List[String]): F[NonEmptyList[String]]         = newFormatPackageName(packageName)
     def formatTypeName(typeName: String, suffix: Option[String] = None): F[String]    = newFormatTypeName(typeName, suffix)
     def formatFieldName(fieldName: String): F[String]                                 = newFormatFieldName(fieldName)
     def formatMethodName(methodName: String): F[String]                               = newFormatMethodName(methodName)
@@ -314,18 +316,18 @@ abstract class LanguageTerms[L <: LA, F[_]] {
     ) = newWriteProtocolDefinition(outputPath, pkgName, definitions, dtoComponents, imports, protoImplicitName, elem)
     def writeClient(
         pkgPath: Path,
-        pkgName: List[String],
+        pkgName: NonEmptyList[String],
         customImports: List[L#Import],
         frameworkImplicitNames: List[L#TermName],
-        dtoComponents: Option[List[String]],
+        dtoComponents: Option[NonEmptyList[String]],
         client: Client[L]
     ) = newWriteClient(pkgPath, pkgName, customImports, frameworkImplicitNames, dtoComponents, client)
     def writeServer(
         pkgPath: Path,
-        pkgName: List[String],
+        pkgName: NonEmptyList[String],
         customImports: List[L#Import],
         frameworkImplicitNames: List[L#TermName],
-        dtoComponents: Option[List[String]],
+        dtoComponents: Option[NonEmptyList[String]],
         server: Server[L]
     )                                                                                            = newWriteServer(pkgPath, pkgName, customImports, frameworkImplicitNames, dtoComponents, server)
     def wrapToObject(name: L#TermName, imports: List[L#Import], definitions: List[L#Definition]) = newWrapToObject(name, imports, definitions)

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/terms/LanguageTerms.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/terms/LanguageTerms.scala
@@ -68,14 +68,14 @@ abstract class LanguageTerms[L <: LA, F[_]] {
 
   def renderImplicits(
       pkgPath: Path,
-      pkgName: List[String],
+      pkgName: NonEmptyList[String],
       frameworkImports: List[L#Import],
       jsonImports: List[L#Import],
       customImports: List[L#Import]
   ): F[Option[WriteTree]]
   def renderFrameworkImplicits(
       pkgPath: Path,
-      pkgName: List[String],
+      pkgName: NonEmptyList[String],
       frameworkImports: List[L#Import],
       frameworkImplicitImportNames: List[L#TermName],
       jsonImports: List[L#Import],
@@ -84,7 +84,7 @@ abstract class LanguageTerms[L <: LA, F[_]] {
   ): F[WriteTree]
   def renderFrameworkDefinitions(
       pkgPath: Path,
-      pkgName: List[String],
+      pkgName: NonEmptyList[String],
       frameworkImports: List[L#Import],
       frameworkDefinitions: List[L#Definition],
       frameworkDefinitionsName: L#TermName
@@ -176,10 +176,18 @@ abstract class LanguageTerms[L <: LA, F[_]] {
       newWidenObjectDefinition: L#ObjectDefinition => F[L#Definition] = widenObjectDefinition _,
       newFindCommonDefaultValue: (String, Option[L#Term], Option[L#Term]) => F[Option[L#Term]] = findCommonDefaultValue _,
       newFindCommonRawType: (String, RawParameterType, RawParameterType) => F[RawParameterType] = findCommonRawType _,
-      newRenderImplicits: (Path, List[String], List[L#Import], List[L#Import], List[L#Import]) => F[Option[WriteTree]] = renderImplicits _,
-      newRenderFrameworkImplicits: (Path, List[String], List[L#Import], List[L#TermName], List[L#Import], L#ObjectDefinition, L#TermName) => F[WriteTree] =
-        renderFrameworkImplicits _,
-      newRenderFrameworkDefinitions: (Path, List[String], List[L#Import], List[L#Definition], L#TermName) => F[WriteTree] = renderFrameworkDefinitions _,
+      newRenderImplicits: (Path, NonEmptyList[String], List[L#Import], List[L#Import], List[L#Import]) => F[Option[WriteTree]] = renderImplicits _,
+      newRenderFrameworkImplicits: (
+          Path,
+          NonEmptyList[String],
+          List[L#Import],
+          List[L#TermName],
+          List[L#Import],
+          L#ObjectDefinition,
+          L#TermName
+      ) => F[WriteTree] = renderFrameworkImplicits _,
+      newRenderFrameworkDefinitions: (Path, NonEmptyList[String], List[L#Import], List[L#Definition], L#TermName) => F[WriteTree] =
+        renderFrameworkDefinitions _,
       newWritePackageObject: (
           Path,
           List[String],
@@ -251,11 +259,17 @@ abstract class LanguageTerms[L <: LA, F[_]] {
     def widenObjectDefinition(value: L#ObjectDefinition)                              = newWidenObjectDefinition(value)
     def findCommonDefaultValue(history: String, a: Option[L#Term], b: Option[L#Term]) = newFindCommonDefaultValue(history, a, b)
     def findCommonRawType(history: String, a: RawParameterType, b: RawParameterType)  = newFindCommonRawType(history, a, b)
-    def renderImplicits(pkgPath: Path, pkgName: List[String], frameworkImports: List[L#Import], jsonImports: List[L#Import], customImports: List[L#Import]) =
+    def renderImplicits(
+        pkgPath: Path,
+        pkgName: NonEmptyList[String],
+        frameworkImports: List[L#Import],
+        jsonImports: List[L#Import],
+        customImports: List[L#Import]
+    ) =
       newRenderImplicits(pkgPath, pkgName, frameworkImports, jsonImports, customImports)
     def renderFrameworkImplicits(
         pkgPath: Path,
-        pkgName: List[String],
+        pkgName: NonEmptyList[String],
         frameworkImports: List[L#Import],
         frameworkImplicitImportNames: List[L#TermName],
         jsonImports: List[L#Import],
@@ -264,7 +278,7 @@ abstract class LanguageTerms[L <: LA, F[_]] {
     ) = newRenderFrameworkImplicits(pkgPath, pkgName, frameworkImports, frameworkImplicitImportNames, jsonImports, frameworkImplicits, frameworkImplicitName)
     def renderFrameworkDefinitions(
         pkgPath: Path,
-        pkgName: List[String],
+        pkgName: NonEmptyList[String],
         frameworkImports: List[L#Import],
         frameworkDefinitions: List[L#Definition],
         frameworkDefinitionsName: L#TermName

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/terms/LanguageTerms.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/terms/LanguageTerms.scala
@@ -92,7 +92,7 @@ abstract class LanguageTerms[L <: LA, F[_]] {
 
   def writePackageObject(
       dtoPackagePath: Path,
-      pkgComponents: List[String],
+      pkgComponents: NonEmptyList[String],
       dtoComponents: Option[NonEmptyList[String]],
       customImports: List[L#Import],
       packageObjectImports: List[L#Import],
@@ -102,9 +102,9 @@ abstract class LanguageTerms[L <: LA, F[_]] {
   ): F[Option[WriteTree]]
   def writeProtocolDefinition(
       outputPath: Path,
-      pkgName: List[String],
+      pkgName: NonEmptyList[String],
       definitions: List[String],
-      dtoComponents: List[String],
+      dtoComponents: NonEmptyList[String],
       imports: List[L#Import],
       protoImplicitName: Option[L#TermName],
       elem: StrictProtocolElems[L]
@@ -190,7 +190,7 @@ abstract class LanguageTerms[L <: LA, F[_]] {
         renderFrameworkDefinitions _,
       newWritePackageObject: (
           Path,
-          List[String],
+          NonEmptyList[String],
           Option[NonEmptyList[String]],
           List[L#Import],
           List[L#Import],
@@ -200,9 +200,9 @@ abstract class LanguageTerms[L <: LA, F[_]] {
       ) => F[Option[WriteTree]] = writePackageObject _,
       newWriteProtocolDefinition: (
           Path,
+          NonEmptyList[String],
           List[String],
-          List[String],
-          List[String],
+          NonEmptyList[String],
           List[L#Import],
           Option[L#TermName],
           StrictProtocolElems[L]
@@ -285,7 +285,7 @@ abstract class LanguageTerms[L <: LA, F[_]] {
     ) = newRenderFrameworkDefinitions(pkgPath, pkgName, frameworkImports, frameworkDefinitions, frameworkDefinitionsName)
     def writePackageObject(
         dtoPackagePath: Path,
-        pkgComponents: List[String],
+        pkgComponents: NonEmptyList[String],
         dtoComponents: Option[NonEmptyList[String]],
         customImports: List[L#Import],
         packageObjectImports: List[L#Import],
@@ -305,9 +305,9 @@ abstract class LanguageTerms[L <: LA, F[_]] {
       )
     def writeProtocolDefinition(
         outputPath: Path,
-        pkgName: List[String],
+        pkgName: NonEmptyList[String],
         definitions: List[String],
-        dtoComponents: List[String],
+        dtoComponents: NonEmptyList[String],
         imports: List[L#Import],
         protoImplicitName: Option[L#TermName],
         elem: StrictProtocolElems[L]

--- a/modules/codegen/src/main/scala/com/twilio/guardrail/terms/LanguageTerms.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/terms/LanguageTerms.scala
@@ -18,7 +18,7 @@ abstract class LanguageTerms[L <: LA, F[_]] {
   def litLong(value: Long): F[L#Term]
   def litBoolean(value: Boolean): F[L#Term]
 
-  def fullyQualifyPackageName(rawPkgName: List[String]): F[List[String]]
+  def fullyQualifyPackageName(rawPkgName: NonEmptyList[String]): F[NonEmptyList[String]]
 
   def lookupEnumDefaultValue(tpe: L#TypeName, defaultValue: L#Term, values: List[(String, L#TermName, L#TermSelect)]): F[L#TermSelect]
 
@@ -136,7 +136,7 @@ abstract class LanguageTerms[L <: LA, F[_]] {
       newLitInt: Int => F[L#Term] = litInt _,
       newLitLong: Long => F[L#Term] = litLong _,
       newLitBoolean: Boolean => F[L#Term] = litBoolean _,
-      newFullyQualifyPackageName: List[String] => F[List[String]] = fullyQualifyPackageName _,
+      newFullyQualifyPackageName: NonEmptyList[String] => F[NonEmptyList[String]] = fullyQualifyPackageName _,
       newLookupEnumDefaultValue: (L#TypeName, L#Term, List[(String, L#TermName, L#TermSelect)]) => F[L#TermSelect] = lookupEnumDefaultValue _,
       newFormatPackageName: List[String] => F[NonEmptyList[String]] = formatPackageName _,
       newFormatTypeName: (String, Option[String]) => F[String] = formatTypeName _,
@@ -213,14 +213,14 @@ abstract class LanguageTerms[L <: LA, F[_]] {
         writeServer _,
       newWrapToObject: (L#TermName, List[L#Import], List[L#Definition]) => F[Option[L#ObjectDefinition]] = wrapToObject _
   ) = new LanguageTerms[L, F] {
-    def MonadF                                            = newMonadF
-    def litString(value: String)                          = newLitString(value)
-    def litFloat(value: Float)                            = newLitFloat(value)
-    def litDouble(value: Double)                          = newLitDouble(value)
-    def litInt(value: Int)                                = newLitInt(value)
-    def litLong(value: Long)                              = newLitLong(value)
-    def litBoolean(value: Boolean)                        = newLitBoolean(value)
-    def fullyQualifyPackageName(rawPkgName: List[String]) = newFullyQualifyPackageName(rawPkgName)
+    def MonadF                                                    = newMonadF
+    def litString(value: String)                                  = newLitString(value)
+    def litFloat(value: Float)                                    = newLitFloat(value)
+    def litDouble(value: Double)                                  = newLitDouble(value)
+    def litInt(value: Int)                                        = newLitInt(value)
+    def litLong(value: Long)                                      = newLitLong(value)
+    def litBoolean(value: Boolean)                                = newLitBoolean(value)
+    def fullyQualifyPackageName(rawPkgName: NonEmptyList[String]) = newFullyQualifyPackageName(rawPkgName)
     def lookupEnumDefaultValue(tpe: L#TypeName, defaultValue: L#Term, values: List[(String, L#TermName, L#TermSelect)]) =
       newLookupEnumDefaultValue(tpe, defaultValue, values)
     def formatPackageName(packageName: List[String]): F[NonEmptyList[String]]         = newFormatPackageName(packageName)

--- a/modules/codegen/src/test/scala/core/issues/Issue166.scala
+++ b/modules/codegen/src/test/scala/core/issues/Issue166.scala
@@ -1,5 +1,6 @@
 package tests.core.issues
 
+import cats.data.NonEmptyList
 import io.swagger.parser.OpenAPIParser
 import io.swagger.v3.parser.core.models.ParseOptions
 import com.twilio.guardrail._
@@ -51,7 +52,7 @@ class Issue166 extends AnyFunSuite with Matchers with SwaggerSpecRunner {
           Context.empty,
           Tracker(new OpenAPIParser().readContents(swagger, new java.util.LinkedList(), opts).getOpenAPI),
           List.empty,
-          List.empty
+          NonEmptyList.one("support")
         )
     )
 

--- a/modules/codegen/src/test/scala/support/SwaggerSpecRunner.scala
+++ b/modules/codegen/src/test/scala/support/SwaggerSpecRunner.scala
@@ -26,7 +26,7 @@ trait SwaggerSpecRunner extends EitherValues with OptionValues {
   def runSwaggerSpec[L <: LA](
       spec: String,
       dtoPackage: List[String] = List.empty,
-      supportPackage: List[String] = List.empty
+      supportPackage: NonEmptyList[String] = NonEmptyList.one("support")
   )(
       context: Context,
       framework: Framework[L, Target],
@@ -44,7 +44,7 @@ trait SwaggerSpecRunner extends EitherValues with OptionValues {
   private def runSwagger[L <: LA](
       swagger: OpenAPI,
       dtoPackage: List[String],
-      supportPackage: List[String]
+      supportPackage: NonEmptyList[String]
   )(context: Context, framework: Framework[L, Target], targets: NonEmptyList[CodegenTarget]): (ProtocolDefinitions[L], Clients[L], Servers[L]) = {
     import framework._
     targets
@@ -96,7 +96,7 @@ trait SwaggerSpecRunner extends EitherValues with OptionValues {
         context,
         Tracker(swagger),
         List.empty,
-        List.empty
+        NonEmptyList.one("support")
       ) match {
       case TargetError(err, la) => (la, err)
       case _                    => ???

--- a/modules/codegen/src/test/scala/tests/core/TypesTest.scala
+++ b/modules/codegen/src/test/scala/tests/core/TypesTest.scala
@@ -367,16 +367,16 @@ class TypesTest extends AnyFunSuite with Matchers with SwaggerSpecRunner {
             Encoder.AsObject.instance[TestObject](a => JsonObject.fromIterable(Vector(("required", a.required.asJson), ("required-nullable", a.requiredNullable.asJson), ("legacy", a.legacy.asJson)) ++ a.optional.fold(ifAbsent = None, ifPresent = value => Some("optional" -> value.asJson)) ++ a.optionalNullable.fold(ifAbsent = None, ifPresent = value => Some("optional-nullable" -> value.asJson)))).mapJsonObject(_.filterKeys(key => !(readOnlyKeys contains key)))
           }
           implicit val decodeTestObject: Decoder[TestObject] = new Decoder[TestObject] {
-            final def apply(c: HCursor): Decoder.Result[TestObject] = for (v0 <- c.downField("required").as[String]; v1 <- c.downField("required-nullable").as[Json].flatMap(_.as[Option[String]]); v2 <- ((c: HCursor) => c.value.asObject.filter(!_.contains("optional")).fold(c.downField("optional").as[String].map(x => Presence.present(x))) {
-              _ => Right(Presence.absent)
-            })(c); v3 <- ((c: HCursor) => c.value.asObject.filter(!_.contains("optional-nullable")).fold(c.downField("optional-nullable").as[Option[String]].map(x => Presence.present(x))) {
-              _ => Right(Presence.absent)
+            final def apply(c: HCursor): Decoder.Result[TestObject] = for (v0 <- c.downField("required").as[String]; v1 <- c.downField("required-nullable").as[Json].flatMap(_.as[Option[String]]); v2 <- ((c: HCursor) => c.value.asObject.filter(!_.contains("optional")).fold(c.downField("optional").as[String].map(x => support.Presence.present(x))) {
+              _ => Right(support.Presence.absent)
+            })(c); v3 <- ((c: HCursor) => c.value.asObject.filter(!_.contains("optional-nullable")).fold(c.downField("optional-nullable").as[Option[String]].map(x => support.Presence.present(x))) {
+              _ => Right(support.Presence.absent)
             })(c); v4 <- c.downField("legacy").as[Option[String]]) yield TestObject(v0, v1, v2, v3, v4)
           }
         }
        """
     val definition =
-      q"""case class TestObject(required: String, requiredNullable: Option[String] = None, optional: Presence[String] = Presence.Absent, optionalNullable: Presence[Option[String]], legacy: Option[String] = None)"""
+      q"""case class TestObject(required: String, requiredNullable: Option[String] = None, optional: support.Presence[String] = support.Presence.Absent, optionalNullable: support.Presence[Option[String]], legacy: Option[String] = None)"""
 
     cls.structure shouldEqual definition.structure
     cmp.structure shouldEqual companion.structure

--- a/modules/codegen/src/test/scala/tests/generators/dropwizardScala/server/DropwizardScalaJsr310Test.scala
+++ b/modules/codegen/src/test/scala/tests/generators/dropwizardScala/server/DropwizardScalaJsr310Test.scala
@@ -54,7 +54,7 @@ class DropwizardScalaJsr310Test extends AnyFreeSpec with Matchers with OptionVal
       _,
       _,
       Servers(Server(_, _, handler, server) :: Nil, _)
-    ) = runSwaggerSpec(openapi, supportPackage = List("support"))(Context.empty, Dropwizard, targets = NonEmptyList.of(CodegenTarget.Server))
+    ) = runSwaggerSpec(openapi)(Context.empty, Dropwizard, targets = NonEmptyList.of(CodegenTarget.Server))
 
     handler match {
       case Defn.Trait(

--- a/modules/microsite/src/main/scala/DocsHelpers.scala
+++ b/modules/microsite/src/main/scala/DocsHelpers.scala
@@ -3,6 +3,7 @@ package com.twilio.guardrail.docs
 import io.swagger.parser.OpenAPIParser
 import io.swagger.v3.oas.models.OpenAPI
 import io.swagger.v3.parser.core.models.ParseOptions
+import cats.data.NonEmptyList
 import com.twilio.guardrail._
 import com.twilio.guardrail.core.Tracker
 import com.twilio.guardrail.generators.Framework
@@ -26,7 +27,7 @@ object DocsHelpers {
     val segments: List[Option[String]] = identifier match {
       case GeneratingAServer =>
         val (_, codegenDefinitions) = Target.unsafeExtract(
-          Common.prepareDefinitions[ScalaLanguage, Target](CodegenTarget.Server, Context.empty, openAPI, List("definitions"), List("support"))
+          Common.prepareDefinitions[ScalaLanguage, Target](CodegenTarget.Server, Context.empty, openAPI, List("definitions"), NonEmptyList.one("support"))
         )
         val server = codegenDefinitions.servers.head
         val q"object ${oname} { ..${stats} }" = server.serverDefinitions.head
@@ -43,7 +44,7 @@ object DocsHelpers {
         )
       case GeneratingClients =>
         val (_, codegenDefinitions) = Target.unsafeExtract(
-          Common.prepareDefinitions[ScalaLanguage, Target](CodegenTarget.Client, Context.empty, openAPI, List("definitions"), List("support"))
+          Common.prepareDefinitions[ScalaLanguage, Target](CodegenTarget.Client, Context.empty, openAPI, List("definitions"), NonEmptyList.one("support"))
         )
         codegenDefinitions.clients match {
           case g :: Nil =>


### PR DESCRIPTION
In situations where we are guaranteed to need lists with at least one element, use `NonEmptyList` to communicate this.

An alternate approach would be to use `::` explicitly, but I think NEL is less error-prone.