### PR TITLE
Support `x-empty-is-null` when generating Jackson-annotated DTOs

### DIFF
--- a/modules/java-support/src/main/scala/dev/guardrail/generators/syntax/Java.scala
+++ b/modules/java-support/src/main/scala/dev/guardrail/generators/syntax/Java.scala
@@ -151,10 +151,10 @@ object Java {
     case other                        => other.toString
   }
 
-  def requireNonNullExpr(param: Expression): Expression = new MethodCallExpr(
+  def requireNonNullExpr(param: Expression, paramNameForDescription: Option[String] = None): Expression = new MethodCallExpr(
     "requireNonNull",
     param,
-    new StringLiteralExpr(s"${nameFromExpr(param)} is required")
+    new StringLiteralExpr(s"${paramNameForDescription.getOrElse(nameFromExpr(param))} is required")
   )
 
   def requireNonNullExpr(paramName: String): Expression = requireNonNullExpr(new NameExpr(paramName))

--- a/modules/sample-dropwizard/src/test/scala/core/Jackson/JacksonEmptyIsNullTest.scala
+++ b/modules/sample-dropwizard/src/test/scala/core/Jackson/JacksonEmptyIsNullTest.scala
@@ -1,0 +1,66 @@
+package core.Jackson
+
+import java.util.Optional
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.exc.ValueInstantiationException
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module
+import emptyIsNull.client.dropwizard.definitions.EmptyIsNullProperties
+import org.scalatest.TryValues
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.must.Matchers
+
+import scala.util.Try
+
+class JacksonEmptyIsNullTest extends AnyFreeSpec with Matchers with TryValues {
+  private val mapper = new ObjectMapper().registerModule(new Jdk8Module)
+
+  private val okAllPresent =
+    """{
+      |  "empty_allowed": "",
+      |  "empty_not_allowed": "hi",
+      |  "empty_allowed_opt": "",
+      |  "empty_not_allowed_opt": "hi"
+      |}""".stripMargin
+
+  private val okOptionalEmpty =
+    """{
+      |  "empty_allowed": "",
+      |  "empty_not_allowed": "hi",
+      |  "empty_allowed_opt": "",
+      |  "empty_not_allowed_opt": ""
+      |}""".stripMargin
+
+  private val badRequiredEmpty =
+    """{
+      |  "empty_allowed": "",
+      |  "empty_not_allowed": "",
+      |  "empty_allowed_opt": "",
+      |  "empty_not_allowed_opt": "hi"
+      |}""".stripMargin
+
+  "When deserializing an object with x-empty-is null" - {
+    "a valid JSON object is deserialized successfully" in {
+      val result = mapper.readValue(okAllPresent, classOf[EmptyIsNullProperties])
+      result.getEmptyAllowed mustBe ""
+      result.getEmptyNotAllowed mustBe "hi"
+      result.getEmptyAllowedOpt mustBe Optional.of("")
+      result.getEmptyNotAllowedOpt mustBe Optional.of("hi")
+    }
+
+    "a JSON object with an empty optional property deserializes with an empty optional" in {
+      val result = mapper.readValue(okOptionalEmpty, classOf[EmptyIsNullProperties])
+      result.getEmptyAllowed mustBe ""
+      result.getEmptyNotAllowed mustBe "hi"
+      result.getEmptyAllowedOpt mustBe Optional.of("")
+      result.getEmptyNotAllowedOpt mustBe Optional.empty()
+    }
+
+    "a JSON object with an empty required property fails to deserialize" in {
+      val result = Try(mapper.readValue(badRequiredEmpty, classOf[EmptyIsNullProperties]))
+      result.isFailure mustBe true
+      result.failure.exception.getClass mustBe classOf[ValueInstantiationException]
+      result.failure.exception.getCause.getClass mustBe classOf[NullPointerException]
+    }
+  }
+}

--- a/modules/sample-dropwizardScala/src/test/scala/core/Jackson/JacksonEmptyIsNullTest.scala
+++ b/modules/sample-dropwizardScala/src/test/scala/core/Jackson/JacksonEmptyIsNullTest.scala
@@ -1,0 +1,62 @@
+package core.Jackson
+
+import com.fasterxml.jackson.databind.{ JsonMappingException, ObjectMapper }
+import com.fasterxml.jackson.module.scala.DefaultScalaModule
+import emptyIsNull.server.dropwizardScala.definitions.EmptyIsNullProperties
+import org.scalatest.TryValues
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.must.Matchers
+import scala.util.Try
+
+class JacksonEmptyIsNullTest extends AnyFreeSpec with Matchers with TryValues {
+  private val mapper = new ObjectMapper().registerModule(DefaultScalaModule)
+
+  private val okAllPresent =
+    """{
+      |  "empty_allowed": "",
+      |  "empty_not_allowed": "hi",
+      |  "empty_allowed_opt": "",
+      |  "empty_not_allowed_opt": "hi"
+      |}""".stripMargin
+
+  private val okOptionalEmpty =
+    """{
+      |  "empty_allowed": "",
+      |  "empty_not_allowed": "hi",
+      |  "empty_allowed_opt": "",
+      |  "empty_not_allowed_opt": ""
+      |}""".stripMargin
+
+  private val badRequiredEmpty =
+    """{
+      |  "empty_allowed": "",
+      |  "empty_not_allowed": "",
+      |  "empty_allowed_opt": "",
+      |  "empty_not_allowed_opt": "hi"
+      |}""".stripMargin
+
+  "When deserializing an object with x-empty-is null" - {
+    "a valid JSON object is deserialized successfully" in {
+      val result = mapper.readValue(okAllPresent, classOf[EmptyIsNullProperties])
+      result.emptyAllowed mustBe ""
+      result.emptyNotAllowed mustBe "hi"
+      result.emptyAllowedOpt mustBe Some("")
+      result.emptyNotAllowedOpt mustBe Some("hi")
+    }
+
+    "a JSON object with an empty optional property deserializes with an empty optional" in {
+      val result = mapper.readValue(okOptionalEmpty, classOf[EmptyIsNullProperties])
+      result.emptyAllowed mustBe ""
+      result.emptyNotAllowed mustBe "hi"
+      result.emptyAllowedOpt mustBe Some("")
+      result.emptyNotAllowedOpt mustBe None
+    }
+
+    "a JSON object with an empty required property fails to deserialize" in {
+      val result = Try(mapper.readValue(badRequiredEmpty, classOf[EmptyIsNullProperties]))
+      result.isFailure mustBe true
+      result.failure.exception.getClass mustBe classOf[JsonMappingException]
+      result.failure.exception.getMessage must startWith("Value cannot be null")
+    }
+  }
+}

--- a/modules/sample/src/main/resources/empty-is-null.yaml
+++ b/modules/sample/src/main/resources/empty-is-null.yaml
@@ -1,0 +1,23 @@
+openapi: 3.0.2
+info:
+  title: empty is null
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    EmptyIsNullProperties:
+      type: object
+      required:
+        - empty_allowed
+        - empty_not_allowed
+      properties:
+        empty_allowed:
+          type: string
+        empty_not_allowed:
+          type: string
+          x-empty-is-null: true
+        empty_allowed_opt:
+          type: string
+        empty_not_allowed_opt:
+          type: string
+          x-empty-is-null: true

--- a/project/src/main/scala/RegressionTests.scala
+++ b/project/src/main/scala/RegressionTests.scala
@@ -32,6 +32,7 @@ object RegressionTests {
     ExampleCase(sampleResource("custom-header-type.yaml"), "tests.customTypes.customHeader"),
     ExampleCase(sampleResource("date-time.yaml"), "dateTime"),
     ExampleCase(sampleResource("edgecases/defaults.yaml"), "edgecases.defaults"),
+    ExampleCase(sampleResource("empty-is-null.yaml"), "emptyIsNull"),
     ExampleCase(sampleResource("invalid-characters.yaml"), "invalidCharacters").frameworks("java" -> Set("dropwizard", "dropwizard-vavr")),
     ExampleCase(sampleResource("formData.yaml"), "form"),
     ExampleCase(sampleResource("enumerations.yaml"), "enumerations"),


### PR DESCRIPTION
Closes #1257 

(Bonus: beyond #1257, this implements it for scala/jackson as well as java/jackson. Unbonus: this does _not_ work when using the new-style `Presence` stuff; only the legacy handling supports this for now.)