### PR TITLE
Only permit generating a body parameter for non-form content types

### DIFF
--- a/modules/codegen/src/main/scala/com/twilio/guardrail/terms/SwaggerTerm.scala
+++ b/modules/codegen/src/main/scala/com/twilio/guardrail/terms/SwaggerTerm.scala
@@ -9,7 +9,7 @@ import com.twilio.guardrail.core.{ Mappish, Tracker }
 import com.twilio.guardrail.generators.syntax._
 import com.twilio.guardrail.generators.{ LanguageParameter, LanguageParameters }
 import com.twilio.guardrail.languages.LA
-import com.twilio.guardrail.protocol.terms.{ ContentType, UrlencodedFormData }
+import com.twilio.guardrail.protocol.terms.{ ContentType, TextPlain, UrlencodedFormData }
 import com.twilio.guardrail.terms.SecurityRequirements.SecurityScopes
 import com.twilio.guardrail.terms.framework.FrameworkTerms
 import io.swagger.v3.oas.models.PathItem.HttpMethod
@@ -69,13 +69,14 @@ case class RouteMeta(path: Tracker[String], method: HttpMethod, operation: Track
     // FIXME: Just taking the head here isn't super great
     def unifyEntries: List[(String, Tracker[MediaType])] => Option[Tracker[Schema[_]]] =
       _.flatMap({
-        case (contentType, mediaType) =>
+        case (ContentType(contentType), mediaType) =>
           mediaType
-            .refine[Option[Tracker[Schema[_]]]]({ case mt @ MediaType(None, _, _) if contentType == "text/plain" => mt })(
+            .refine[Option[Tracker[Schema[_]]]]({ case mt @ MediaType(None, _, _) if contentType == TextPlain => mt })(
               x => Option(Tracker.cloneHistory(x, new StringSchema()))
             )
             .orRefine({ case mt @ MediaType(schema, _, _) => schema })(_.indexedDistribute)
             .orRefineFallback(_ => None)
+        case _ => None
       }).headOption
     for {
       schema <- unifyEntries(fields.value)

--- a/modules/codegen/src/test/scala/core/issues/Issue313.scala
+++ b/modules/codegen/src/test/scala/core/issues/Issue313.scala
@@ -1,0 +1,93 @@
+package core.issues
+
+import cats.data.NonEmptyList
+import com.twilio.guardrail.generators.Scala.AkkaHttp
+import com.twilio.guardrail.generators.syntax.Scala.companionForStaticDefns
+import com.twilio.guardrail.{ Client, Clients, Context }
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+import support.SwaggerSpecRunner
+
+import scala.meta._
+
+class Issue313 extends AnyFunSuite with Matchers with SwaggerSpecRunner {
+  val swagger: String = s"""
+    |openapi: 3.0.2
+    |info:
+    |  title: Whatever
+    |  version: 1.0.0
+    |servers:
+    |  - url: http://localhost:1234
+    |paths:
+    |  /users/{name}:
+    |    patch:
+    |      operationId: changeUser
+    |      parameters:
+    |      - name: name
+    |        in: path
+    |        required: true
+    |        schema:
+    |          type: string
+    |      requestBody:
+    |        required: true
+    |        content:
+    |          multipart/form-data:
+    |            schema:
+    |              type: object
+    |              required:
+    |                - id
+    |              properties:
+    |                id:
+    |                  type: integer
+    |                  format: int64
+    |      responses:
+    |        '204': {}
+    |""".stripMargin
+
+  test("Test in body generation") {
+    val (
+      _,
+      Clients(Client(tags, className, imports, staticDefns, NonEmptyList(Right(cls), _), _) :: _, Nil),
+      _
+    )       = runSwaggerSpec(swagger)(Context.empty, AkkaHttp)
+    val cmp = companionForStaticDefns(staticDefns)
+
+    val client = q"""
+      class Client(host: String = "http://localhost:1234")(implicit httpClient: HttpRequest => Future[HttpResponse], ec: ExecutionContext, mat: Materializer) {
+        val basePath: String = ""
+        private[this] def makeRequest[T: ToEntityMarshaller](method: HttpMethod, uri: Uri, headers: scala.collection.immutable.Seq[HttpHeader], entity: T, protocol: HttpProtocol): EitherT[Future, Either[Throwable, HttpResponse], HttpRequest] = {
+          EitherT(Marshal(entity).to[RequestEntity].map[Either[Either[Throwable, HttpResponse], HttpRequest]] {
+            entity => Right(HttpRequest(method = method, uri = uri, headers = headers, entity = entity, protocol = protocol))
+          }.recover({
+            case t =>
+              Left(Left(t))
+          }))
+        }
+        def changeUser(name: String, id: Long, headers: List[HttpHeader] = Nil): EitherT[Future, Either[Throwable, HttpResponse], ChangeUserResponse] = {
+          val allHeaders = headers ++ scala.collection.immutable.Seq[Option[HttpHeader]]().flatten
+          makeRequest(HttpMethods.PATCH, host + basePath + "/users/" + Formatter.addPath(name), allHeaders, Multipart.FormData(Source.fromIterator {
+            () => List(Some(Multipart.FormData.BodyPart("id", Formatter.show(id)))).flatten.iterator
+          }), HttpProtocols.`HTTP/1.1`).flatMap(req => EitherT(httpClient(req).flatMap(resp => resp.status match {
+            case StatusCodes.NoContent =>
+              resp.discardEntityBytes().future.map(_ => Right(ChangeUserResponse.NoContent))
+            case _ =>
+              FastFuture.successful(Left(Right(resp)))
+          }).recover({
+            case e: Throwable =>
+              Left(Left(e))
+          })))
+        }
+      }
+    """
+
+    val companion = q"""
+      object Client {
+        def apply(host: String = "http://localhost:1234")(implicit httpClient: HttpRequest => Future[HttpResponse], ec: ExecutionContext, mat: Materializer): Client = new Client(host = host)(httpClient = httpClient, ec = ec, mat = mat)
+        def httpClient(httpClient: HttpRequest => Future[HttpResponse], host: String = "http://localhost:1234")(implicit ec: ExecutionContext, mat: Materializer): Client = new Client(host = host)(httpClient = httpClient, ec = ec, mat = mat)
+      }
+    """
+
+    cls.structure shouldBe client.structure
+    cmp.structure shouldBe companion.structure
+  }
+}


### PR DESCRIPTION
Resolve #313 
Extending from #424, I didn't realize that @sbrunk already wrote exactly this before, but I hadn't encountered it myself, so I'm using the metadata from that commit to recognize the effort put forward at that time.