### PR TITLE
Pin various eclipse java formatter versions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -41,6 +41,31 @@ val javaxElVersion         = "3.0.0"
 val vavrVersion            = "0.10.3"
 val dropwizardVavrVersion  = "1.3.0-4"
 
+// TAKE CARE WHEN UPDATING THESE
+val eclipseFormatterDependencies = Seq(
+  "org.eclipse.jdt" % "org.eclipse.jdt.core" % "3.24.0",
+  // These version pins are necessary because a bunch of transitive dependencies
+  // are specified via an allowed version range rather than being pinned to a
+  // particular version.  Unfortunately, at some point some of them started
+  // being compiled targeting Java 11, which breaks builds for people who are
+  // still building their projects with a JDK8 distribution.  Pinning only
+  // the Java11-compiled dependencies is not enough, as some of them are not
+  // mutually compatible.
+  "org.eclipse.platform" % "org.eclipse.core.commands"       % "3.10.0",
+  "org.eclipse.platform" % "org.eclipse.core.contenttype"    % "3.7.1000",
+  "org.eclipse.platform" % "org.eclipse.core.expressions"    % "3.7.100",
+  "org.eclipse.platform" % "org.eclipse.core.filesystem"     % "1.9.0",
+  "org.eclipse.platform" % "org.eclipse.core.jobs"           % "3.11.0",
+  "org.eclipse.platform" % "org.eclipse.core.resources"      % "3.14.0",
+  "org.eclipse.platform" % "org.eclipse.core.runtime"        % "3.20.100",
+  "org.eclipse.platform" % "org.eclipse.equinox.app"         % "1.5.100",
+  "org.eclipse.platform" % "org.eclipse.equinox.common"      % "3.14.100",
+  "org.eclipse.platform" % "org.eclipse.equinox.preferences" % "3.8.200",
+  "org.eclipse.platform" % "org.eclipse.equinox.registry"    % "3.10.200",
+  "org.eclipse.platform" % "org.eclipse.osgi"                % "3.16.300",
+  "org.eclipse.platform" % "org.eclipse.text"                % "3.11.0",
+)
+
 assembly / mainClass := Some("com.twilio.guardrail.CLI")
 assembly / assemblyMergeStrategy := {
   case ".api_description" => MergeStrategy.discard
@@ -314,10 +339,8 @@ lazy val codegen = (project in file("modules/codegen"))
   .settings(
     libraryDependencies ++= Seq(
       "com.github.javaparser"       % "javaparser-symbol-solver-core" % javaparserVersion,
-      "org.eclipse.jdt"             % "org.eclipse.jdt.core"          % "3.24.0",
-      "org.eclipse.platform"        % "org.eclipse.equinox.app"       % "1.5.100",
       "io.swagger.parser.v3"        % "swagger-parser"                % "2.0.26",
-    ) ++ Seq(
+    ) ++ eclipseFormatterDependencies ++ Seq(
       "org.scalameta"               %% "scalameta"                    % "4.4.15",
       "org.tpolecat"                %% "atto-core"                    % "0.9.3",
       "org.typelevel"               %% "cats-core"                    % catsVersion,


### PR DESCRIPTION
Some of these packages have started being compiled against Java 11, which means users building their projects with a JDK8 distribution will fail to build (even though the generated code could of course run on Java 8).  These packages are somewhat odd in that many specify an allowed version range, rather than a specific version, of their dependencies.  So all of our existing releases through summer 2019 have likely stopped working over the last month or so when the toolchain used is JDK8.