### PR TITLE
runExample bugfix, regenerate release-drafter additions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -34,12 +34,14 @@ runExample := Def.inputTaskDyn {
   import complete.DefaultParsers.spaceDelimited
 
   val args: Seq[String] = spaceDelimited("<arg>").parsed
-  val runArgs = args match {
-    case language :: framework :: Nil => exampleArgs(language, Some(framework))
-    case language :: Nil => exampleArgs(language)
-    case Nil => exampleArgs("scala") ++ exampleArgs("java")
+  val runArgs: List[List[List[String]]] = args match {
+    case language :: framework :: Nil => List(exampleArgs(language, Some(framework)))
+    case language :: Nil => List(exampleArgs(language))
+    case Nil => List(exampleArgs("scala"), exampleArgs("java"))
   }
-  runTask(Test, "dev.guardrail.cli.CLI", runArgs.flatten.filter(_.nonEmpty): _*)
+  Def.sequential(
+    runArgs.map(args => runTask(Test, "dev.guardrail.cli.CLI", args.flatten.filter(_.nonEmpty): _*))
+  )
 }.evaluated
 
 addCommandAlias("resetSample", "; " ++ (scalaFrameworks ++ javaFrameworks).map(x => s"sample-${x}/clean").mkString(" ; "))

--- a/support/regenerate-release-drafter.sh
+++ b/support/regenerate-release-drafter.sh
@@ -99,6 +99,20 @@ jobs:
 !
 }
 
+reinitialize_release_drafter() {
+  cat > .github/workflows/release-drafter.yml <<!
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch: {}
+
+jobs:
+!
+}
+
 write_release() {
   module="$1"; shift || die "Missing module for write_release"
   cat <<!
@@ -115,15 +129,33 @@ write_release() {
 !
 }
 
+write_release_drafter() {
+  module="$1"; shift || die "Missing module for write_release"
+  cat <<!
+  ${module}:
+    name: '[${module}] Draft release'
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: blast-hardcheese/release-drafter@v5.16.42
+        with:
+          config-name: release-drafter-${module}.yml
+        env:
+          GITHUB_TOKEN: \${{ secrets.GITHUB_TOKEN }}
+!
+}
+
 write() {
   module="$1"; shift || die "Missing module for write"
   render "$module" "$@" \
     > ".github/release-drafter-$module.yml"
   write_release "$module" \
     >> .github/workflows/release.yml
+  write_release_drafter "$module" \
+    >> .github/workflows/release-drafter.yml
 }
 
 reinitialize_release
+reinitialize_release_drafter
 
 write core              modules/core/              build.sbt  project/src/main/scala/modules/core.scala
 write guardrail         modules/codegen/           build.sbt  project/src/main/scala/modules/guardrail.scala project/src/main/scala/modules/cli.scala


### PR DESCRIPTION
It looks like after the language prefix stuff was added, `runExample` stopped parsing since the language prefix switching from scala to java was included in the middle of the CLI args, which then switched the language for the initially parsed arguments.