### PR TITLE
Adding new GuardrailRunnerCompat

### DIFF
--- a/modules/core/src/main/scala/dev/guardrail/runner/GuardrailRunnerCompat.scala
+++ b/modules/core/src/main/scala/dev/guardrail/runner/GuardrailRunnerCompat.scala
@@ -1,0 +1,7 @@
+package dev.guardrail.runner
+
+import cats.data.NonEmptyList
+
+import dev.guardrail.{ Args, ReadSwagger, Target, WriteTree }
+
+abstract class GuardrailRunnerCompat(val languages: Map[String, NonEmptyList[Args] => Target[NonEmptyList[ReadSwagger[Target[List[WriteTree]]]]]]) extends GuardrailRunner


### PR DESCRIPTION
This should permit non-scala build tooling to construct a guardrail runner