### PR TITLE
Sorting http4s route matching based on first templated variable

### DIFF
--- a/modules/codegen/src/test/scala/core/issues/Issue165.scala
+++ b/modules/codegen/src/test/scala/core/issues/Issue165.scala
@@ -43,15 +43,22 @@ class Issue165 extends AnyFunSuite with Matchers with SwaggerSpecRunner {
 
     val handler  = q"""
       trait StoreHandler[F[_]] {
+        def getRoot(respond: GetRootResponse.type)(): F[GetRootResponse]
         def getFoo(respond: GetFooResponse.type)(): F[GetFooResponse]
         def getFooDir(respond: GetFooDirResponse.type)(): F[GetFooDirResponse]
-        def getRoot(respond: GetRootResponse.type)(): F[GetRootResponse]
       }
     """
     val resource = q"""
       class StoreResource[F[_]](mapRoute: (String, Request[F], F[Response[F]]) => F[Response[F]] = (_: String, _: Request[F], r: F[Response[F]]) => r)(implicit F: Async[F]) extends Http4sDsl[F] with CirceInstances {
         def routes(handler: StoreHandler[F]): HttpRoutes[F] = HttpRoutes.of {
           {
+            case req @ GET -> Root =>
+              mapRoute("getRoot", req, {
+                handler.getRoot(GetRootResponse)() flatMap ({
+                  case GetRootResponse.Ok =>
+                    F.pure(Response[F](status = org.http4s.Status.Ok))
+                })
+              })
             case req @ GET -> Root / "foo" =>
               mapRoute("getFoo", req, {
                 handler.getFoo(GetFooResponse)() flatMap ({
@@ -63,13 +70,6 @@ class Issue165 extends AnyFunSuite with Matchers with SwaggerSpecRunner {
               mapRoute("getFooDir", req, {
                 handler.getFooDir(GetFooDirResponse)() flatMap ({
                   case GetFooDirResponse.Ok =>
-                    F.pure(Response[F](status = org.http4s.Status.Ok))
-                })
-              })
-            case req @ GET -> Root =>
-              mapRoute("getRoot", req, {
-                handler.getRoot(GetRootResponse)() flatMap ({
-                  case GetRootResponse.Ok =>
                     F.pure(Response[F](status = org.http4s.Status.Ok))
                 })
               })

--- a/modules/core/src/main/scala/dev/guardrail/ServerGenerator.scala
+++ b/modules/core/src/main/scala/dev/guardrail/ServerGenerator.scala
@@ -36,7 +36,7 @@ object ServerGenerator {
       supportDefinitions <- generateSupportDefinitions(context.tracing, securitySchemes)
       servers <- groupedRoutes.traverse {
         case (className, unsortedRoutes) =>
-          val routes = unsortedRoutes.sortBy(r => (r.path.unwrapTracker, r.method))
+          val routes = unsortedRoutes.groupBy(_.path.unwrapTracker.indexOf('{')).mapValues(_.sortBy(r => (r.path.unwrapTracker, r.method))).toList.sortBy(_._1).flatMap(_._2)
           for {
             resourceName <- formatTypeName(className.lastOption.getOrElse(""), Some("Resource"))
             handlerName  <- formatTypeName(className.lastOption.getOrElse(""), Some("Handler"))

--- a/modules/scala-http4s/src/main/scala/dev/guardrail/generators/Scala/Http4sServerGenerator.scala
+++ b/modules/scala-http4s/src/main/scala/dev/guardrail/generators/Scala/Http4sServerGenerator.scala
@@ -152,7 +152,7 @@ object Http4sServerGenerator {
                 ) =>
               generateRoute(resourceName, basePath, methodName, responseClsName, sr, customExtractionFields, tracingFields, parameters, responses)
           }
-          .map(_.flatten.sortBy(_.methodName))
+          .map(_.flatten)
         routeTerms = renderedRoutes.map(_.route)
         combinedRouteTerms <- combineRouteTerms(routeTerms)
         methodSigs = renderedRoutes.map(_.methodSig)


### PR DESCRIPTION
Resolves #1229 

My understanding is that since the path extractor happens first, there's no problem with reordering paths like this. Additionally, since users can define functions in whatever order in their implementations, there's no user-facing change here, other than fixing the path matching bug.