### PR TITLE
Renaming confusing integer enum fields from V${num} to ${clsName}${num}

### DIFF
--- a/modules/codegen/src/main/scala/com/twilio/guardrail/ProtocolGenerator.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/ProtocolGenerator.scala
@@ -162,7 +162,7 @@ object ProtocolGenerator {
             for {
               elems <- value.traverse { elem =>
                 for {
-                  termName  <- formatEnumName(s"v${elem}") // TODO: Push this string into LanguageTerms
+                  termName  <- formatEnumName(s"${clsName}${elem}") // TODO: Push this string into LanguageTerms
                   valueTerm <- pureTermName(termName)
                   accessor  <- buildAccessor(clsName, termName)
                 } yield (elem, valueTerm, accessor)
@@ -174,7 +174,7 @@ object ProtocolGenerator {
             for {
               elems <- value.traverse { elem =>
                 for {
-                  termName  <- formatEnumName(s"v${elem}") // TODO: Push this string into LanguageTerms
+                  termName  <- formatEnumName(s"${clsName}${elem}") // TODO: Push this string into LanguageTerms
                   valueTerm <- pureTermName(termName)
                   accessor  <- buildAccessor(clsName, termName)
                 } yield (elem, valueTerm, accessor)

--- a/modules/sample-http4s/src/test/scala/core/Http4s/Http4sNonStringEnumerationTest.scala
+++ b/modules/sample-http4s/src/test/scala/core/Http4s/Http4sNonStringEnumerationTest.scala
@@ -33,10 +33,10 @@ class Http4sNonStringEnumerationTest extends AnyFunSuite with Matchers with Eith
     }
 
   test("round-trip: Ensure enumerations are unpacked correctly") {
-    val expectedInt      = cdefs.IntEnum.V1
-    val expectedLong     = cdefs.LongEnum.V2
+    val expectedInt      = cdefs.IntEnum.IntEnum1
+    val expectedLong     = cdefs.LongEnum.LongEnum2
     val expectedString   = cdefs.StringEnum.ILikeSpaces
-    val expectedBody     = cdefs.IntEnum.V3
+    val expectedBody     = cdefs.IntEnum.IntEnum3
     val expectedResponse = cdefs.StringEnum.ILikeSpaces
 
     val httpService = new FooResource[IO]().routes(new FooHandler[IO] {
@@ -59,10 +59,10 @@ class Http4sNonStringEnumerationTest extends AnyFunSuite with Matchers with Eith
   }
 
   test("raw client: Ensure enumerations are unpacked correctly") {
-    val expectedInt      = cdefs.IntEnum.V1
-    val expectedLong     = cdefs.LongEnum.V2
+    val expectedInt      = cdefs.IntEnum.IntEnum1
+    val expectedLong     = cdefs.LongEnum.LongEnum2
     val expectedString   = cdefs.StringEnum.ILikeSpaces
-    val expectedBody     = cdefs.IntEnum.V3
+    val expectedBody     = cdefs.IntEnum.IntEnum3
     val expectedResponse = cdefs.StringEnum.ILikeSpaces
 
     val httpService = new FooResource[IO]().routes(new FooHandler[IO] {
@@ -89,10 +89,10 @@ class Http4sNonStringEnumerationTest extends AnyFunSuite with Matchers with Eith
   object StringParamMatcher extends OptionalQueryParamDecoderMatcher[String]("stringEnum")
 
   test("raw server: Ensure enumerations are unpacked correctly") {
-    val expectedInt      = cdefs.IntEnum.V1
-    val expectedLong     = cdefs.LongEnum.V2
+    val expectedInt      = cdefs.IntEnum.IntEnum1
+    val expectedLong     = cdefs.LongEnum.LongEnum2
     val expectedString   = cdefs.StringEnum.ILikeSpaces
-    val expectedBody     = cdefs.IntEnum.V3
+    val expectedBody     = cdefs.IntEnum.IntEnum3
     val expectedResponse = cdefs.StringEnum.ILikeSpaces
 
     val httpService = HttpRoutes.of[IO] {


### PR DESCRIPTION
After thinking and discussing a bit more after #1030, I think despite the repetition, prefixing numeric enumerations with the class name will improve intelligibility long-term.

If a specification comes along that permits providing labels for numeric enumeration values, that'll certainly also improve usability.

```diff
@@ -33,10 +33,10 @@ class Http4sNonStringEnumerationTest extends AnyFunSuite with Matchers with Eith
     }
 
   test("round-trip: Ensure enumerations are unpacked correctly") {
-    val expectedInt      = cdefs.IntEnum.V1
-    val expectedLong     = cdefs.LongEnum.V2
+    val expectedInt      = cdefs.IntEnum.IntEnum1
+    val expectedLong     = cdefs.LongEnum.LongEnum2
     val expectedString   = cdefs.StringEnum.ILikeSpaces
-    val expectedBody     = cdefs.IntEnum.V3
+    val expectedBody     = cdefs.IntEnum.IntEnum3
     val expectedResponse = cdefs.StringEnum.ILikeSpaces
 
     val httpService = new FooResource[IO]().routes(new FooHandler[IO] {
@@ -59,10 +59,10 @@ class Http4sNonStringEnumerationTest extends AnyFunSuite with Matchers with Eith
   }
 
   test("raw client: Ensure enumerations are unpacked correctly") {
-    val expectedInt      = cdefs.IntEnum.V1
-    val expectedLong     = cdefs.LongEnum.V2
+    val expectedInt      = cdefs.IntEnum.IntEnum1
+    val expectedLong     = cdefs.LongEnum.LongEnum2
     val expectedString   = cdefs.StringEnum.ILikeSpaces
-    val expectedBody     = cdefs.IntEnum.V3
+    val expectedBody     = cdefs.IntEnum.IntEnum3
     val expectedResponse = cdefs.StringEnum.ILikeSpaces
 
     val httpService = new FooResource[IO]().routes(new FooHandler[IO] {
@@ -89,10 +89,10 @@ class Http4sNonStringEnumerationTest extends AnyFunSuite with Matchers with Eith
   object StringParamMatcher extends OptionalQueryParamDecoderMatcher[String]("stringEnum")
 
   test("raw server: Ensure enumerations are unpacked correctly") {
-    val expectedInt      = cdefs.IntEnum.V1
-    val expectedLong     = cdefs.LongEnum.V2
+    val expectedInt      = cdefs.IntEnum.IntEnum1
+    val expectedLong     = cdefs.LongEnum.LongEnum2
     val expectedString   = cdefs.StringEnum.ILikeSpaces
-    val expectedBody     = cdefs.IntEnum.V3
+    val expectedBody     = cdefs.IntEnum.IntEnum3
     val expectedResponse = cdefs.StringEnum.ILikeSpaces
 
     val httpService = HttpRoutes.of[IO] {
```