### PR TITLE
HTTP4s - Add support for subtypes of application/json 

### DIFF
--- a/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/Http4sHelper.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/generators/Scala/Http4sHelper.scala
@@ -117,6 +117,7 @@ object Http4sHelper {
 
   private def isJsonEncoderDecoder(consumesOrProduces: Seq[ContentType]): Boolean =
     consumesOrProduces.contains(ApplicationJson) ||
+      consumesOrProduces.exists(ct => ct.value.startsWith("application/") && ct.value.endsWith("+json")) ||
       consumesOrProduces.isEmpty ||
       consumesOrProduces.contains(AnyContentType) //guardrial converts missing contentTypes to */* what should be converted to JSON according OpenAPI
 }


### PR DESCRIPTION
Small change to allow for subtypes of application/json contenttype to be recognized for generating entityEncoder/decoder 

For example useful when types such as `application/problem+json` are used to indicate more specifically what kind of content an entity is represented by.