### PR TITLE
Addressing noisy warnings

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,7 +9,7 @@ import dev.guardrail.sbt.RegressionTests._
 import dev.guardrail.sbt.ExampleCase
 import dev.guardrail.sbt.modules
 
-WelcomeMessage.welcomeMessage
+onLoadMessage := WelcomeMessage.welcomeMessage((guardrail / version).value)
 
 import scoverage.ScoverageKeys
 

--- a/build.sbt
+++ b/build.sbt
@@ -113,6 +113,7 @@ lazy val root = modules.root.project
 
 lazy val allDeps = modules.allDeps.project
   .settings(publish / skip := true)
+  .settings(crossScalaVersions := crossScalaVersions.value.filter(_.startsWith("2.12")))
 
 lazy val guardrail = modules.guardrail.project
   .customDependsOn(core)

--- a/build.sbt
+++ b/build.sbt
@@ -127,6 +127,19 @@ lazy val guardrail = modules.guardrail.project
   .customDependsOn(scalaHttp4s)
   .customDependsOn(scalaSupport)
 
+lazy val samples = (project in file("modules/samples"))
+  .settings(publish / skip := true)
+  .aggregate(
+    dropwizardSample,
+    dropwizardVavrSample,
+    javaSpringMvcSample,
+    scalaAkkaHttpJacksonSample,
+    scalaAkkaHttpSample,
+    scalaDropwizardSample,
+    scalaEndpointsSample,
+    scalaHttp4sSample
+  )
+
 lazy val core = modules.core.project
 
 lazy val cli = modules.cli.project

--- a/build.sbt
+++ b/build.sbt
@@ -175,6 +175,7 @@ lazy val microsite = baseModule("microsite", "microsite", file("modules/microsit
   .settings(
     publish / skip := true,
     mdocExtraArguments += "--no-link-hygiene",
+    scalacOptions -= "-Xfatal-warnings"
   )
   .customDependsOn(guardrail)
 

--- a/modules/codegen/src/main/scala/dev/guardrail/generators/java/JavaModule.scala
+++ b/modules/codegen/src/main/scala/dev/guardrail/generators/java/JavaModule.scala
@@ -68,7 +68,7 @@ object JavaModule extends AbstractModule[JavaLanguage] {
       def FrameworkInterp: FrameworkTerms[JavaLanguage, Target]           = framework
       def ProtocolInterp: ProtocolTerms[JavaLanguage, Target]             = protocol
       def ServerInterp: ServerTerms[JavaLanguage, Target]                 = server
-      def SwaggerInterp: SwaggerTerms[JavaLanguage, Target]               = SwaggerGenerator[JavaLanguage]
+      def SwaggerInterp: SwaggerTerms[JavaLanguage, Target]               = SwaggerGenerator[JavaLanguage]()
       def LanguageInterp: LanguageTerms[JavaLanguage, Target]             = JavaGenerator()
       def CollectionsLibInterp: CollectionsLibTerms[JavaLanguage, Target] = collections
     }).runA(modules.toList.toSet)

--- a/modules/codegen/src/main/scala/dev/guardrail/generators/scala/ScalaModule.scala
+++ b/modules/codegen/src/main/scala/dev/guardrail/generators/scala/ScalaModule.scala
@@ -115,7 +115,7 @@ object ScalaModule extends AbstractModule[ScalaLanguage] {
       def FrameworkInterp: FrameworkTerms[ScalaLanguage, Target]           = framework
       def ProtocolInterp: ProtocolTerms[ScalaLanguage, Target]             = protocol
       def ServerInterp: ServerTerms[ScalaLanguage, Target]                 = server
-      def SwaggerInterp: SwaggerTerms[ScalaLanguage, Target]               = SwaggerGenerator[ScalaLanguage]
+      def SwaggerInterp: SwaggerTerms[ScalaLanguage, Target]               = SwaggerGenerator[ScalaLanguage]()
       def LanguageInterp: LanguageTerms[ScalaLanguage, Target]             = ScalaGenerator()
       def CollectionsLibInterp: CollectionsLibTerms[ScalaLanguage, Target] = collections
     }).runA(modules.toList.toSet)

--- a/modules/codegen/src/test/scala/swagger/VendorExtensionTest.scala
+++ b/modules/codegen/src/test/scala/swagger/VendorExtensionTest.scala
@@ -6,7 +6,7 @@ import dev.guardrail.core.extract.VendorExtension
 import io.swagger.parser.OpenAPIParser
 import io.swagger.v3.parser.core.models.ParseOptions
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 

--- a/modules/core/src/main/scala-2.12/dev/guardrail/CollectionsSyntax.scala
+++ b/modules/core/src/main/scala-2.12/dev/guardrail/CollectionsSyntax.scala
@@ -1,0 +1,15 @@
+package dev.guardrail
+
+import scala.collection.IterableView
+
+trait CollectionsSyntax {
+  implicit class ListGroupMap[A](val xs: List[A]) {
+    def groupMap[K, B](toKey: A => K)(toValue: A => B): Map[K, List[B]] =
+      xs.groupBy(toKey).view.map({ case (k, as) => (k, as.map(toValue)) }).toMap
+  }
+
+  implicit class IterableViewMapValues[K, A](val xs: IterableView[(K, A), Iterable[(K, A)]]) {
+    def mapValues[B](f: A => B): IterableView[(K, B), Iterable[_]] =
+      xs.map[(K, B), scala.collection.IterableView[(K, B), Iterable[_]]]({ case (k, a) => (k, f(a)) })
+  }
+}

--- a/modules/core/src/main/scala-2.13/dev/guardrail/CollectionsSyntax.scala
+++ b/modules/core/src/main/scala-2.13/dev/guardrail/CollectionsSyntax.scala
@@ -1,0 +1,3 @@
+package dev.guardrail
+
+trait CollectionsSyntax

--- a/modules/core/src/main/scala/dev/guardrail/Common.scala
+++ b/modules/core/src/main/scala/dev/guardrail/Common.scala
@@ -81,8 +81,7 @@ object Common {
       securitySchemes  <- SwaggerUtil.extractSecuritySchemes(swagger.unwrapTracker, prefixes)
       classNamedRoutes <- routes.traverse(route => getClassName(route.operation, prefixes).map(_ -> route))
       groupedRoutes = classNamedRoutes
-        .groupBy(_._1)
-        .mapValues(_.map(_._2))
+        .groupMap(_._1)(_._2)
         .toList
       frameworkImports <- getFrameworkImports(context.tracing)
 

--- a/modules/core/src/main/scala/dev/guardrail/ReadSwagger.scala
+++ b/modules/core/src/main/scala/dev/guardrail/ReadSwagger.scala
@@ -1,6 +1,6 @@
 package dev.guardrail
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 import java.nio.file.Path
 import java.util

--- a/modules/core/src/main/scala/dev/guardrail/SwaggerUtil.scala
+++ b/modules/core/src/main/scala/dev/guardrail/SwaggerUtil.scala
@@ -13,7 +13,7 @@ import dev.guardrail.core.extract.{ CustomArrayTypeName, CustomMapTypeName, Cust
 import dev.guardrail.core.extract.VendorExtension.VendorExtensible._
 import dev.guardrail.languages.LA
 import dev.guardrail.terms.protocol.PropMeta
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 object SwaggerUtil {
   def customTypeName[L <: LA, F[_], A: VendorExtension.VendorExtensible](v: A)(implicit Cl: CollectionsLibTerms[L, F]): F[Option[String]] = {

--- a/modules/core/src/main/scala/dev/guardrail/Target.scala
+++ b/modules/core/src/main/scala/dev/guardrail/Target.scala
@@ -90,7 +90,7 @@ sealed abstract class Target[+A](val logEntries: StructuredLogger) {
   def map[B](f: A => B): Target[B]
 }
 object TargetValue {
-  def unapply[A](x: TargetValue[A]): Option[(A, StructuredLogger)] = Some((x.value, x.logEntries))
+  def unapply[A](x: TargetValue[A]): Some[(A, StructuredLogger)] = Some((x.value, x.logEntries))
 }
 class TargetValue[A](val value: A, logEntries: StructuredLogger) extends Target[A](logEntries) {
   def valueOr[AA >: A](fallback: Error => AA): AA              = value
@@ -102,7 +102,7 @@ class TargetValue[A](val value: A, logEntries: StructuredLogger) extends Target[
   def map[B](f: A => B): Target[B]                             = new TargetValue(f(value), logEntries)
 }
 object TargetError {
-  def unapply[A](x: TargetError[A]): Option[(Error, StructuredLogger)] = Some((x.error, x.logEntries))
+  def unapply[A](x: TargetError[A]): Some[(Error, StructuredLogger)] = Some((x.error, x.logEntries))
 }
 class TargetError[A](val error: Error, logEntries: StructuredLogger) extends Target[A](logEntries) {
   def valueOr[AA >: A](fallback: Error => AA): AA              = fallback(error)

--- a/modules/core/src/main/scala/dev/guardrail/core/CoreTermInterp.scala
+++ b/modules/core/src/main/scala/dev/guardrail/core/CoreTermInterp.scala
@@ -94,12 +94,7 @@ class CoreTermInterp[L <: LA](
     }
   }
 
-  def processArgSet(targetInterpreter: Framework[L, Target])(args: Args): Target[ReadSwagger[Target[List[WriteTree]]]] = {
-    import scala.meta.parsers.Parsed
-    implicit def parsed2Either[Z]: Parsed[Z] => Either[Parsed.Error, Z] = {
-      case x: Parsed.Error      => Left(x)
-      case Parsed.Success(tree) => Right(tree)
-    }
+  def processArgSet(targetInterpreter: Framework[L, Target])(args: Args): Target[ReadSwagger[Target[List[WriteTree]]]] =
     Target.log.function("processArgSet")(for {
       _          <- Target.log.debug("Processing arguments")
       specPath   <- Target.fromOption(args.specPath, MissingArg(args, Error.ArgName("--specPath")))
@@ -176,5 +171,4 @@ class CoreTermInterp[L <: LA](
         }
       )
     })
-  }
 }

--- a/modules/core/src/main/scala/dev/guardrail/core/Tracker.scala
+++ b/modules/core/src/main/scala/dev/guardrail/core/Tracker.scala
@@ -5,7 +5,7 @@ import cats._
 import cats.data._
 import cats.syntax.all._
 import dev.guardrail.{ Target, UserError }
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import cats.Functor
 
 /**

--- a/modules/core/src/main/scala/dev/guardrail/core/extract/Extractable.scala
+++ b/modules/core/src/main/scala/dev/guardrail/core/extract/Extractable.scala
@@ -3,7 +3,7 @@ package dev.guardrail.core.extract
 import dev.guardrail.core.{ DataRedacted, DataVisible, EmptyIsEmpty, EmptyIsNull, EmptyToNullBehaviour, RedactionBehaviour }
 import scala.util.{ Success, Try }
 import scala.reflect.ClassTag
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import java.util
 
 trait Extractable[T] {

--- a/modules/core/src/main/scala/dev/guardrail/generators/LanguageParameter.scala
+++ b/modules/core/src/main/scala/dev/guardrail/generators/LanguageParameter.scala
@@ -177,7 +177,7 @@ object LanguageParameter {
     import Sc._
     for {
       parameters <- params.traverse(fromParameter(protocolElems))
-      counts     <- parameters.traverse(param => extractTermName(param.paramName)).map(_.groupBy(identity).mapValues(_.length))
+      counts     <- parameters.traverse(param => extractTermName(param.paramName)).map(_.groupBy(identity).view.mapValues(_.length).toMap)
       result <- parameters.traverse { param =>
         extractTermName(param.paramName).flatMap { name =>
           if (counts.getOrElse(name, 0) > 1) {

--- a/modules/core/src/main/scala/dev/guardrail/generators/LanguageParameter.scala
+++ b/modules/core/src/main/scala/dev/guardrail/generators/LanguageParameter.scala
@@ -45,7 +45,7 @@ class LanguageParameter[L <: LA] private[generators] (
     new LanguageParameter[L](in, param, newParamName, argName, argType, rawType, required, hashAlgorithm, isFile)
 }
 object LanguageParameter {
-  def unapply[L <: LA](param: LanguageParameter[L]): Option[(Option[String], L#MethodParameter, L#TermName, RawParameterName, L#Type)] =
+  def unapply[L <: LA](param: LanguageParameter[L]): Some[(Option[String], L#MethodParameter, L#TermName, RawParameterName, L#Type)] =
     Some((param.in, param.param, param.paramName, param.argName, param.argType))
 
   def fromParameter[L <: LA, F[_]](

--- a/modules/core/src/main/scala/dev/guardrail/generators/ProtocolGenerator.scala
+++ b/modules/core/src/main/scala/dev/guardrail/generators/ProtocolGenerator.scala
@@ -500,7 +500,7 @@ object ProtocolGenerator {
     import Lt._
     for {
       paramsWithNames <- params.traverse(param => extractTermNameFromParam(param.term).map((_, param)))
-      counts = paramsWithNames.groupBy(_._1).mapValues(_.length)
+      counts = paramsWithNames.groupBy(_._1).view.mapValues(_.length).toMap
       newParams <- paramsWithNames.traverse({
         case (name, param) =>
           if (counts.getOrElse(name, 0) > 1) {

--- a/modules/core/src/main/scala/dev/guardrail/generators/ProtocolGenerator.scala
+++ b/modules/core/src/main/scala/dev/guardrail/generators/ProtocolGenerator.scala
@@ -31,7 +31,6 @@ import dev.guardrail.terms.{
 import cats.Foldable
 import dev.guardrail.core.extract.Default
 import scala.collection.JavaConverters._
-import scala.language.higherKinds
 
 case class ProtocolDefinitions[L <: LA](
     elems: List[StrictProtocolElems[L]],

--- a/modules/core/src/main/scala/dev/guardrail/generators/ProtocolGenerator.scala
+++ b/modules/core/src/main/scala/dev/guardrail/generators/ProtocolGenerator.scala
@@ -30,7 +30,7 @@ import dev.guardrail.terms.{
 }
 import cats.Foldable
 import dev.guardrail.core.extract.Default
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 case class ProtocolDefinitions[L <: LA](
     elems: List[StrictProtocolElems[L]],

--- a/modules/core/src/main/scala/dev/guardrail/generators/ProtocolGenerator.scala
+++ b/modules/core/src/main/scala/dev/guardrail/generators/ProtocolGenerator.scala
@@ -822,14 +822,14 @@ object ProtocolGenerator {
             map =>
               for {
                 customTpe <- SwaggerUtil.customMapTypeName(map)
-                result    <- customTpe.fold(emptyMap.map(Option(_)))(_ => empty)
+                result    <- customTpe.fold(emptyMap().map(Option(_)))(_ => empty)
               } yield result
           )
           .orRefine({ case arr: ArraySchema if requirement == PropertyRequirement.Required || requirement == PropertyRequirement.RequiredNullable => arr })(
             arr =>
               for {
                 customTpe <- SwaggerUtil.customArrayTypeName(arr)
-                result    <- customTpe.fold(emptyArray.map(Option(_)))(_ => empty)
+                result    <- customTpe.fold(emptyArray().map(Option(_)))(_ => empty)
               } yield result
           )
           .orRefine({ case p: BooleanSchema => p })(p => Default(p).extract[Boolean].fold(empty)(litBoolean(_).map(Some(_))))

--- a/modules/core/src/main/scala/dev/guardrail/generators/ServerGenerator.scala
+++ b/modules/core/src/main/scala/dev/guardrail/generators/ServerGenerator.scala
@@ -42,6 +42,7 @@ object ServerGenerator {
         case (className, unsortedRoutes) =>
           val routes = unsortedRoutes
             .groupBy(_.path.unwrapTracker.indexOf('{'))
+            .view
             .mapValues(_.sortBy(r => (r.path.unwrapTracker, r.method)))
             .toList
             .sortBy(_._1)

--- a/modules/core/src/main/scala/dev/guardrail/package.scala
+++ b/modules/core/src/main/scala/dev/guardrail/package.scala
@@ -34,4 +34,4 @@ package guardrail {
   }
 }
 
-package object guardrail extends MonadChain1
+package object guardrail extends MonadChain1 with CollectionsSyntax

--- a/modules/core/src/main/scala/dev/guardrail/shims/package.scala
+++ b/modules/core/src/main/scala/dev/guardrail/shims/package.scala
@@ -2,7 +2,7 @@ package dev.guardrail
 
 import _root_.io.swagger.v3.oas.models.Operation
 import _root_.io.swagger.v3.oas.models.parameters.Parameter
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 package object shims {
   implicit class OperationExt(operation: Operation) {

--- a/modules/core/src/main/scala/dev/guardrail/terms/Header.scala
+++ b/modules/core/src/main/scala/dev/guardrail/terms/Header.scala
@@ -7,7 +7,7 @@ class Header[L <: LA](val name: String, val isRequired: Boolean, val tpe: L#Type
 }
 
 object Header {
-  def unapply[L <: LA](header: Header[L]): Option[(String, Boolean, L#Type, L#TermName)] = Some((header.name, header.isRequired, header.tpe, header.term))
+  def unapply[L <: LA](header: Header[L]): Some[(String, Boolean, L#Type, L#TermName)] = Some((header.name, header.isRequired, header.tpe, header.term))
 }
 
 class Headers[L <: LA](val value: List[Header[L]])

--- a/modules/core/src/main/scala/dev/guardrail/terms/Responses.scala
+++ b/modules/core/src/main/scala/dev/guardrail/terms/Responses.scala
@@ -18,7 +18,7 @@ class Response[L <: LA](
   override def toString: String = s"Response($statusCodeName, $statusCode, $value, $headers)"
 }
 object Response {
-  def unapply[L <: LA](value: Response[L]): Option[(L#TermName, Option[L#Type], Headers[L])] =
+  def unapply[L <: LA](value: Response[L]): Some[(L#TermName, Option[L#Type], Headers[L])] =
     Some((value.statusCodeName, value.value.map(_._2), value.headers))
 }
 

--- a/modules/core/src/main/scala/dev/guardrail/terms/RouteMeta.scala
+++ b/modules/core/src/main/scala/dev/guardrail/terms/RouteMeta.scala
@@ -6,7 +6,7 @@ import io.swagger.v3.oas.models.Operation
 import io.swagger.v3.oas.models.PathItem.HttpMethod
 import io.swagger.v3.oas.models.media._
 import io.swagger.v3.oas.models.parameters.Parameter
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 import dev.guardrail._
 import dev.guardrail.core.implicits._

--- a/modules/core/src/main/scala/dev/guardrail/terms/RouteMeta.scala
+++ b/modules/core/src/main/scala/dev/guardrail/terms/RouteMeta.scala
@@ -22,11 +22,11 @@ case class RouteMeta(path: Tracker[String], method: HttpMethod, operation: Track
   override def toString(): String =
     s"RouteMeta(${path.unwrapTracker}, $method, ${operation.unwrapTracker.showNotNull} (${operation.showHistory}), $securityRequirements)"
   object MediaType {
-    def unapply(value: MediaType): Option[(Option[Schema[_]], Option[Map[String, Encoding]], Option[Map[String, Object]])] = {
+    def unapply(value: MediaType): Some[(Option[Schema[_]], Option[Map[String, Encoding]], Option[Map[String, Object]])] = {
       val schema: Option[Schema[_]] = Option(value.getSchema)
       val encoding                  = Option(value.getEncoding()).map(_.asScala.toMap)
       val extensions                = Option(value.getExtensions()).map(_.asScala.toMap)
-      Option((schema, encoding, extensions))
+      Some((schema, encoding, extensions))
     }
   }
 

--- a/modules/core/src/main/scala/dev/guardrail/terms/SecurityRequirements.scala
+++ b/modules/core/src/main/scala/dev/guardrail/terms/SecurityRequirements.scala
@@ -24,7 +24,7 @@ object SecurityRequirements {
           .flatMap(
             req =>
               NonEmptyMap.fromMap(
-                TreeMap(req.asScala.mapValues(_.asScala.toList).toSeq: _*)
+                TreeMap(req.asScala.view.mapValues(_.asScala.toList).toSeq: _*)
               )
           )
       )

--- a/modules/core/src/main/scala/dev/guardrail/terms/SecurityRequirements.scala
+++ b/modules/core/src/main/scala/dev/guardrail/terms/SecurityRequirements.scala
@@ -4,7 +4,7 @@ import cats.Order
 import cats.data.{ NonEmptyList, NonEmptyMap }
 import cats.implicits._
 import io.swagger.v3.oas.models.security.SecurityRequirement
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.collection.immutable.TreeMap
 
 import dev.guardrail.terms.SecurityRequirements.SecurityScopes

--- a/modules/core/src/main/scala/dev/guardrail/terms/collections/CollectionsAbstraction.scala
+++ b/modules/core/src/main/scala/dev/guardrail/terms/collections/CollectionsAbstraction.scala
@@ -10,7 +10,7 @@ class TermHolder[L <: LA, +A, HeldType](_value: A) {
   def value: A = _value
 
   override def equals(obj: Any): Boolean = Option(obj) match {
-    case Some(other: TermHolder[_, _, _]) => value.equals(other.value)
+    case Some(other: TermHolder[_, _, _]) => value == other.value
     case _                                => false
   }
   override def hashCode(): Int  = value.hashCode()

--- a/modules/core/src/main/scala/dev/guardrail/terms/collections/CollectionsAbstraction.scala
+++ b/modules/core/src/main/scala/dev/guardrail/terms/collections/CollectionsAbstraction.scala
@@ -21,7 +21,7 @@ object TermHolder {
   type StringMap[A] = Map[String, A]
 
   def apply[L <: LA, A, HeldType](value: A): TermHolder[L, A, HeldType] = new TermHolder[L, A, HeldType](value)
-  def unapply[A](th: TermHolder[_, A, _]): Option[A]                    = Some(th.value)
+  def unapply[A](th: TermHolder[_, A, _]): Some[A]                      = Some(th.value)
 
   final private[collections] class TermHolderPartiallyApplied[L <: LA, HeldType] private[TermHolder] (private val dummy: Boolean = true) extends AnyVal {
     def apply[A <: L#Expression](fa: A): TermHolder[L, A, HeldType] = TermHolder[L, A, HeldType](fa)

--- a/modules/core/src/main/scala/dev/guardrail/terms/package.scala
+++ b/modules/core/src/main/scala/dev/guardrail/terms/package.scala
@@ -1,0 +1,3 @@
+package dev.guardrail
+
+package object terms extends CollectionsSyntax

--- a/modules/core/src/test/scala/support/SwaggerSpecRunner.scala
+++ b/modules/core/src/test/scala/support/SwaggerSpecRunner.scala
@@ -5,10 +5,8 @@ import _root_.io.swagger.v3.oas.models._
 import _root_.io.swagger.v3.parser.core.models.ParseOptions
 import cats.data.NonEmptyList
 import java.util.LinkedList
-import org.scalactic.Equality
 import org.scalatest.{ Assertions, EitherValues, OptionValues }
 import org.scalactic.source.Position
-import scala.meta.Tree
 
 import dev.guardrail._
 import dev.guardrail.core.{ StructuredLogger, Tracker }
@@ -25,15 +23,6 @@ trait TargetValues { self: Assertions =>
 }
 
 trait SwaggerSpecRunner extends EitherValues with OptionValues with TargetValues { self: Assertions =>
-  implicit def TreeEquality[A <: Tree]: Equality[A] =
-    new Equality[A] {
-      def areEqual(a: A, b: Any): Boolean =
-        b match {
-          case x: Tree => a.structure == x.structure
-          case _       => false
-        }
-    }
-
   def swaggerFromString(spec: String): OpenAPI = {
     val parseOpts = new ParseOptions
     parseOpts.setResolve(true)

--- a/modules/java-async-http/src/main/scala/dev/guardrail/generators/java/asyncHttpClient/AsyncHttpClientClientGenerator.scala
+++ b/modules/java-async-http/src/main/scala/dev/guardrail/generators/java/asyncHttpClient/AsyncHttpClientClientGenerator.scala
@@ -217,6 +217,9 @@ object AsyncHttpClientClientGenerator {
         case Some(AnyContentType | OctetStream | TextPlain) =>
           // TODO: These need to be addressed, just suppressing warnings as of now
           None
+        case Some(_: BinaryContent | _: TextContent) =>
+          // Impossible, see https://github.com/scala/bug/issues/12232
+          None
       }
     }
   }
@@ -1223,6 +1226,8 @@ class AsyncHttpClientClientGenerator private (implicit Cl: CollectionsLibTerms[J
         case (Some(_), Some(_)) => // no params
 
         case (Some(_), _) if !tracing => // no params
+
+        case (_, _) => // Catch edge cases
       }
 
       val builderSetters = List(

--- a/modules/java-async-http/src/main/scala/dev/guardrail/generators/java/asyncHttpClient/AsyncHttpClientClientGenerator.scala
+++ b/modules/java-async-http/src/main/scala/dev/guardrail/generators/java/asyncHttpClient/AsyncHttpClientClientGenerator.scala
@@ -428,6 +428,7 @@ object AsyncHttpClientClientGenerator {
     }
 }
 
+@SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements", "org.wartremover.warts.Null"))
 class AsyncHttpClientClientGenerator private (implicit Cl: CollectionsLibTerms[JavaLanguage, Target], Ca: CollectionsAbstraction[JavaLanguage])
     extends ClientTerms[JavaLanguage, Target] {
   import AsyncHttpClientClientGenerator._

--- a/modules/java-async-http/src/main/scala/dev/guardrail/generators/java/asyncHttpClient/AsyncHttpClientClientGenerator.scala
+++ b/modules/java-async-http/src/main/scala/dev/guardrail/generators/java/asyncHttpClient/AsyncHttpClientClientGenerator.scala
@@ -28,7 +28,19 @@ import dev.guardrail.shims._
 import dev.guardrail.terms.client.ClientTerms
 import dev.guardrail.terms.collections.CollectionsAbstraction
 import dev.guardrail.terms.protocol.{ StaticDefns, StrictProtocolElems }
-import dev.guardrail.terms.{ ApplicationJson, BinaryContent, ContentType, MultipartFormData, Response, Responses, TextContent, UrlencodedFormData }
+import dev.guardrail.terms.{
+  AnyContentType,
+  ApplicationJson,
+  BinaryContent,
+  ContentType,
+  MultipartFormData,
+  OctetStream,
+  Response,
+  Responses,
+  TextContent,
+  TextPlain,
+  UrlencodedFormData
+}
 import dev.guardrail.terms.{ CollectionsLibTerms, RouteMeta, SecurityScheme }
 
 @SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements", "org.wartremover.warts.Null"))
@@ -201,6 +213,9 @@ object AsyncHttpClientClientGenerator {
 
         case Some(UrlencodedFormData) | Some(MultipartFormData) =>
           // We shouldn't be here, since we can't have a body param with these content types
+          None
+        case Some(AnyContentType | OctetStream | TextPlain) =>
+          // TODO: These need to be addressed, just suppressing warnings as of now
           None
       }
     }

--- a/modules/java-dropwizard/src/main/scala/dev/guardrail/generators/java/dropwizard/Dropwizard.scala
+++ b/modules/java-dropwizard/src/main/scala/dev/guardrail/generators/java/dropwizard/Dropwizard.scala
@@ -17,6 +17,6 @@ object Dropwizard extends Framework[JavaLanguage, Target] {
   implicit def ClientInterp         = AsyncHttpClientClientGenerator()
   implicit def FrameworkInterp      = DropwizardGenerator()
   implicit def ServerInterp         = DropwizardServerGenerator()
-  implicit def SwaggerInterp        = SwaggerGenerator[JavaLanguage]
+  implicit def SwaggerInterp        = SwaggerGenerator[JavaLanguage]()
   implicit def LanguageInterp       = JavaGenerator()
 }

--- a/modules/java-dropwizard/src/main/scala/dev/guardrail/generators/java/dropwizard/DropwizardServerGenerator.scala
+++ b/modules/java-dropwizard/src/main/scala/dev/guardrail/generators/java/dropwizard/DropwizardServerGenerator.scala
@@ -30,7 +30,6 @@ import dev.guardrail.terms.collections.CollectionsAbstraction
 import dev.guardrail.terms.protocol.StrictProtocolElems
 import dev.guardrail.terms.server._
 import dev.guardrail.terms.{
-  AnyContentType,
   ApplicationJson,
   BinaryContent,
   CollectionsLibTerms,
@@ -66,7 +65,7 @@ class DropwizardServerGenerator private (implicit Cl: CollectionsLibTerms[JavaLa
     case OctetStream         => new FieldAccessExpr(new NameExpr("MediaType"), "APPLICATION_OCTET_STREAM")
     case TextContent(name)   => new StringLiteralExpr(name)
     case BinaryContent(name) => new StringLiteralExpr(name)
-    case AnyContentType      => ??? // TODO: What do we do if we get here?
+    case _                   => ??? // TODO: What do we do if we get here?
   }
 
   private val ASYNC_RESPONSE_TYPE   = StaticJavaParser.parseClassOrInterfaceType("AsyncResponse")

--- a/modules/java-dropwizard/src/main/scala/dev/guardrail/generators/java/dropwizard/DropwizardServerGenerator.scala
+++ b/modules/java-dropwizard/src/main/scala/dev/guardrail/generators/java/dropwizard/DropwizardServerGenerator.scala
@@ -30,6 +30,7 @@ import dev.guardrail.terms.collections.CollectionsAbstraction
 import dev.guardrail.terms.protocol.StrictProtocolElems
 import dev.guardrail.terms.server._
 import dev.guardrail.terms.{
+  AnyContentType,
   ApplicationJson,
   BinaryContent,
   CollectionsLibTerms,
@@ -66,6 +67,7 @@ class DropwizardServerGenerator private (implicit Cl: CollectionsLibTerms[JavaLa
     case OctetStream         => new FieldAccessExpr(new NameExpr("MediaType"), "APPLICATION_OCTET_STREAM")
     case TextContent(name)   => new StringLiteralExpr(name)
     case BinaryContent(name) => new StringLiteralExpr(name)
+    case AnyContentType      => ??? // TODO: What do we do if we get here?
   }
 
   private val ASYNC_RESPONSE_TYPE   = StaticJavaParser.parseClassOrInterfaceType("AsyncResponse")

--- a/modules/java-dropwizard/src/main/scala/dev/guardrail/generators/java/dropwizard/DropwizardServerGenerator.scala
+++ b/modules/java-dropwizard/src/main/scala/dev/guardrail/generators/java/dropwizard/DropwizardServerGenerator.scala
@@ -45,7 +45,6 @@ import dev.guardrail.terms.{
   TextPlain,
   UrlencodedFormData
 }
-import dev.guardrail.terms.{ CollectionsLibTerms, RouteMeta, SecurityScheme }
 
 object DropwizardServerGenerator {
   def apply()(implicit Cl: CollectionsLibTerms[JavaLanguage, Target], Ca: CollectionsAbstraction[JavaLanguage]): ServerTerms[JavaLanguage, Target] =

--- a/modules/java-dropwizard/src/test/scala/tests/core/RequestBodiesTest.scala
+++ b/modules/java-dropwizard/src/test/scala/tests/core/RequestBodiesTest.scala
@@ -6,7 +6,7 @@ import dev.guardrail.generators.java.dropwizard.Dropwizard
 import dev.guardrail.generators.java.syntax._
 import dev.guardrail.Context
 import dev.guardrail.generators.Clients
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import support.SwaggerSpecRunner
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers

--- a/modules/java-dropwizard/src/test/scala/tests/generators/dropwizard/server/DropwizardContentTypesTest.scala
+++ b/modules/java-dropwizard/src/test/scala/tests/generators/dropwizard/server/DropwizardContentTypesTest.scala
@@ -6,7 +6,7 @@ import dev.guardrail.Context
 import dev.guardrail.generators.{ Server, Servers }
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.must.Matchers
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.compat.java8.OptionConverters._
 import support.SwaggerSpecRunner
 

--- a/modules/java-dropwizard/src/test/scala/tests/generators/dropwizard/server/DropwizardOptionalArrayParamTest.scala
+++ b/modules/java-dropwizard/src/test/scala/tests/generators/dropwizard/server/DropwizardOptionalArrayParamTest.scala
@@ -8,7 +8,7 @@ import org.scalatest.Retries
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.must.Matchers
 import org.scalatest.tagobjects.Retryable
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.compat.java8.OptionConverters._
 import support.SwaggerSpecRunner
 

--- a/modules/java-spring-mvc/src/main/scala/dev/guardrail/generators/java/springMvc/SpringMvc.scala
+++ b/modules/java-spring-mvc/src/main/scala/dev/guardrail/generators/java/springMvc/SpringMvc.scala
@@ -16,6 +16,6 @@ object SpringMvc extends Framework[JavaLanguage, Target] {
   implicit def ClientInterp         = SpringMvcClientGenerator()
   implicit def FrameworkInterp      = SpringMvcGenerator()
   implicit def ServerInterp         = SpringMvcServerGenerator()
-  implicit def SwaggerInterp        = SwaggerGenerator[JavaLanguage]
+  implicit def SwaggerInterp        = SwaggerGenerator[JavaLanguage]()
   implicit def LanguageInterp       = JavaGenerator()
 }

--- a/modules/java-spring-mvc/src/main/scala/dev/guardrail/generators/java/springMvc/SpringMvcServerGenerator.scala
+++ b/modules/java-spring-mvc/src/main/scala/dev/guardrail/generators/java/springMvc/SpringMvcServerGenerator.scala
@@ -67,6 +67,8 @@ class SpringMvcServerGenerator private (implicit Cl: CollectionsLibTerms[JavaLan
     case TextContent(name)   => new StringLiteralExpr(name)
     case BinaryContent(name) => new StringLiteralExpr(name)
     case AnyContentType      => ??? // TODO: What do we do if we get here?
+    case _: TextContent      => ???
+    case _: BinaryContent    => ???
   }
 
   private val ASYNC_RESPONSE_TYPE        = StaticJavaParser.parseClassOrInterfaceType("DeferredResult<ResponseEntity<?>>")

--- a/modules/java-spring-mvc/src/main/scala/dev/guardrail/generators/java/springMvc/SpringMvcServerGenerator.scala
+++ b/modules/java-spring-mvc/src/main/scala/dev/guardrail/generators/java/springMvc/SpringMvcServerGenerator.scala
@@ -28,6 +28,7 @@ import dev.guardrail.terms.server._
 import dev.guardrail.shims.OperationExt
 import dev.guardrail.terms.collections.CollectionsAbstraction
 import dev.guardrail.terms.{
+  AnyContentType,
   ApplicationJson,
   BinaryContent,
   CollectionsLibTerms,
@@ -65,6 +66,7 @@ class SpringMvcServerGenerator private (implicit Cl: CollectionsLibTerms[JavaLan
     case OctetStream         => new FieldAccessExpr(new NameExpr("MediaType"), "APPLICATION_OCTET_STREAM_VALUE")
     case TextContent(name)   => new StringLiteralExpr(name)
     case BinaryContent(name) => new StringLiteralExpr(name)
+    case AnyContentType      => ??? // TODO: What do we do if we get here?
   }
 
   private val ASYNC_RESPONSE_TYPE        = StaticJavaParser.parseClassOrInterfaceType("DeferredResult<ResponseEntity<?>>")

--- a/modules/java-support/src/main/scala/dev/guardrail/generators/java/JavaGenerator.scala
+++ b/modules/java-support/src/main/scala/dev/guardrail/generators/java/JavaGenerator.scala
@@ -15,7 +15,7 @@ import java.util.Locale
 import org.eclipse.jdt.core.formatter.{ CodeFormatter, DefaultCodeFormatterConstants }
 import org.eclipse.jdt.core.{ JavaCore, ToolFactory }
 import org.eclipse.jface.text.Document
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 import scala.language.existentials

--- a/modules/java-support/src/main/scala/dev/guardrail/generators/java/jackson/JacksonGenerator.scala
+++ b/modules/java-support/src/main/scala/dev/guardrail/generators/java/jackson/JacksonGenerator.scala
@@ -13,7 +13,6 @@ import com.github.javaparser.ast.body._
 import com.github.javaparser.ast.expr.{ MethodCallExpr, _ }
 import com.github.javaparser.ast.stmt._
 
-import dev.guardrail.{ RuntimeFailure, Target, UserError }
 import dev.guardrail.core
 import dev.guardrail.core.Tracker
 import dev.guardrail.core.extract.{ DataRedaction, EmptyValueIsNull }
@@ -23,11 +22,11 @@ import dev.guardrail.generators.java.JavaGenerator
 import dev.guardrail.generators.java.JavaLanguage
 import dev.guardrail.generators.java.syntax._
 import dev.guardrail.generators.{ RawParameterName, RawParameterType }
-import dev.guardrail.terms.{ CollectionsLibTerms, RenderedEnum, RenderedIntEnum, RenderedLongEnum, RenderedStringEnum }
 import dev.guardrail.terms.collections.CollectionsAbstraction
 import dev.guardrail.terms.protocol.PropertyRequirement
 import dev.guardrail.terms.protocol._
 import dev.guardrail.terms.{ CollectionsLibTerms, ProtocolTerms, RenderedEnum, RenderedIntEnum, RenderedLongEnum, RenderedStringEnum }
+import dev.guardrail.{ RuntimeFailure, Target, UserError }
 
 object JacksonGenerator {
   def apply()(implicit Cl: CollectionsLibTerms[JavaLanguage, Target], Ca: CollectionsAbstraction[JavaLanguage]): ProtocolTerms[JavaLanguage, Target] =

--- a/modules/java-support/src/main/scala/dev/guardrail/generators/java/syntax/Java.scala
+++ b/modules/java-support/src/main/scala/dev/guardrail/generators/java/syntax/Java.scala
@@ -8,7 +8,7 @@ import com.github.javaparser.ast.comments.{ BlockComment, Comment }
 import com.github.javaparser.ast.expr._
 import com.github.javaparser.ast.nodeTypes.{ NodeWithName, NodeWithSimpleName }
 import com.github.javaparser.ast.{ CompilationUnit, ImportDeclaration, Node, NodeList }
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.compat.java8.OptionConverters._
 import scala.reflect.ClassTag
 import scala.util.{ Failure, Success, Try }

--- a/modules/java-support/src/test/scala/tests/generators/helpers/JacksonHelpersTest.scala
+++ b/modules/java-support/src/test/scala/tests/generators/helpers/JacksonHelpersTest.scala
@@ -37,23 +37,23 @@ class JacksonHelpersTest extends AnyFreeSpec with Matchers {
     )
 
   object StringLiteralExpr {
-    def unapply(value: expr.StringLiteralExpr): Option[String] = Some(value.getValue())
+    def unapply(value: expr.StringLiteralExpr): Some[String] = Some(value.getValue())
   }
 
   object BooleanLiteralExpr {
-    def unapply(value: expr.BooleanLiteralExpr): Option[Boolean] = Some(value.getValue())
+    def unapply(value: expr.BooleanLiteralExpr): Some[Boolean] = Some(value.getValue())
   }
 
   object IntegerLiteralExpr {
-    def unapply(value: expr.IntegerLiteralExpr): Option[String] = Some(value.getValue())
+    def unapply(value: expr.IntegerLiteralExpr): Some[String] = Some(value.getValue())
   }
 
   object LongLiteralExpr {
-    def unapply(value: expr.LongLiteralExpr): Option[String] = Some(value.getValue())
+    def unapply(value: expr.LongLiteralExpr): Some[String] = Some(value.getValue())
   }
 
   object DoubleLiteralExpr {
-    def unapply(value: expr.DoubleLiteralExpr): Option[String] = Some(value.getValue())
+    def unapply(value: expr.DoubleLiteralExpr): Some[String] = Some(value.getValue())
   }
 
   object ObjectCreationExpr {

--- a/modules/java-support/src/test/scala/tests/generators/helpers/JacksonHelpersTest.scala
+++ b/modules/java-support/src/test/scala/tests/generators/helpers/JacksonHelpersTest.scala
@@ -65,45 +65,59 @@ class JacksonHelpersTest extends AnyFreeSpec with Matchers {
 
   "Jackson can build a discriminator value expression" - {
     "from a string" in {
-      val StringLiteralExpr(foobar) = discriminatorExpression("foobar", "string").value
-      foobar mustBe "foobar"
+      discriminatorExpression("foobar", "string").value match {
+        case StringLiteralExpr(foobar) => foobar mustBe "foobar"
+        case _                         => fail()
+      }
     }
 
     "from a boolean" in {
-      val BooleanLiteralExpr(bool) = discriminatorExpression("true", "boolean").value
-      bool mustBe true
+      discriminatorExpression("true", "boolean").value match {
+        case BooleanLiteralExpr(bool) => bool mustBe true
+        case _                        => fail()
+      }
     }
 
     "from an int32" in {
-      val IntegerLiteralExpr(int) = discriminatorExpression("42", "integer", Some("int32")).value
-      int mustBe "42"
+      discriminatorExpression("42", "integer", Some("int32")).value match {
+        case IntegerLiteralExpr(int) => int mustBe "42"
+        case _                       => fail()
+      }
     }
 
     "from an int64" in {
-      val LongLiteralExpr(long) = discriminatorExpression(Long.MaxValue.toString, "integer", Some("int64")).value
-      long mustBe Long.MaxValue.toString()
+      discriminatorExpression(Long.MaxValue.toString, "integer", Some("int64")).value match {
+        case LongLiteralExpr(long) => long mustBe Long.MaxValue.toString()
+        case _                     => fail()
+      }
     }
 
     "from a bigint" in {
-      val ObjectCreationExpr(_, BIG_INTEGER_FQ_TYPE, List(StringLiteralExpr(bigintStr))) = discriminatorExpression("12345678901234567890", "integer").value
-      println(bigintStr.getClass())
-      bigintStr mustBe "12345678901234567890"
+      discriminatorExpression("12345678901234567890", "integer").value match {
+        case ObjectCreationExpr(_, BIG_INTEGER_FQ_TYPE, List(StringLiteralExpr(bigintStr))) => bigintStr mustBe "12345678901234567890"
+        case _                                                                              => fail()
+      }
     }
 
     "from a float" in {
-      val DoubleLiteralExpr(floatStr) = discriminatorExpression("42.42", "number", Some("float")).value
-      floatStr mustBe "42.41999816894531" // Not "42.42" but kinda close enough I guess.
+      discriminatorExpression("42.42", "number", Some("float")).value match {
+        case DoubleLiteralExpr(floatStr) => floatStr mustBe "42.41999816894531" // Not "42.42" but kinda close enough I guess.
+        case _                           => fail()
+      }
     }
 
     "from a double" in {
-      val DoubleLiteralExpr(doubleStr) = discriminatorExpression("42.42", "number", Some("double")).value
-      doubleStr mustBe "42.42" // Why isn't this inaccurate like "from a float"?
+      discriminatorExpression("42.42", "number", Some("double")).value match {
+        case DoubleLiteralExpr(doubleStr) => doubleStr mustBe "42.42" // Why isn't this inaccurate like "from a float"?
+        case _                            => fail()
+      }
     }
 
     "from a bigdecimal" in {
-      val ObjectCreationExpr(_, BIG_DECIMAL_FQ_TYPE, List(StringLiteralExpr(bigdecStr))) =
-        discriminatorExpression("12345678901234567890.0987654321", "number").value
-      bigdecStr mustBe "12345678901234567890.0987654321"
+      discriminatorExpression("12345678901234567890.0987654321", "number").value match {
+        case ObjectCreationExpr(_, BIG_DECIMAL_FQ_TYPE, List(StringLiteralExpr(bigdecStr))) => bigdecStr mustBe "12345678901234567890.0987654321"
+        case _                                                                              => fail()
+      }
     }
   }
 

--- a/modules/microsite/src/main/scala/DocsHelpers.scala
+++ b/modules/microsite/src/main/scala/DocsHelpers.scala
@@ -18,6 +18,7 @@ sealed trait SnippetComponent
 case object GeneratingAServer extends SnippetComponent
 case object GeneratingClients extends SnippetComponent
 
+@SuppressWarnings(Array("org.wartremover.warts.EitherProjectionPartial", "org.wartremover.warts.TraversableOps"))
 object DocsHelpers {
   def sampleSpec = "modules/microsite/docs/sample-user.json"
   def renderScalaSnippet(generator: Framework[ScalaLanguage, Target], identifier: SnippetComponent)(prefix: String, suffix: String): Unit = {

--- a/modules/sample-akkaHttp/src/test/scala/core/issues/Issue357.scala
+++ b/modules/sample-akkaHttp/src/test/scala/core/issues/Issue357.scala
@@ -105,7 +105,7 @@ class Issue357Suite extends AnyFunSpec with Matchers with EitherValues with Scal
     import issues.issue357.client.akkaHttp.{ Client, DeleteFooResponse, PatchFooResponse, PutFooResponse }
 
     object pathRE {
-      def unapply(value: Uri.Path): Option[String] =
+      def unapply(value: Uri.Path): Some[String] =
         value match {
           case Uri.Path.Slash(Uri.Path.Segment(head, tail)) => Some(head)
           case rest                                         => fail("Expected \"/{arg}\" did not match: " + rest.toString())

--- a/modules/sample-akkaHttpJackson/src/test/scala/core/issues/Issue357.scala
+++ b/modules/sample-akkaHttpJackson/src/test/scala/core/issues/Issue357.scala
@@ -102,7 +102,7 @@ class Issue357Suite extends AnyFunSpec with TestImplicits with Matchers with Eit
     import issues.issue357.client.akkaHttpJackson.{ Client, DeleteFooResponse, PatchFooResponse, PutFooResponse }
 
     object pathRE {
-      def unapply(value: Uri.Path): Option[String] =
+      def unapply(value: Uri.Path): Some[String] =
         value match {
           case Uri.Path.Slash(Uri.Path.Segment(head, tail)) => Some(head)
           case rest                                         => fail("Expected \"/{arg}\" did not match: " + rest.toString())

--- a/modules/sample-dropwizard/src/test/scala/core/Dropwizard/JavaInvalidCharacterEscapingTest.scala
+++ b/modules/sample-dropwizard/src/test/scala/core/Dropwizard/JavaInvalidCharacterEscapingTest.scala
@@ -14,7 +14,7 @@ import org.asynchttpclient.uri.Uri
 import org.asynchttpclient.{ HttpResponseStatus, Request, Response }
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.must.Matchers
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 object JavaInvalidCharacterEscapingTest {
   private implicit class RichString(private val s: String) extends AnyVal {

--- a/modules/sample-dropwizard/src/test/scala/core/Jackson/Issue389.scala
+++ b/modules/sample-dropwizard/src/test/scala/core/Jackson/Issue389.scala
@@ -5,7 +5,7 @@ import issues.issue389.client.dropwizard.definitions.{ Bar, Foo }
 import java.util
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module
 
 class Issue389 extends AnyFreeSpec with Matchers {

--- a/modules/sample-http4s/src/test/scala/core/Http4s/Http4sNonStringEnumerationTest.scala
+++ b/modules/sample-http4s/src/test/scala/core/Http4s/Http4sNonStringEnumerationTest.scala
@@ -79,7 +79,7 @@ class Http4sNonStringEnumerationTest extends AnyFunSuite with Matchers with Eith
 
     val client = Client.fromHttpApp(httpService.orNotFound)
 
-    val uri = Uri().withPath("/foo/1").withQueryParam("longEnum", "2").withQueryParam("stringEnum", "i like spaces")
+    val uri = Uri().withPath(Uri.Path.unsafeFromString("/foo/1")).withQueryParam("longEnum", "2").withQueryParam("stringEnum", "i like spaces")
     client.expect[Json](Request[IO](method = Method.POST, uri = uri).withEntity("3")).attempt.unsafeRunSync() should be(
       Right(Json.fromString(expectedResponse.value))
     )

--- a/modules/sample-http4s/src/test/scala/core/issues/Issue1218.scala
+++ b/modules/sample-http4s/src/test/scala/core/issues/Issue1218.scala
@@ -1,0 +1,112 @@
+package core.issues
+
+import scala.language.{ higherKinds, reflectiveCalls }
+
+import cats.effect.IO
+import cats.data.{ Kleisli, ValidatedNel }
+import org.http4s._
+import org.http4s.client.{ Client => Http4sClient }
+import org.http4s.blaze.client._
+import org.http4s.headers._
+import org.http4s.implicits._
+import org.http4s.multipart._
+import cats.instances.future._
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.time.SpanSugar._
+import org.scalatest.EitherValues
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+import io.circe._
+import org.scalatest.enablers.Aggregating
+import org.scalactic.Equality
+import org.http4s.dsl.impl.{ OptionalMultiQueryParamDecoderMatcher, QueryParamDecoderMatcher }
+
+class Issue1218Suite extends AnyFunSuite with Matchers with EitherValues with ScalaFutures {
+  override implicit val patienceConfig = PatienceConfig(10 seconds, 1 second)
+
+  // Hackily provide Aggregating instance for Option
+  implicit def aggregatingOption[A](implicit ev: Equality[A]): Aggregating[Option[A]] = new Aggregating[Option[A]] {
+    val proxy = Aggregating.aggregatingNatureOfGenTraversable[A, Iterable](ev)
+
+    def containsAllOf(aggregation: Option[A], eles: _root_.scala.collection.Seq[Any]): Boolean        = proxy.containsAllOf(aggregation, eles)
+    def containsAtLeastOneOf(aggregation: Option[A], eles: _root_.scala.collection.Seq[Any]): Boolean = proxy.containsAtLeastOneOf(aggregation, eles)
+    def containsAtMostOneOf(aggregation: Option[A], eles: _root_.scala.collection.Seq[Any]): Boolean  = proxy.containsAtMostOneOf(aggregation, eles)
+    def containsOnly(aggregation: Option[A], eles: _root_.scala.collection.Seq[Any]): Boolean         = proxy.containsOnly(aggregation, eles)
+    def containsTheSameElementsAs(leftAggregation: Option[A], rightAggregation: _root_.scala.collection.GenTraversable[Any]): Boolean =
+      proxy.containsTheSameElementsAs(leftAggregation, rightAggregation)
+  }
+
+  class CompareQueryParamDecoderMatcherHolder[A, Container[_]](val dummy: Boolean = true) {
+    def apply[
+        Ours <: { def unapply(params: Map[String, _root_.scala.collection.Seq[String]]): Option[Container[A]] }
+    ](
+        ours: Ours,
+        key: String
+    )(implicit ev1: Equality[A], ev2: Aggregating[Container[A]], ev3: QueryParamDecoder[A]): Map[String, _root_.scala.collection.Seq[String]] => Unit = {
+      cases =>
+        val theirs = new QueryParamDecoderMatcher[A](key) {}
+
+        cases.foreach {
+          case (label, values) =>
+            val params = Map(key -> values)
+            ours.unapply(params) should contain theSameElementsAs (theirs.unapplySeq(params))
+        }
+    }
+  }
+  def compareQPDM[A, Container[_]]: CompareQueryParamDecoderMatcherHolder[A, Container] = new CompareQueryParamDecoderMatcherHolder[A, Container]()
+
+  class CompareOptionalMultiQueryParamDecoderMatcherHolder[A, Container[_]](val dummy: Boolean = true) {
+    def apply[
+        Ours <: { def unapply(params: Map[String, collection.Seq[String]]): Option[Option[Container[A]]] }
+    ](ours: Ours, key: String)(implicit ev1: Equality[A], ev2: Aggregating[Container[A]], ev3: QueryParamDecoder[A]): Map[String, Seq[String]] => Unit = {
+      cases =>
+        val theirs = new OptionalMultiQueryParamDecoderMatcher[A](key) {}
+
+        cases.foreach {
+          case (label, values) =>
+            val params = Map(key -> values)
+            ours.unapply(params) should contain theSameElementsAs (theirs.unapply(params).collectFirst {
+              case cats.data.Validated.Valid(value) => Option(value).filter(_.nonEmpty)
+            })
+        }
+    }
+  }
+  def compareOMQPDM[A, Container[_]]: CompareOptionalMultiQueryParamDecoderMatcherHolder[A, Container] =
+    new CompareOptionalMultiQueryParamDecoderMatcherHolder[A, Container]()
+
+  test("All query parameter matchers behave the same as in-built ones") {
+    val resource = new issues.issue1218.server.http4s.Resource[IO]()
+
+    val stringCases = Map[String, Seq[String]](
+      "empty"     -> Seq.empty,
+      "single"    -> Seq("foo"),
+      "double"    -> Seq("foo", "bar"),
+      "repeating" -> Seq("foo", "foo")
+    )
+
+    val longCases = Map[String, Seq[String]](
+      "empty"     -> Seq.empty,
+      "single"    -> Seq("123"),
+      "double"    -> Seq("123", "234"),
+      "repeating" -> Seq("123", "123")
+    )
+
+    compareOMQPDM[Long, Iterable](resource.DoFooOptrefidxseqMatcher, "optrefidxseq").apply(longCases)
+    compareOMQPDM[Long, List](resource.DoFooOptreflistMatcher, "optreflist").apply(longCases)
+    compareOMQPDM[Long, Seq](resource.DoFooOptrefseqMatcher, "optrefseq").apply(longCases)
+    compareOMQPDM[Long, Vector](resource.DoFooOptrefvecMatcher, "optrefvec").apply(longCases)
+    compareOMQPDM[String, Iterable](resource.DoFooOptidxseqMatcher, "optidxseq").apply(stringCases)
+    compareOMQPDM[String, Iterable](resource.DoFooOptlistMatcher, "optlist").apply(stringCases)
+    compareOMQPDM[String, Iterable](resource.DoFooOptseqMatcher, "optseq").apply(stringCases)
+    compareOMQPDM[String, Iterable](resource.DoFooOptvectorMatcher, "optvector").apply(stringCases)
+    compareQPDM[Long, IndexedSeq](resource.DoFooRefidxseqMatcher, "refidxseq").apply(longCases)
+    compareQPDM[Long, List](resource.DoFooReflistMatcher, "reflist").apply(longCases)
+    compareQPDM[Long, Seq](resource.DoFooRefseqMatcher, "refseq").apply(longCases)
+    compareQPDM[Long, Vector](resource.DoFooRefvecMatcher, "refvec").apply(longCases)
+    compareQPDM[String, Iterable](resource.DoFooIdxseqMatcher, "idxseq").apply(stringCases)
+    compareQPDM[String, Iterable](resource.DoFooListMatcher, "list").apply(stringCases)
+    compareQPDM[String, Iterable](resource.DoFooSeqMatcher, "seq").apply(stringCases)
+    compareQPDM[String, Iterable](resource.DoFooVectorMatcher, "vector").apply(stringCases)
+  }
+}

--- a/modules/sample-springMvc/src/test/scala/examples/server/springMvc/pet/BaselineSpecs.scala
+++ b/modules/sample-springMvc/src/test/scala/examples/server/springMvc/pet/BaselineSpecs.scala
@@ -29,7 +29,7 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.{reques
 import org.springframework.web.multipart.MultipartFile
 import spring.test.TestApplication
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 @RunWith(classOf[SpringRunner])
 @SpringBootTest(classes = Array(classOf[TestApplication]))

--- a/modules/sample/src/main/resources/issues/issue1218.yaml
+++ b/modules/sample/src/main/resources/issues/issue1218.yaml
@@ -1,0 +1,148 @@
+openapi: 3.0.2
+servers:
+  - url: "http://localhost:1234"
+paths:
+  /foo:
+    post:
+      operationId: doFoo
+      responses:
+        '204':
+          description: No response
+      parameters:
+        - name: refvec
+          in: query
+          required: true
+          schema:
+            $ref: "#!/components/schemas/refvec"
+        - name: reflist
+          in: query
+          required: true
+          schema:
+            $ref: "#!/components/schemas/reflist"
+        - name: refseq
+          in: query
+          required: true
+          schema:
+            $ref: "#!/components/schemas/refseq"
+        - name: refidxseq
+          in: query
+          required: true
+          schema:
+            $ref: "#!/components/schemas/refidxseq"
+        - name: vector
+          in: query
+          required: true
+          schema:
+            type: array
+            x-scala-array-type: Vector
+            items:
+              type: integer
+              format: int64
+        - name: list
+          in: query
+          required: true
+          schema:
+            type: array
+            x-scala-array-type: List
+            items:
+              type: integer
+              format: int64
+        - name: seq
+          in: query
+          required: true
+          schema:
+            type: array
+            x-scala-array-type: Seq
+            items:
+              type: integer
+              format: int64
+        - name: idxseq
+          in: query
+          required: true
+          schema:
+            type: array
+            x-scala-array-type: IndexedSeq
+            items:
+              type: integer
+              format: int64
+        - name: optrefvec
+          in: query
+          required: false
+          schema:
+            $ref: "#!/components/schemas/refvec"
+        - name: optreflist
+          in: query
+          required: false
+          schema:
+            $ref: "#!/components/schemas/reflist"
+        - name: optrefseq
+          in: query
+          required: false
+          schema:
+            $ref: "#!/components/schemas/refseq"
+        - name: optrefidxseq
+          in: query
+          required: false
+          schema:
+            $ref: "#!/components/schemas/refidxseq"
+        - name: optvector
+          in: query
+          required: false
+          schema:
+            type: array
+            x-scala-array-type: Vector
+            items:
+              type: integer
+              format: int64
+        - name: optlist
+          in: query
+          required: false
+          schema:
+            type: array
+            x-scala-array-type: List
+            items:
+              type: integer
+              format: int64
+        - name: optseq
+          in: query
+          required: false
+          schema:
+            type: array
+            x-scala-array-type: Seq
+            items:
+              type: integer
+              format: int64
+        - name: optidxseq
+          in: query
+          required: false
+          schema:
+            type: array
+            x-scala-array-type: IndexedSeq
+            items:
+              type: integer
+              format: int64
+components:
+  schemas:
+    refvec:
+      type: array
+      items:
+        type: integer
+        format: int64
+    reflist:
+      type: array
+      x-scala-array-type: List
+      items:
+        type: integer
+        format: int64
+    refseq:
+      type: array
+      x-scala-array-type: Seq
+      items:
+        type: integer
+        format: int64
+    refidxseq:
+      type: array
+      x-scala-array-type: IndexedSeq
+      items:
+        type: integer
+        format: int64

--- a/modules/scala-akka-http/src/main/scala/dev/guardrail/generators/scala/akkaHttp/AkkaHttp.scala
+++ b/modules/scala-akka-http/src/main/scala/dev/guardrail/generators/scala/akkaHttp/AkkaHttp.scala
@@ -11,6 +11,6 @@ object AkkaHttp extends Framework[ScalaLanguage, Target] {
   implicit def FrameworkInterp      = AkkaHttpGenerator(AkkaHttpVersion.V10_2, CirceModelGenerator.V012)
   implicit def ProtocolInterp       = CirceProtocolGenerator(CirceModelGenerator.V012)
   implicit def ServerInterp         = AkkaHttpServerGenerator(AkkaHttpVersion.V10_2, CirceModelGenerator.V012)
-  implicit def SwaggerInterp        = SwaggerGenerator[ScalaLanguage]
+  implicit def SwaggerInterp        = SwaggerGenerator[ScalaLanguage]()
   implicit def LanguageInterp       = ScalaGenerator()
 }

--- a/modules/scala-akka-http/src/main/scala/dev/guardrail/generators/scala/akkaHttp/AkkaHttpGenerator.scala
+++ b/modules/scala-akka-http/src/main/scala/dev/guardrail/generators/scala/akkaHttp/AkkaHttpGenerator.scala
@@ -1,8 +1,7 @@
 package dev.guardrail.generators.scala.akkaHttp
 
 import dev.guardrail.Target
-import dev.guardrail.generators.scala.{ CirceModelGenerator, JacksonModelGenerator, ModelGeneratorType }
-import dev.guardrail.generators.scala.{ AkkaHttpVersion, ModelGeneratorType, ScalaLanguage }
+import dev.guardrail.generators.scala.{ AkkaHttpVersion, CirceModelGenerator, JacksonModelGenerator, ModelGeneratorType, ScalaLanguage }
 import dev.guardrail.terms.CollectionsLibTerms
 import dev.guardrail.terms.framework._
 import scala.meta._

--- a/modules/scala-akka-http/src/main/scala/dev/guardrail/generators/scala/akkaHttp/AkkaHttpJackson.scala
+++ b/modules/scala-akka-http/src/main/scala/dev/guardrail/generators/scala/akkaHttp/AkkaHttpJackson.scala
@@ -12,6 +12,6 @@ object AkkaHttpJackson extends Framework[ScalaLanguage, Target] {
   implicit def ClientInterp         = AkkaHttpClientGenerator(JacksonModelGenerator)
   implicit def FrameworkInterp      = AkkaHttpGenerator(AkkaHttpVersion.V10_2, JacksonModelGenerator)
   implicit def ServerInterp         = AkkaHttpServerGenerator(AkkaHttpVersion.V10_2, JacksonModelGenerator)
-  implicit def SwaggerInterp        = SwaggerGenerator[ScalaLanguage]
+  implicit def SwaggerInterp        = SwaggerGenerator[ScalaLanguage]()
   implicit def LanguageInterp       = ScalaGenerator()
 }

--- a/modules/scala-akka-http/src/test/scala/core/issues/Issue43.scala
+++ b/modules/scala-akka-http/src/test/scala/core/issues/Issue43.scala
@@ -7,7 +7,6 @@ import org.scalatest.matchers.should.Matchers
 import support.SwaggerSpecRunner
 
 import dev.guardrail.Context
-import dev.guardrail._
 import dev.guardrail.generators.ProtocolDefinitions
 import dev.guardrail.generators.scala.akkaHttp.AkkaHttp
 import dev.guardrail.generators.scala.syntax.companionForStaticDefns

--- a/modules/scala-dropwizard/src/main/scala/dev/guardrail/generators/scala/dropwizard/DropwizardServerGenerator.scala
+++ b/modules/scala-dropwizard/src/main/scala/dev/guardrail/generators/scala/dropwizard/DropwizardServerGenerator.scala
@@ -28,7 +28,6 @@ import dev.guardrail.terms.{
   TextPlain,
   UrlencodedFormData
 }
-import dev.guardrail.terms.{ CollectionsLibTerms, RouteMeta, SecurityScheme }
 
 object DropwizardServerGenerator {
   def apply()(implicit Cl: CollectionsLibTerms[ScalaLanguage, Target]): ServerTerms[ScalaLanguage, Target] =

--- a/modules/scala-dropwizard/src/main/scala/dev/guardrail/generators/scala/dropwizard/DropwizardServerGenerator.scala
+++ b/modules/scala-dropwizard/src/main/scala/dev/guardrail/generators/scala/dropwizard/DropwizardServerGenerator.scala
@@ -15,6 +15,7 @@ import dev.guardrail.shims.OperationExt
 import dev.guardrail.terms.protocol.StrictProtocolElems
 import dev.guardrail.terms.server.{ GenerateRouteMeta, ServerTerms }
 import dev.guardrail.terms.{
+  AnyContentType,
   ApplicationJson,
   BinaryContent,
   CollectionsLibTerms,
@@ -54,6 +55,8 @@ class DropwizardServerGenerator private (implicit Cl: CollectionsLibTerms[ScalaL
     case OctetStream         => q"MediaType.APPLICATION_OCTET_STREAM"
     case TextContent(name)   => Lit.String(name)
     case BinaryContent(name) => Lit.String(name)
+    case AnyContentType      => ??? // TODO: What do we do if we get here?
+    case _                   => ???
   }
 
   private def unwrapContainer(tpe: Type): (Type, Type => Type) = {

--- a/modules/scala-endpoints/src/main/scala/dev/guardrail/generators/scala/endpoints/Endpoints.scala
+++ b/modules/scala-endpoints/src/main/scala/dev/guardrail/generators/scala/endpoints/Endpoints.scala
@@ -14,6 +14,6 @@ object Endpoints extends Framework[ScalaLanguage, Target] {
   implicit def ClientInterp         = EndpointsClientGenerator()
   implicit def FrameworkInterp      = EndpointsGenerator()
   implicit def ServerInterp         = EndpointsServerGenerator()
-  implicit def SwaggerInterp        = SwaggerGenerator[ScalaLanguage]
+  implicit def SwaggerInterp        = SwaggerGenerator[ScalaLanguage]()
   implicit def LanguageInterp       = ScalaGenerator()
 }

--- a/modules/scala-http4s/src/main/scala/dev/guardrail/generators/scala/http4s/Http4s.scala
+++ b/modules/scala-http4s/src/main/scala/dev/guardrail/generators/scala/http4s/Http4s.scala
@@ -13,6 +13,6 @@ object Http4s extends Framework[ScalaLanguage, Target] {
   implicit def ClientInterp         = Http4sClientGenerator()
   implicit def FrameworkInterp      = Http4sGenerator()
   implicit def ServerInterp         = Http4sServerGenerator()
-  implicit def SwaggerInterp        = SwaggerGenerator[ScalaLanguage]
+  implicit def SwaggerInterp        = SwaggerGenerator[ScalaLanguage]()
   implicit def LanguageInterp       = ScalaGenerator()
 }

--- a/modules/scala-http4s/src/main/scala/dev/guardrail/generators/scala/http4s/Http4sServerGenerator.scala
+++ b/modules/scala-http4s/src/main/scala/dev/guardrail/generators/scala/http4s/Http4sServerGenerator.scala
@@ -830,7 +830,7 @@ class Http4sServerGenerator private (implicit Cl: CollectionsLibTerms[ScalaLangu
               (q"""
                  object ${matcherName} {
                    val delegate = new QueryParamDecoderMatcher[$tpe](${argName.toLit}) {}
-                   def unapply(params: Map[String, Seq[String]]): Option[$container[$tpe]] = delegate.unapplySeq(params).map(x => ${containerTransformations(
+                   def unapply(params: Map[String, Seq[String]]): Some[$container[$tpe]] = delegate.unapplySeq(params).map(x => ${containerTransformations(
                 container.syntax
               )(q"x")})
                  }
@@ -839,7 +839,7 @@ class Http4sServerGenerator private (implicit Cl: CollectionsLibTerms[ScalaLangu
               (q"""
                  object ${matcherName} {
                    val delegate = new QueryParamDecoderMatcher[$tpe](${argName.toLit}) {}
-                   def unapply(params: Map[String, Seq[String]]): Option[$container[$tpe]] = delegate.unapplySeq(params).map(x => ${containerTransformations(
+                   def unapply(params: Map[String, Seq[String]]): Some[$container[$tpe]] = delegate.unapplySeq(params).map(x => ${containerTransformations(
                 container.syntax
               )(q"x")})
                  }
@@ -929,14 +929,14 @@ class Http4sServerGenerator private (implicit Cl: CollectionsLibTerms[ScalaLangu
   def generateTracingExtractor(methodName: String, tracingField: Term): Defn.Object =
     q"""
        object ${Term.Name(s"usingFor${methodName.capitalize}")} {
-         def unapply(r: Request[F]): Option[(Request[F], TraceBuilder[F])] = Some(r -> $tracingField(r))
+         def unapply(r: Request[F]): Some[(Request[F], TraceBuilder[F])] = Some(r -> $tracingField(r))
        }
      """
 
   def generateCustomExtractionFieldsExtractor(methodName: String, extractField: Term): Defn.Object =
     q"""
        object ${Term.Name(s"extractorFor${methodName.capitalize}")} {
-         def unapply(r: Request[F]): Option[(Request[F], $customExtractionTypeName)] = Some(r -> $extractField(r))
+         def unapply(r: Request[F]): Some[(Request[F], $customExtractionTypeName)] = Some(r -> $extractField(r))
        }
      """
 }

--- a/modules/scala-http4s/src/test/scala/tests/core/FullyQualifiedNames.scala
+++ b/modules/scala-http4s/src/test/scala/tests/core/FullyQualifiedNames.scala
@@ -4,7 +4,7 @@ import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 import scala.meta._
 
-import support.SwaggerSpecRunner
+import support.{ ScalaMetaMatchers, SwaggerSpecRunner }
 
 import dev.guardrail.Context
 import dev.guardrail.generators.ProtocolDefinitions
@@ -12,7 +12,7 @@ import dev.guardrail.generators.scala.http4s.Http4s
 import dev.guardrail.generators.{ Client, Clients }
 import dev.guardrail.terms.protocol.ClassDefinition
 
-class FullyQualifiedNames extends AnyFunSuite with Matchers with SwaggerSpecRunner {
+class FullyQualifiedNames extends AnyFunSuite with Matchers with SwaggerSpecRunner with ScalaMetaMatchers {
 
   val swagger =
     """

--- a/modules/scala-http4s/src/test/scala/tests/generators/http4s/Http4sServerTest.scala
+++ b/modules/scala-http4s/src/test/scala/tests/generators/http4s/Http4sServerTest.scala
@@ -235,11 +235,11 @@ class Http4sServerTest extends AnyFunSuite with Matchers with SwaggerSpecRunner 
         implicit val OrderStatusQueryParamDecoder: QueryParamDecoder[OrderStatus] = (value: QueryParameterValue) => Json.fromString(value.value).as[OrderStatus].leftMap(t => ParseFailure("Query decoding failed", t.getMessage)).toValidatedNel
         object GetOrderByIdStatusMatcher extends QueryParamDecoderMatcher[OrderStatus]("status")
         object PutBarBarMatcher extends QueryParamDecoderMatcher[Long]("bar")
-        object usingForGetFoo { def unapply(r: Request[F]): Option[(Request[F], TraceBuilder[F])] = Some(r -> trace("store:getFoo")(r)) }
-        object usingForGetFooBar { def unapply(r: Request[F]): Option[(Request[F], TraceBuilder[F])] = Some(r -> trace("completely-custom-label")(r)) }
-        object usingForGetOrderById { def unapply(r: Request[F]): Option[(Request[F], TraceBuilder[F])] = Some(r -> trace("store:getOrderById")(r)) }
-        object usingForGetRoot { def unapply(r: Request[F]): Option[(Request[F], TraceBuilder[F])] = Some(r -> trace("store:getRoot")(r)) }
-        object usingForPutBar { def unapply(r: Request[F]): Option[(Request[F], TraceBuilder[F])] = Some(r -> trace("store:putBar")(r)) }
+        object usingForGetFoo { def unapply(r: Request[F]): Some[(Request[F], TraceBuilder[F])] = Some(r -> trace("store:getFoo")(r)) }
+        object usingForGetFooBar { def unapply(r: Request[F]): Some[(Request[F], TraceBuilder[F])] = Some(r -> trace("completely-custom-label")(r)) }
+        object usingForGetOrderById { def unapply(r: Request[F]): Some[(Request[F], TraceBuilder[F])] = Some(r -> trace("store:getOrderById")(r)) }
+        object usingForGetRoot { def unapply(r: Request[F]): Some[(Request[F], TraceBuilder[F])] = Some(r -> trace("store:getRoot")(r)) }
+        object usingForPutBar { def unapply(r: Request[F]): Some[(Request[F], TraceBuilder[F])] = Some(r -> trace("store:putBar")(r)) }
         private[this] val getFooBarOkEncoder = jsonEncoderOf[F, Boolean]
         private[this] val getFooBarOkEntityResponseGenerator = new org.http4s.dsl.impl.EntityResponseGenerator[F, F] {
           def status = org.http4s.Status.Ok
@@ -324,11 +324,11 @@ class Http4sServerTest extends AnyFunSuite with Matchers with SwaggerSpecRunner 
           implicit val OrderStatusQueryParamDecoder: QueryParamDecoder[OrderStatus] = (value: QueryParameterValue) => Json.fromString(value.value).as[OrderStatus].leftMap(t => ParseFailure("Query decoding failed", t.getMessage)).toValidatedNel
           object GetOrderByIdStatusMatcher extends QueryParamDecoderMatcher[OrderStatus]("status")
           object PutBarBarMatcher extends QueryParamDecoderMatcher[Long]("bar")
-          object extractorForGetFoo { def unapply(r: Request[F]): Option[(Request[F], E)] = Some(r -> customExtract("getFoo")(r)) }
-          object extractorForGetFooBar { def unapply(r: Request[F]): Option[(Request[F], E)] = Some(r -> customExtract("getFooBar")(r)) }
-          object extractorForGetOrderById { def unapply(r: Request[F]): Option[(Request[F], E)] = Some(r -> customExtract("getOrderById")(r)) }
-          object extractorForGetRoot { def unapply(r: Request[F]): Option[(Request[F], E)] = Some(r -> customExtract("getRoot")(r)) }
-          object extractorForPutBar { def unapply(r: Request[F]): Option[(Request[F], E)] = Some(r -> customExtract("putBar")(r)) }
+          object extractorForGetFoo { def unapply(r: Request[F]): Some[(Request[F], E)] = Some(r -> customExtract("getFoo")(r)) }
+          object extractorForGetFooBar { def unapply(r: Request[F]): Some[(Request[F], E)] = Some(r -> customExtract("getFooBar")(r)) }
+          object extractorForGetOrderById { def unapply(r: Request[F]): Some[(Request[F], E)] = Some(r -> customExtract("getOrderById")(r)) }
+          object extractorForGetRoot { def unapply(r: Request[F]): Some[(Request[F], E)] = Some(r -> customExtract("getRoot")(r)) }
+          object extractorForPutBar { def unapply(r: Request[F]): Some[(Request[F], E)] = Some(r -> customExtract("putBar")(r)) }
           private[this] val getFooBarOkEncoder = jsonEncoderOf[F, Boolean]
           private[this] val getFooBarOkEntityResponseGenerator = new org.http4s.dsl.impl.EntityResponseGenerator[F, F] {
             def status = org.http4s.Status.Ok

--- a/modules/scala-support/src/main/scala/dev/guardrail/generators/scala/ScalaGenerator.scala
+++ b/modules/scala-support/src/main/scala/dev/guardrail/generators/scala/ScalaGenerator.scala
@@ -267,7 +267,7 @@ class ScalaGenerator private extends LanguageTerms[ScalaLanguage, Target] {
             }
             object Base64String {
               def apply(bytes: Array[Byte]): Base64String = new Base64String(bytes)
-              def unapply(value: Base64String): Option[Array[Byte]] = Some(value.data)
+              def unapply(value: Base64String): Some[Array[Byte]] = Some(value.data)
             }
 
           }

--- a/modules/scala-support/src/main/scala/dev/guardrail/generators/scala/jackson/JacksonProtocolGenerator.scala
+++ b/modules/scala-support/src/main/scala/dev/guardrail/generators/scala/jackson/JacksonProtocolGenerator.scala
@@ -342,7 +342,7 @@ object JacksonProtocolGenerator {
                     jsonNode match {
                       case arr: com.fasterxml.jackson.databind.node.ArrayNode =>
                         import cats.implicits._
-                        import _root_.scala.collection.JavaConverters._
+                        import _root_.scala.jdk.CollectionConverters._
                         arr.iterator().asScala.toVector.traverse(implicitly[GuardrailDecoder[B]].decode)
                       case _ =>
                         scala.util.Failure(new com.fasterxml.jackson.databind.JsonMappingException(null, s"Can't decode to vector; node of type $${jsonNode.getClass.getSimpleName} is not an array"))
@@ -355,7 +355,7 @@ object JacksonProtocolGenerator {
                     jsonNode match {
                       case obj: com.fasterxml.jackson.databind.node.ObjectNode =>
                         import cats.implicits._
-                        import _root_.scala.collection.JavaConverters._
+                        import _root_.scala.jdk.CollectionConverters._
                         obj.fields().asScala.toVector.traverse(entry => implicitly[GuardrailDecoder[B]].decode(entry.getValue).map((entry.getKey, _))).map(_.toMap)
                       case _ =>
                         scala.util.Failure(new com.fasterxml.jackson.databind.JsonMappingException(null, s"Can't decode to map; node of type $${jsonNode.getClass.getSimpleName} is not an object"))
@@ -385,7 +385,7 @@ object JacksonProtocolGenerator {
               object GuardrailValidator {
                 def instance[A]: GuardrailValidator[A] = new GuardrailValidator[A] {
                   override def validate(a: A)(implicit validator: javax.validation.Validator): scala.util.Try[A] = {
-                    import _root_.scala.collection.JavaConverters._
+                    import _root_.scala.jdk.CollectionConverters._
                     scala.util.Try(validator.validate(a)).flatMap({
                       case violations if violations.isEmpty =>
                         scala.util.Success(a)

--- a/modules/scala-support/src/main/scala/dev/guardrail/generators/scala/syntax/Scala.scala
+++ b/modules/scala-support/src/main/scala/dev/guardrail/generators/scala/syntax/Scala.scala
@@ -44,6 +44,7 @@ package object syntax {
             None,
             false
           )
+        case _: Term.Param => ??? // Impossible, see https://github.com/scalameta/scalameta/pull/2501
       }
   }
 

--- a/modules/scala-support/src/test/scala/support/ScalaMetaSupport.scala
+++ b/modules/scala-support/src/test/scala/support/ScalaMetaSupport.scala
@@ -1,0 +1,15 @@
+package support
+
+import org.scalactic.Equality
+import scala.meta.Tree
+
+trait ScalaMetaMatchers {
+  implicit def TreeEquality[A <: Tree]: Equality[A] =
+    new Equality[A] {
+      def areEqual(a: A, b: Any): Boolean =
+        b match {
+          case x: Tree => a.structure == x.structure
+          case _       => false
+        }
+    }
+}

--- a/project/WelcomeMessage.scala
+++ b/project/WelcomeMessage.scala
@@ -2,7 +2,7 @@ import sbt._
 import Keys._
 
 object WelcomeMessage {
-  def welcomeMessage = onLoadMessage := {
+  def welcomeMessage(guardrailVersion: String) = {
     import scala.Console
 
     def header(text: String): String = s"${Console.WHITE}${text}${Console.RESET}"
@@ -20,7 +20,7 @@ object WelcomeMessage {
         |${header(" | (_| | |_| | (_| | | | (_| | | | (_| | | |")}
         |${header("  \\__, |\\__,_|\\__,_|_|  \\__,_|_|  \\__,_|_|_|")}
         |${header("   __/ |")}
-        |${header(s"  |___/   ${version.value}")}
+        |${header(s"  |___/   ${guardrailVersion}")}
         |
         |Useful sbt tasks:
         |${item("cli")} - Use the CLI driver to run guardrail directly. `cli --help` to get started

--- a/project/src/main/scala/Build.scala
+++ b/project/src/main/scala/Build.scala
@@ -22,7 +22,7 @@ object Build {
         publish / skip := true,
       )
 
-  val excludedWarts = Set(Wart.DefaultArguments, Wart.Product, Wart.Serializable, Wart.Any)
+  val excludedWarts = Set(Wart.DefaultArguments, Wart.Product, Wart.Serializable, Wart.Any, Wart.StringPlusAny)
 
   val codegenSettings = Seq(
     ScoverageKeys.coverageExcludedPackages := "<empty>;dev.guardrail.terms.*;dev.guardrail.protocol.terms.*",

--- a/project/src/main/scala/Build.scala
+++ b/project/src/main/scala/Build.scala
@@ -16,6 +16,7 @@ object Build {
     Project(s"sample-${name}", file(s"modules/sample-${name}"))
       .settings(commonSettings)
       .settings(codegenSettings)
+      .settings(libraryDependencies += "org.scala-lang.modules" %% "scala-collection-compat" % "2.5.0")
       .settings(
         libraryDependencies ++= extraLibraryDependencies,
         Compile / unmanagedSourceDirectories += baseDirectory.value / "target" / "generated",

--- a/project/src/main/scala/Build.scala
+++ b/project/src/main/scala/Build.scala
@@ -57,6 +57,7 @@ object Build {
     versionScheme := Some("early-semver"), // This should help once the build plugins start depending directly on modules
 
     scalacOptions ++= Seq(
+      "-Xfatal-warnings",
       "-Ydelambdafy:method",
       "-Yrangepos",
       // "-Ywarn-unused-import",  // TODO: Enable this! https://github.com/guardrail-dev/guardrail/pull/282
@@ -66,6 +67,7 @@ object Build {
       "-encoding",
       "utf8"
     ),
+    Test / scalacOptions -= "-Xfatal-warnings",
     scalacOptions ++= ifScalaVersion(_ <= 11)(List("-Xexperimental")).value,
     scalacOptions ++= ifScalaVersion(_ == 12)(List("-Ypartial-unification")).value,
     Test / parallelExecution := true,

--- a/project/src/main/scala/RegressionTests.scala
+++ b/project/src/main/scala/RegressionTests.scala
@@ -80,6 +80,7 @@ object RegressionTests {
     ExampleCase(sampleResource("issues/issue622.yaml"), "issues.issue622"),
     ExampleCase(sampleResource("issues/issue1138.yaml"), "issues.issue1138"),
     ExampleCase(sampleResource("issues/issue1260.yaml"), "issues.issue1260"),
+    ExampleCase(sampleResource("issues/issue1218.yaml"), "issues.issue1218").frameworks("scala" -> Set("http4s")),
     ExampleCase(sampleResource("multipart-form-data.yaml"), "multipartFormData"),
     ExampleCase(sampleResource("petstore.json"), "examples").args("--import", "examples.support.PositiveLong"),
     // ExampleCase(sampleResource("petstore-openapi-3.0.2.yaml"), "examples.petstore.openapi302").args("--import", "examples.support.PositiveLong"),

--- a/project/src/main/scala/modules/core.scala
+++ b/project/src/main/scala/modules/core.scala
@@ -12,10 +12,8 @@ object core {
     commonModule("core")
       .settings(
         libraryDependencies ++= Seq(
-          "com.github.javaparser"       % "javaparser-symbol-solver-core" % "3.22.1",
           "io.swagger.parser.v3"        % "swagger-parser"                % "2.0.28",
         ) ++ Seq(
-          "org.scalameta"               %% "scalameta"                    % "4.4.29",
           "org.scala-lang.modules"      %% "scala-collection-compat"      % "2.5.0",
           "org.tpolecat"                %% "atto-core"                    % "0.9.5",
           "org.typelevel"               %% "cats-core"                    % catsVersion,

--- a/project/src/main/scala/modules/core.scala
+++ b/project/src/main/scala/modules/core.scala
@@ -16,6 +16,7 @@ object core {
           "io.swagger.parser.v3"        % "swagger-parser"                % "2.0.28",
         ) ++ Seq(
           "org.scalameta"               %% "scalameta"                    % "4.4.29",
+          "org.scala-lang.modules"      %% "scala-collection-compat"      % "2.5.0",
           "org.tpolecat"                %% "atto-core"                    % "0.9.5",
           "org.typelevel"               %% "cats-core"                    % catsVersion,
           "org.typelevel"               %% "cats-kernel"                  % catsVersion,

--- a/project/src/main/scala/modules/javaDropwizard.scala
+++ b/project/src/main/scala/modules/javaDropwizard.scala
@@ -42,6 +42,6 @@ object javaDropwizard {
 
   val project = commonModule("java-dropwizard")
 
-  val sample = buildSampleProject("dropwizard", dependencies)
-  val sampleVavr = buildSampleProject("dropwizardVavr", dependenciesVavr)
+  val sample = buildSampleProject("dropwizard", dependencies).settings(scalacOptions -= "-Xfatal-warnings")
+  val sampleVavr = buildSampleProject("dropwizardVavr", dependenciesVavr).settings(scalacOptions -= "-Xfatal-warnings")
 }

--- a/project/src/main/scala/modules/javaSpringMvc.scala
+++ b/project/src/main/scala/modules/javaSpringMvc.scala
@@ -24,5 +24,5 @@ object javaSpringMvc {
 
   val project = commonModule("java-spring-mvc")
 
-  val sample = buildSampleProject("springMvc", dependencies)
+  val sample = buildSampleProject("springMvc", dependencies).settings(scalacOptions -= "-Xfatal-warnings")
 }

--- a/project/src/main/scala/modules/javaSupport.scala
+++ b/project/src/main/scala/modules/javaSupport.scala
@@ -34,6 +34,7 @@ object javaSupport {
   val project =
     commonModule("java-support")
       .settings(
-        libraryDependencies ++= eclipseFormatterDependencies
+        libraryDependencies ++= eclipseFormatterDependencies,
+        libraryDependencies += "com.github.javaparser" % "javaparser-symbol-solver-core" % "3.22.1"
       )
 }

--- a/project/src/main/scala/modules/scalaAkkaHttp.scala
+++ b/project/src/main/scala/modules/scalaAkkaHttp.scala
@@ -4,6 +4,7 @@ import dev.guardrail.sbt.Build._
 
 import sbt._
 import sbt.Keys._
+import wartremover.WartRemover.autoImport._
 
 object scalaAkkaHttp {
   val akkaHttpVersion        = "10.2.6"
@@ -53,6 +54,10 @@ object scalaAkkaHttp {
 
   val project = commonModule("scala-akka-http")
 
-  val sample = buildSampleProject("akkaHttp", dependencies)
-  val sampleJackson = buildSampleProject("akkaHttpJackson", dependenciesJackson)
+  val sample =
+    buildSampleProject("akkaHttp", dependencies)
+      .settings(Compile / compile / wartremoverWarnings --= Seq(Wart.NonUnitStatements, Wart.Throw))
+  val sampleJackson =
+    buildSampleProject("akkaHttpJackson", dependenciesJackson)
+      .settings(Compile / compile / wartremoverWarnings --= Seq(Wart.AsInstanceOf, Wart.NonUnitStatements, Wart.Null, Wart.OptionPartial, Wart.Throw))
 }

--- a/project/src/main/scala/modules/scalaDropwizard.scala
+++ b/project/src/main/scala/modules/scalaDropwizard.scala
@@ -37,5 +37,5 @@ object scalaDropwizard {
 
   val project = commonModule("scala-dropwizard")
 
-  val sample = buildSampleProject("dropwizardScala", dependencies)
+  val sample = buildSampleProject("dropwizardScala", dependencies).settings(scalacOptions -= "-Xfatal-warnings")
 }

--- a/project/src/main/scala/modules/scalaSupport.scala
+++ b/project/src/main/scala/modules/scalaSupport.scala
@@ -6,5 +6,9 @@ import sbt._
 import sbt.Keys._
 
 object scalaSupport {
-  val project = commonModule("scala-support")
+  val project =
+    commonModule("scala-support")
+      .settings(
+        libraryDependencies += "org.scalameta" %% "scalameta" % "4.4.29"
+      )
 }


### PR DESCRIPTION
- Addressing edge case warnings
- Addressing akka-streams deprecation warning that was missed in #1305. Currently akka-streams 2.5.x is bundled with akka-http 10.1 source generator, though this can be broken out if necessary
- Adding `-Xfatal-warnings` to most projects
- Switching to `scala.jdk.CollectionConverters` for internal and generated code
- Tightened up dependencies on which modules depend on scalameta/javaparser

Migration notes:
- For those using akka-streams 2.5 and below, as well as akka-http server generation, as well as who expose endpoints that handle file uploads, it's important to either upgrade to akka-streams 2.6+ or switch to the `akka-http-v10.1` module. Otherwise there may be edge cases where temporary files are not cleaned up on disk. This is only temporary until #1308 is addressed.
- For 2.12.x codebases, you may be required to depend on `"org.scala-lang.modules" %% "scala-collection-compat" % "2.5.0"` in order to get the newly generated code to compile. This is probably not an issue, as the JavaConverters/JavaConversions stuff has been deprecated a while anyway, so likely guardrail has been the only thing continuing to use the old imports.