### PR TITLE
Ensuring bincompat for guardrail modules

### DIFF
--- a/.github/release-drafter-core.yml
+++ b/.github/release-drafter-core.yml
@@ -5,6 +5,7 @@ include-paths:
   - "modules/core/"
   - "build.sbt"
   - "project/"
+# NB: Managed by support/regenerate-release-drafter.sh
 categories:
   - title: '🚀 Features'
     labels:

--- a/.github/release-drafter-core.yml
+++ b/.github/release-drafter-core.yml
@@ -2,7 +2,9 @@ name-template: 'core-v$RESOLVED_VERSION'
 tag-template: 'core-v$RESOLVED_VERSION'
 tag-prefix: core-v
 include-paths:
-  - modules/core/
+  - "modules/core/"
+  - "build.sbt"
+  - "project/"
 categories:
   - title: '🚀 Features'
     labels:

--- a/.github/release-drafter-guardrail.yml
+++ b/.github/release-drafter-guardrail.yml
@@ -5,6 +5,7 @@ include-paths:
   - "modules/codegen/"
   - "build.sbt"
   - "project/"
+# NB: Managed by support/regenerate-release-drafter.sh
 categories:
   - title: '🚀 Features'
     labels:

--- a/.github/release-drafter-guardrail.yml
+++ b/.github/release-drafter-guardrail.yml
@@ -2,7 +2,9 @@ name-template: 'guardrail-v$RESOLVED_VERSION'
 tag-template: 'guardrail-v$RESOLVED_VERSION'
 tag-prefix: guardrail-v
 include-paths:
-  - modules/codegen/
+  - "modules/codegen/"
+  - "build.sbt"
+  - "project/"
 categories:
   - title: '🚀 Features'
     labels:

--- a/.github/release-drafter-java-async-http.yml
+++ b/.github/release-drafter-java-async-http.yml
@@ -2,7 +2,9 @@ name-template: 'java-async-http-v$RESOLVED_VERSION'
 tag-template: 'java-async-http-v$RESOLVED_VERSION'
 tag-prefix: java-async-http-v
 include-paths:
-  - modules/java-async-http/
+  - "modules/java-async-http/"
+  - "build.sbt"
+  - "project/"
 categories:
   - title: '🚀 Features'
     labels:

--- a/.github/release-drafter-java-async-http.yml
+++ b/.github/release-drafter-java-async-http.yml
@@ -5,6 +5,7 @@ include-paths:
   - "modules/java-async-http/"
   - "build.sbt"
   - "project/"
+# NB: Managed by support/regenerate-release-drafter.sh
 categories:
   - title: '🚀 Features'
     labels:

--- a/.github/release-drafter-java-dropwizard.yml
+++ b/.github/release-drafter-java-dropwizard.yml
@@ -2,7 +2,9 @@ name-template: 'java-dropwizard-v$RESOLVED_VERSION'
 tag-template: 'java-dropwizard-v$RESOLVED_VERSION'
 tag-prefix: java-dropwizard-v
 include-paths:
-  - modules/java-dropwizard/
+  - "modules/java-dropwizard/"
+  - "build.sbt"
+  - "project/"
 categories:
   - title: '🚀 Features'
     labels:

--- a/.github/release-drafter-java-dropwizard.yml
+++ b/.github/release-drafter-java-dropwizard.yml
@@ -5,6 +5,7 @@ include-paths:
   - "modules/java-dropwizard/"
   - "build.sbt"
   - "project/"
+# NB: Managed by support/regenerate-release-drafter.sh
 categories:
   - title: '🚀 Features'
     labels:

--- a/.github/release-drafter-java-spring-mvc.yml
+++ b/.github/release-drafter-java-spring-mvc.yml
@@ -2,7 +2,9 @@ name-template: 'java-spring-mvc-v$RESOLVED_VERSION'
 tag-template: 'java-spring-mvc-v$RESOLVED_VERSION'
 tag-prefix: java-spring-mvc-v
 include-paths:
-  - modules/java-spring-mvc/
+  - "modules/java-spring-mvc/"
+  - "build.sbt"
+  - "project/"
 categories:
   - title: '🚀 Features'
     labels:

--- a/.github/release-drafter-java-spring-mvc.yml
+++ b/.github/release-drafter-java-spring-mvc.yml
@@ -5,6 +5,7 @@ include-paths:
   - "modules/java-spring-mvc/"
   - "build.sbt"
   - "project/"
+# NB: Managed by support/regenerate-release-drafter.sh
 categories:
   - title: '🚀 Features'
     labels:

--- a/.github/release-drafter-java-support.yml
+++ b/.github/release-drafter-java-support.yml
@@ -5,6 +5,7 @@ include-paths:
   - "modules/java-support/"
   - "build.sbt"
   - "project/"
+# NB: Managed by support/regenerate-release-drafter.sh
 categories:
   - title: '🚀 Features'
     labels:

--- a/.github/release-drafter-java-support.yml
+++ b/.github/release-drafter-java-support.yml
@@ -2,7 +2,9 @@ name-template: 'java-support-v$RESOLVED_VERSION'
 tag-template: 'java-support-v$RESOLVED_VERSION'
 tag-prefix: java-support-v
 include-paths:
-  - modules/java-support/
+  - "modules/java-support/"
+  - "build.sbt"
+  - "project/"
 categories:
   - title: '🚀 Features'
     labels:

--- a/.github/release-drafter-scala-akka-http.yml
+++ b/.github/release-drafter-scala-akka-http.yml
@@ -5,6 +5,7 @@ include-paths:
   - "modules/scala-akka-http/"
   - "build.sbt"
   - "project/"
+# NB: Managed by support/regenerate-release-drafter.sh
 categories:
   - title: '🚀 Features'
     labels:

--- a/.github/release-drafter-scala-akka-http.yml
+++ b/.github/release-drafter-scala-akka-http.yml
@@ -2,7 +2,9 @@ name-template: 'scala-akka-http-v$RESOLVED_VERSION'
 tag-template: 'scala-akka-http-v$RESOLVED_VERSION'
 tag-prefix: scala-akka-http-v
 include-paths:
-  - modules/scala-akka-http/
+  - "modules/scala-akka-http/"
+  - "build.sbt"
+  - "project/"
 categories:
   - title: '🚀 Features'
     labels:

--- a/.github/release-drafter-scala-dropwizard.yml
+++ b/.github/release-drafter-scala-dropwizard.yml
@@ -5,6 +5,7 @@ include-paths:
   - "modules/scala-dropwizard/"
   - "build.sbt"
   - "project/"
+# NB: Managed by support/regenerate-release-drafter.sh
 categories:
   - title: '🚀 Features'
     labels:

--- a/.github/release-drafter-scala-dropwizard.yml
+++ b/.github/release-drafter-scala-dropwizard.yml
@@ -2,7 +2,9 @@ name-template: 'scala-dropwizard-v$RESOLVED_VERSION'
 tag-template: 'scala-dropwizard-v$RESOLVED_VERSION'
 tag-prefix: scala-dropwizard-v
 include-paths:
-  - modules/scala-dropwizard/
+  - "modules/scala-dropwizard/"
+  - "build.sbt"
+  - "project/"
 categories:
   - title: '🚀 Features'
     labels:

--- a/.github/release-drafter-scala-endpoints.yml
+++ b/.github/release-drafter-scala-endpoints.yml
@@ -2,7 +2,9 @@ name-template: 'scala-endpoints-v$RESOLVED_VERSION'
 tag-template: 'scala-endpoints-v$RESOLVED_VERSION'
 tag-prefix: scala-endpoints-v
 include-paths:
-  - modules/scala-endpoints/
+  - "modules/scala-endpoints/"
+  - "build.sbt"
+  - "project/"
 categories:
   - title: '🚀 Features'
     labels:

--- a/.github/release-drafter-scala-endpoints.yml
+++ b/.github/release-drafter-scala-endpoints.yml
@@ -5,6 +5,7 @@ include-paths:
   - "modules/scala-endpoints/"
   - "build.sbt"
   - "project/"
+# NB: Managed by support/regenerate-release-drafter.sh
 categories:
   - title: '🚀 Features'
     labels:

--- a/.github/release-drafter-scala-http4s.yml
+++ b/.github/release-drafter-scala-http4s.yml
@@ -5,6 +5,7 @@ include-paths:
   - "modules/scala-http4s/"
   - "build.sbt"
   - "project/"
+# NB: Managed by support/regenerate-release-drafter.sh
 categories:
   - title: '🚀 Features'
     labels:

--- a/.github/release-drafter-scala-http4s.yml
+++ b/.github/release-drafter-scala-http4s.yml
@@ -2,7 +2,9 @@ name-template: 'scala-http4s-v$RESOLVED_VERSION'
 tag-template: 'scala-http4s-v$RESOLVED_VERSION'
 tag-prefix: scala-http4s-v
 include-paths:
-  - modules/scala-http4s/
+  - "modules/scala-http4s/"
+  - "build.sbt"
+  - "project/"
 categories:
   - title: '🚀 Features'
     labels:

--- a/.github/release-drafter-scala-support.yml
+++ b/.github/release-drafter-scala-support.yml
@@ -5,6 +5,7 @@ include-paths:
   - "modules/scala-support/"
   - "build.sbt"
   - "project/"
+# NB: Managed by support/regenerate-release-drafter.sh
 categories:
   - title: '🚀 Features'
     labels:

--- a/.github/release-drafter-scala-support.yml
+++ b/.github/release-drafter-scala-support.yml
@@ -2,7 +2,9 @@ name-template: 'scala-support-v$RESOLVED_VERSION'
 tag-template: 'scala-support-v$RESOLVED_VERSION'
 tag-prefix: scala-support-v
 include-paths:
-  - modules/scala-support/
+  - "modules/scala-support/"
+  - "build.sbt"
+  - "project/"
 categories:
   - title: '🚀 Features'
     labels:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,102 +35,110 @@ jobs:
           gpg --version
           ruby --version
           jekyll --version
+      # NB: Managed by support/regenerate-release-drafter.sh
       - name: 'Publish artifacts [core]'
         if: ${{ steps.set-project-from-tag.outputs.module == 'core' }}
-        run: sbt 'project guardrail-core' 'show version' clean ci-release
+        run: sbt 'show version' "project core" clean compile versionCheck ci-release
         env:
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
           PGP_SECRET: ${{ secrets.PGP_SECRET }}
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
           GUARDRAIL_RELEASE_MODULE: ${{ steps.set-project-from-tag.outputs.module }}
-
-      - name: 'Publish artifacts [java-support]'
-        if: ${{ steps.set-project-from-tag.outputs.module == 'java-support' }}
-        run: sbt "project guardrail-java-support" 'show version' clean ci-release
-        env:
-          PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
-          PGP_SECRET: ${{ secrets.PGP_SECRET }}
-          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
-          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
-          GUARDRAIL_RELEASE_MODULE: ${{ steps.set-project-from-tag.outputs.module }}
-      - name: 'Publish artifacts [scala-support]'
-        if: ${{ steps.set-project-from-tag.outputs.module == 'scala-support' }}
-        run: sbt "project guardrail-scala-support" 'show version' clean ci-release
-        env:
-          PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
-          PGP_SECRET: ${{ secrets.PGP_SECRET }}
-          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
-          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
-          GUARDRAIL_RELEASE_MODULE: ${{ steps.set-project-from-tag.outputs.module }}
-
-      - name: 'Publish artifacts [java-async-http]'
-        if: ${{ steps.set-project-from-tag.outputs.module == 'java-async-http' }}
-        run: sbt "project guardrail-java-async-http" 'show version' clean ci-release
-        env:
-          PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
-          PGP_SECRET: ${{ secrets.PGP_SECRET }}
-          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
-          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
-          GUARDRAIL_RELEASE_MODULE: ${{ steps.set-project-from-tag.outputs.module }}
-      - name: 'Publish artifacts [java-dropwizard]'
-        if: ${{ steps.set-project-from-tag.outputs.module == 'java-dropwizard' }}
-        run: sbt "project guardrail-java-dropwizard" 'show version' clean ci-release
-        env:
-          PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
-          PGP_SECRET: ${{ secrets.PGP_SECRET }}
-          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
-          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
-          GUARDRAIL_RELEASE_MODULE: ${{ steps.set-project-from-tag.outputs.module }}
-      - name: 'Publish artifacts [java-spring-mvc]'
-        if: ${{ steps.set-project-from-tag.outputs.module == 'java-spring-mvc' }}
-        run: sbt "project guardrail-java-spring-mvc" 'show version' clean ci-release
-        env:
-          PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
-          PGP_SECRET: ${{ secrets.PGP_SECRET }}
-          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
-          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
-          GUARDRAIL_RELEASE_MODULE: ${{ steps.set-project-from-tag.outputs.module }}
-      - name: 'Publish artifacts [scala-akka-http]'
-        if: ${{ steps.set-project-from-tag.outputs.module == 'scala-akka-http' }}
-        run: sbt "project guardrail-scala-akka-http" 'show version' clean ci-release
-        env:
-          PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
-          PGP_SECRET: ${{ secrets.PGP_SECRET }}
-          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
-          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
-          GUARDRAIL_RELEASE_MODULE: ${{ steps.set-project-from-tag.outputs.module }}
-      - name: 'Publish artifacts [scala-dropwizard]'
-        if: ${{ steps.set-project-from-tag.outputs.module == 'scala-dropwizard' }}
-        run: sbt "project guardrail-scala-dropwizard" 'show version' clean ci-release
-        env:
-          PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
-          PGP_SECRET: ${{ secrets.PGP_SECRET }}
-          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
-          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
-          GUARDRAIL_RELEASE_MODULE: ${{ steps.set-project-from-tag.outputs.module }}
-      - name: 'Publish artifacts [scala-endpoints]'
-        if: ${{ steps.set-project-from-tag.outputs.module == 'scala-endpoints' }}
-        run: sbt "project guardrail-scala-endpoints" 'show version' clean ci-release
-        env:
-          PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
-          PGP_SECRET: ${{ secrets.PGP_SECRET }}
-          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
-          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
-          GUARDRAIL_RELEASE_MODULE: ${{ steps.set-project-from-tag.outputs.module }}
-      - name: 'Publish artifacts [scala-http4s]'
-        if: ${{ steps.set-project-from-tag.outputs.module == 'scala-http4s' }}
-        run: sbt "project guardrail-scala-http4s" 'show version' clean ci-release
-        env:
-          PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
-          PGP_SECRET: ${{ secrets.PGP_SECRET }}
-          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
-          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
-          GUARDRAIL_RELEASE_MODULE: ${{ steps.set-project-from-tag.outputs.module }}
-
+      # NB: Managed by support/regenerate-release-drafter.sh
       - name: 'Publish artifacts [guardrail]'
         if: ${{ steps.set-project-from-tag.outputs.module == 'guardrail' }}
-        run: sbt "project guardrail" 'show version' clean ci-release
+        run: sbt 'show version' "project guardrail" clean compile versionCheck ci-release
+        env:
+          PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
+          PGP_SECRET: ${{ secrets.PGP_SECRET }}
+          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+          GUARDRAIL_RELEASE_MODULE: ${{ steps.set-project-from-tag.outputs.module }}
+      # NB: Managed by support/regenerate-release-drafter.sh
+      - name: 'Publish artifacts [java-async-http]'
+        if: ${{ steps.set-project-from-tag.outputs.module == 'java-async-http' }}
+        run: sbt 'show version' "project java-async-http" clean compile versionCheck ci-release
+        env:
+          PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
+          PGP_SECRET: ${{ secrets.PGP_SECRET }}
+          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+          GUARDRAIL_RELEASE_MODULE: ${{ steps.set-project-from-tag.outputs.module }}
+      # NB: Managed by support/regenerate-release-drafter.sh
+      - name: 'Publish artifacts [java-dropwizard]'
+        if: ${{ steps.set-project-from-tag.outputs.module == 'java-dropwizard' }}
+        run: sbt 'show version' "project java-dropwizard" clean compile versionCheck ci-release
+        env:
+          PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
+          PGP_SECRET: ${{ secrets.PGP_SECRET }}
+          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+          GUARDRAIL_RELEASE_MODULE: ${{ steps.set-project-from-tag.outputs.module }}
+      # NB: Managed by support/regenerate-release-drafter.sh
+      - name: 'Publish artifacts [java-spring-mvc]'
+        if: ${{ steps.set-project-from-tag.outputs.module == 'java-spring-mvc' }}
+        run: sbt 'show version' "project java-spring-mvc" clean compile versionCheck ci-release
+        env:
+          PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
+          PGP_SECRET: ${{ secrets.PGP_SECRET }}
+          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+          GUARDRAIL_RELEASE_MODULE: ${{ steps.set-project-from-tag.outputs.module }}
+      # NB: Managed by support/regenerate-release-drafter.sh
+      - name: 'Publish artifacts [java-support]'
+        if: ${{ steps.set-project-from-tag.outputs.module == 'java-support' }}
+        run: sbt 'show version' "project java-support" clean compile versionCheck ci-release
+        env:
+          PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
+          PGP_SECRET: ${{ secrets.PGP_SECRET }}
+          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+          GUARDRAIL_RELEASE_MODULE: ${{ steps.set-project-from-tag.outputs.module }}
+      # NB: Managed by support/regenerate-release-drafter.sh
+      - name: 'Publish artifacts [scala-akka-http]'
+        if: ${{ steps.set-project-from-tag.outputs.module == 'scala-akka-http' }}
+        run: sbt 'show version' "project scala-akka-http" clean compile versionCheck ci-release
+        env:
+          PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
+          PGP_SECRET: ${{ secrets.PGP_SECRET }}
+          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+          GUARDRAIL_RELEASE_MODULE: ${{ steps.set-project-from-tag.outputs.module }}
+      # NB: Managed by support/regenerate-release-drafter.sh
+      - name: 'Publish artifacts [scala-dropwizard]'
+        if: ${{ steps.set-project-from-tag.outputs.module == 'scala-dropwizard' }}
+        run: sbt 'show version' "project scala-dropwizard" clean compile versionCheck ci-release
+        env:
+          PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
+          PGP_SECRET: ${{ secrets.PGP_SECRET }}
+          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+          GUARDRAIL_RELEASE_MODULE: ${{ steps.set-project-from-tag.outputs.module }}
+      # NB: Managed by support/regenerate-release-drafter.sh
+      - name: 'Publish artifacts [scala-endpoints]'
+        if: ${{ steps.set-project-from-tag.outputs.module == 'scala-endpoints' }}
+        run: sbt 'show version' "project scala-endpoints" clean compile versionCheck ci-release
+        env:
+          PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
+          PGP_SECRET: ${{ secrets.PGP_SECRET }}
+          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+          GUARDRAIL_RELEASE_MODULE: ${{ steps.set-project-from-tag.outputs.module }}
+      # NB: Managed by support/regenerate-release-drafter.sh
+      - name: 'Publish artifacts [scala-http4s]'
+        if: ${{ steps.set-project-from-tag.outputs.module == 'scala-http4s' }}
+        run: sbt 'show version' "project scala-http4s" clean compile versionCheck ci-release
+        env:
+          PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
+          PGP_SECRET: ${{ secrets.PGP_SECRET }}
+          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+          GUARDRAIL_RELEASE_MODULE: ${{ steps.set-project-from-tag.outputs.module }}
+      # NB: Managed by support/regenerate-release-drafter.sh
+      - name: 'Publish artifacts [scala-support]'
+        if: ${{ steps.set-project-from-tag.outputs.module == 'scala-support' }}
+        run: sbt 'show version' "project scala-support" clean compile versionCheck ci-release
         env:
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
           PGP_SECRET: ${{ secrets.PGP_SECRET }}

--- a/build.sbt
+++ b/build.sbt
@@ -281,6 +281,8 @@ val commonSettings = Seq(
   crossScalaVersions := Seq("2.12.14", "2.13.6"),
   scalaVersion := "2.12.14",
 
+  versionScheme := Some("early-semver"), // This should help once the build plugins start depending directly on modules
+
   scalacOptions ++= Seq(
     "-Ydelambdafy:method",
     "-Yrangepos",

--- a/build.sbt
+++ b/build.sbt
@@ -375,6 +375,7 @@ def baseModule(moduleName: String, moduleSegment: String, path: File): Project =
       }
     )
     .settings(commonSettings)
+    .settings(versionPolicyIntention := Compatibility.BinaryCompatible)
     .settings(name := moduleName)
     .settings(codegenSettings)
     .settings(libraryDependencies ++= testDependencies)

--- a/project/version-policy.sbt
+++ b/project/version-policy.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("ch.epfl.scala" % "sbt-version-policy" % "2.0.0")

--- a/support/regenerate-release-drafter.sh
+++ b/support/regenerate-release-drafter.sh
@@ -1,0 +1,75 @@
+#!/bin/sh
+
+set -e
+
+die() {
+  echo "$@" >&2
+  exit 1
+}
+
+render() {
+  module="$1"; shift || die "Missing module for render"
+
+  cat <<!
+name-template: '$module-v\$RESOLVED_VERSION'
+tag-template: '$module-v\$RESOLVED_VERSION'
+tag-prefix: $module-v
+include-paths:
+!
+  for path in "$@"; do
+    [ -e "$path" ] || die "$path specified in $module, but does not exist"
+    cat <<!
+  - "$path"
+!
+  done
+  cat <<!
+categories:
+  - title: '🚀 Features'
+    labels:
+      - 'enhancement'
+  - title: '🐛 Bug Fixes'
+    labels:
+      - 'bug'
+  - title: '🧰 Maintenance'
+    label: 'chore'
+change-template: '- \$TITLE @\$AUTHOR (#\$NUMBER)'
+change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add \` to disable code blocks.
+version-resolver:
+  major:
+    labels:
+      - 'major'
+  minor:
+    labels:
+      - 'minor'
+  patch:
+    labels:
+      - 'patch'
+  default: patch
+template: |
+  ## Changes
+
+  \$CHANGES
+
+  ## Contributors
+
+  Thanks to \$CONTRIBUTORS for your contributions to this release!
+!
+}
+
+write() {
+  module="$1"; shift || die "Missing module for write"
+  render "$module" "$@" \
+    > ".github/release-drafter-$module.yml"
+}
+
+write core              modules/core/              build.sbt  project/
+write guardrail         modules/codegen/           build.sbt  project/
+write java-async-http   modules/java-async-http/   build.sbt  project/
+write java-dropwizard   modules/java-dropwizard/   build.sbt  project/
+write java-spring-mvc   modules/java-spring-mvc/   build.sbt  project/
+write java-support      modules/java-support/      build.sbt  project/
+write scala-akka-http   modules/scala-akka-http/   build.sbt  project/
+write scala-dropwizard  modules/scala-dropwizard/  build.sbt  project/
+write scala-endpoints   modules/scala-endpoints/   build.sbt  project/
+write scala-http4s      modules/scala-http4s/      build.sbt  project/
+write scala-support     modules/scala-support/     build.sbt  project/

--- a/support/regenerate-release-drafter.sh
+++ b/support/regenerate-release-drafter.sh
@@ -105,7 +105,7 @@ write_release() {
       # NB: Managed by support/regenerate-release-drafter.sh
       - name: 'Publish artifacts [${module}]'
         if: \${{ steps.set-project-from-tag.outputs.module == '${module}' }}
-        run: sbt 'show version' "project ${module}" clean compile ci-release
+        run: sbt 'show version' "project ${module}" clean compile versionCheck ci-release
         env:
           PGP_PASSPHRASE: \${{ secrets.PGP_PASSPHRASE }}
           PGP_SECRET: \${{ secrets.PGP_SECRET }}

--- a/support/regenerate-release-drafter.sh
+++ b/support/regenerate-release-drafter.sh
@@ -23,6 +23,7 @@ include-paths:
 !
   done
   cat <<!
+# NB: Managed by support/regenerate-release-drafter.sh
 categories:
   - title: '🚀 Features'
     labels:


### PR DESCRIPTION
- Track not just the module directory, but also `project/` and `build.sbt` when considering release-drafter for modules
- Using `sbt-version-policy`'s `versionCheck` to ensure bincompat on release so we can rely on `provided` scope
- Using sbt's built-in `versionScheme := Some("early-semver")` to ensure that dependency evictions cause an error
- Adding `support/regenerate-release-drafter.sh` to make it easier to generate the release infrastructure boilerplate