### PR TITLE
Updating README with explicit module versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-guardrail [![Build Status](https://github.com/guardrail-dev/guardrail/workflows/CI/badge.svg)](https://github.com/guardrail-dev/guardrail/actions?query=workflow%3A%22CI%22) | [![codecov](https://codecov.io/gh/guardrail-dev/guardrail/branch/master/graph/badge.svg?token=ssLYYkVBgv)](https://codecov.io/gh/guardrail-dev/guardrail) | [![maven central](https://maven-badges.herokuapp.com/maven-central/dev.guardrail/guardrail_2.12/badge.svg)](https://search.maven.org/search?q=g:dev.guardrail%20a:guardrail_2.12) | [![Join the chat at https://gitter.im/guardrail-dev/guardrail](https://badges.gitter.im/guardrail-dev/guardrail.svg)](https://gitter.im/guardrail-dev/guardrail?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+guardrail [![Build Status](https://github.com/guardrail-dev/guardrail/workflows/CI/badge.svg)](https://github.com/guardrail-dev/guardrail/actions?query=workflow%3A%22CI%22) | [![codecov](https://codecov.io/gh/guardrail-dev/guardrail/branch/master/graph/badge.svg?token=ssLYYkVBgv)](https://codecov.io/gh/guardrail-dev/guardrail) | [![Join the chat at https://gitter.im/guardrail-dev/guardrail](https://badges.gitter.im/guardrail-dev/guardrail.svg)](https://gitter.im/guardrail-dev/guardrail?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 ===
 
 guardrail is a code generation tool, capable of reading from OpenAPI/Swagger specification files and generating both Scala and Java source code, targeting various libraries and frameworks listed here:
@@ -6,12 +6,40 @@ guardrail is a code generation tool, capable of reading from OpenAPI/Swagger spe
 - Scala: `akka-http` and `http4s`, both backed by `circe`, as well as `dropwizard` backed by `jackson`
 - Java: `dropwizard` and `spring-mvc`, both backed by `jackson`
 
+| Plugins | versions |
+|---|---|
+| `sbt-guardrail` | [![sbt-guardrail](https://maven-badges.herokuapp.com/maven-central/dev.guardrail/sbt-guardrail/badge.svg)](https://search.maven.org/search?q=g:dev.guardrail%20a:sbt-guardrail) |
+| `guardrail-maven-plugin` | [![guardrail-maven-plugin](https://maven-badges.herokuapp.com/maven-central/dev.guardrail/guardrail-maven-plugin/badge.svg)](https://search.maven.org/search?q=g:dev.guardrail%20a:guardrail-maven-plugin_2.12) |
+| `guardrail-gradle-plugin` | [Plugin Portal](https://plugins.gradle.org/plugin/com.twilio.guardrail) |
+
 New to guardrail?
 ---
 
 Check out the [docs](https://guardrail.dev/)!
 
 Compatible library versions are listed in [COMPATIBILITY.md](COMPATIBILITY.md)
+
+guardrail module versions
+---
+
+guardrail is modularized, using [`sbt-version-policy`](https://github.com/scalacenter/sbt-version-policy) to ensure binary compatibility between dependent modules.
+
+The dependency chain and versions of published modules are listed below for reference:
+
+| module  | version  | depends on |
+|-----|-----|-----|
+| guardrail-core | [![guardrail-core](https://maven-badges.herokuapp.com/maven-central/dev.guardrail/guardrail-core_2.12/badge.svg)](https://search.maven.org/search?q=g:dev.guardrail%20a:guardrail-core_2.12) |  |
+| guardrail-java-support | [![guardrail-java-support](https://maven-badges.herokuapp.com/maven-central/dev.guardrail/guardrail-java-support_2.12/badge.svg)](https://search.maven.org/search?q=g:dev.guardrail%20a:guardrail-java-support_2.12) | core |
+| guardrail-java-async-http | [![guardrail-java-async-http](https://maven-badges.herokuapp.com/maven-central/dev.guardrail/guardrail-java-async-http_2.12/badge.svg)](https://search.maven.org/search?q=g:dev.guardrail%20a:guardrail-java-async-http_2.12) | java-support |
+| guardrail-java-dropwizard | [![guardrail-java-dropwizard](https://maven-badges.herokuapp.com/maven-central/dev.guardrail/guardrail-java-dropwizard_2.12/badge.svg)](https://search.maven.org/search?q=g:dev.guardrail%20a:guardrail-java-dropwizard_2.12) | java-support, java-async-http |
+| guardrail-java-spring-mvc | [![guardrail-java-spring-mvc](https://maven-badges.herokuapp.com/maven-central/dev.guardrail/guardrail-java-spring-mvc_2.12/badge.svg)](https://search.maven.org/search?q=g:dev.guardrail%20a:guardrail-java-spring-mvc_2.12) | java-support |
+| guardrail-scala-support | [![guardrail-scala-support](https://maven-badges.herokuapp.com/maven-central/dev.guardrail/guardrail-scala-support_2.12/badge.svg)](https://search.maven.org/search?q=g:dev.guardrail%20a:guardrail-scala-support_2.12) | core |
+| guardrail-scala-akka-http | [![guardrail-scala-akka-http](https://maven-badges.herokuapp.com/maven-central/dev.guardrail/guardrail-scala-akka-http_2.12/badge.svg)](https://search.maven.org/search?q=g:dev.guardrail%20a:guardrail-scala-akka-http_2.12) | scala-support |
+| guardrail-scala-dropwizard | [![guardrail-scala-dropwizard](https://maven-badges.herokuapp.com/maven-central/dev.guardrail/guardrail-scala-dropwizard_2.12/badge.svg)](https://search.maven.org/search?q=g:dev.guardrail%20a:guardrail-scala-dropwizard_2.12) | scala-support |
+| guardrail-scala-endpoints | [![guardrail-scala-endpoints](https://maven-badges.herokuapp.com/maven-central/dev.guardrail/guardrail-scala-endpoints_2.12/badge.svg)](https://search.maven.org/search?q=g:dev.guardrail%20a:guardrail-scala-endpoints_2.12) | scala-support |
+| guardrail-scala-http4s | [![guardrail-scala-http4s](https://maven-badges.herokuapp.com/maven-central/dev.guardrail/guardrail-scala-http4s_2.12/badge.svg)](https://search.maven.org/search?q=g:dev.guardrail%20a:guardrail-scala-http4s_2.12) | scala-support |
+| guardrail | [![guardrail](https://maven-badges.herokuapp.com/maven-central/dev.guardrail/guardrail_2.12/badge.svg)](https://search.maven.org/search?q=g:dev.guardrail%20a:guardrail_2.12) | core, java-support, java-dropwizard,<br /> java-spring-mvc, java-async-http,<br /> scala-support, scala-akka-http,<br /> scala-dropwizard, scala-endpoints,<br /> scala-http4s |
+| guardrail-cli | [![guardrail-cli](https://maven-badges.herokuapp.com/maven-central/dev.guardrail/guardrail-cli_2.12/badge.svg)](https://search.maven.org/search?q=g:dev.guardrail%20a:guardrail-cli_2.12) | guardrail |
 
 Interested in contributing?
 ---


### PR DESCRIPTION
Now that there are multiple modules, a single version is only a part of the picture. Restructure README to surface useful version numbers.