### PR TITLE
Ensure deser failure when primitive type is missing in Jackson DTOs

### DIFF
--- a/modules/codegen/src/main/scala/dev/guardrail/generators/Java/JacksonGenerator.scala
+++ b/modules/codegen/src/main/scala/dev/guardrail/generators/Java/JacksonGenerator.scala
@@ -126,7 +126,6 @@ object JacksonGenerator {
                     new AssignExpr(
                       new FieldAccessExpr(new ThisExpr, term.parameterName),
                       term.fieldType match {
-                        case _: PrimitiveType => new NameExpr(term.parameterName)
                         case ft if ft.isOptionalType =>
                           new ConditionalExpr(
                             new BinaryExpr(new NameExpr(term.parameterName), new NullLiteralExpr, BinaryExpr.Operator.EQUALS),
@@ -470,7 +469,7 @@ object JacksonGenerator {
             new NodeList(
               withoutDiscriminators(parentTerms ++ terms).map({
                 case ParameterTerm(propertyName, parameterName, fieldType, _, _, _, _) =>
-                  new Parameter(new NodeList(finalModifier), fieldType, new SimpleName(parameterName))
+                  new Parameter(new NodeList(finalModifier), fieldType.box, new SimpleName(parameterName))
                     .addAnnotation(new SingleMemberAnnotationExpr(new Name("JsonProperty"), new StringLiteralExpr(propertyName)))
               }): _*
             )
@@ -1084,7 +1083,7 @@ object JacksonGenerator {
           .addConstructor(PROTECTED)
           .setParameters(
             (parentTerms ++ terms)
-              .map(term => new Parameter(new NodeList(finalModifier), term.fieldType, new SimpleName(term.parameterName)))
+              .map(term => new Parameter(new NodeList(finalModifier), term.fieldType.box, new SimpleName(term.parameterName)))
               .toNodeList
           )
           .setBody(constructorBody)

--- a/modules/codegen/src/main/scala/dev/guardrail/generators/syntax/Java.scala
+++ b/modules/codegen/src/main/scala/dev/guardrail/generators/syntax/Java.scala
@@ -2,7 +2,7 @@ package dev.guardrail.generators.syntax
 
 import cats.syntax.all._
 import com.github.javaparser.StaticJavaParser
-import com.github.javaparser.ast.`type`.{ ClassOrInterfaceType, Type }
+import com.github.javaparser.ast.`type`.{ ClassOrInterfaceType, PrimitiveType, Type }
 import com.github.javaparser.ast.body._
 import com.github.javaparser.ast.comments.{ BlockComment, Comment }
 import com.github.javaparser.ast.expr._
@@ -11,6 +11,7 @@ import com.github.javaparser.ast.{ CompilationUnit, ImportDeclaration, Node, Nod
 import dev.guardrail.languages.JavaLanguage
 import dev.guardrail.languages.JavaLanguage.JavaTypeName
 import dev.guardrail.{ RuntimeFailure, SupportDefinition, Target }
+
 import scala.collection.JavaConverters._
 import scala.compat.java8.OptionConverters._
 import scala.reflect.ClassTag
@@ -22,6 +23,12 @@ object Java {
       tpe match {
         case cls: ClassOrInterfaceType => cls.getTypeArguments.asScala.filter(_.size == 1).fold(tpe)(_.get(0))
         case _                         => tpe
+      }
+
+    def box: Type =
+      tpe match {
+        case pt: PrimitiveType => pt.toBoxedType
+        case _                 => tpe
       }
 
     def unbox: Type =

--- a/modules/sample-dropwizard/src/test/scala/core/Jackson/JacksonPropertyTest.scala
+++ b/modules/sample-dropwizard/src/test/scala/core/Jackson/JacksonPropertyTest.scala
@@ -1,0 +1,24 @@
+package core.Jackson
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.exc.ValueInstantiationException
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.must.Matchers
+import raw.client.dropwizard.definitions.Foo
+
+import scala.util.Try
+
+class JacksonPropertyTest extends AnyFreeSpec with Matchers {
+  private final val mapper = new ObjectMapper
+
+  private val badStr = "{}"
+  private val goodStr = """{ "id": 5 }"""
+
+  "Missing required primitive property should not deserialize" in {
+    Try(mapper.readValue(badStr, classOf[Foo])).failed.get.getClass mustBe classOf[ValueInstantiationException]
+  }
+
+  "Present required primitive property should deserialize" in {
+    mapper.readValue(goodStr, classOf[Foo]).getId mustBe 5
+  }
+}


### PR DESCRIPTION
If a primitive type is specified but no value is present in the JSON string, Jackson will pass its zero value to the constructor.  Using
boxed types in the constructor allows Jackson to pass `null` to the constructor, which we can catch.