### PR TITLE
Explicit dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -13,6 +13,22 @@ onLoadMessage := WelcomeMessage.welcomeMessage((guardrail / version).value)
 
 import scoverage.ScoverageKeys
 
+/**
+ * Modules
+ */
+
+val guardrailGuardrail = "dev.guardrail" %% "guardrail" % "0.67.0"
+val guardrailCore = "dev.guardrail" %% "guardrail-core" % "0.67.0"
+val guardrailJavaDropwizard = "dev.guardrail" %% "guardrail-java-dropwizard" % "0.66.0"
+val guardrailJavaSpringMvc = "dev.guardrail" %% "guardrail-java-spring-mvc" % "0.66.0"
+val guardrailJavaSupport = "dev.guardrail" %% "guardrail-java-support" % "0.66.0"
+val guardrailJavaAsyncHttp = "dev.guardrail" %% "guardrail-java-async-http" % "0.66.0"
+val guardrailScalaAkkaHttp = "dev.guardrail" %% "guardrail-scala-akka-http" % "0.68.0"
+val guardrailScalaDropwizard = "dev.guardrail" %% "guardrail-scala-dropwizard" % "0.66.0"
+val guardrailScalaEndpoints = "dev.guardrail" %% "guardrail-scala-endpoints" % "0.66.0"
+val guardrailScalaHttp4s = "dev.guardrail" %% "guardrail-scala-http4s" % "0.66.0"
+val guardrailScalaSupport = "dev.guardrail" %% "guardrail-scala-support" % "0.67.0"
+
 lazy val runJavaExample: TaskKey[Unit] = taskKey[Unit]("Run java generator with example args")
 fullRunTask(
   runJavaExample,
@@ -90,9 +106,9 @@ val javaSampleSettings = Seq(
 
 lazy val root = modules.root.project
   .settings(publish / skip := true)
-  .customDependsOn(guardrail)
-  .customDependsOn(microsite)
-  .customDependsOn(cli)
+  .internalModuleDep(guardrail)
+  .internalModuleDep(microsite)
+  .internalModuleDep(cli)
   .aggregate(allDeps, microsite)
   .aggregate(
     cli,
@@ -116,16 +132,16 @@ lazy val allDeps = modules.allDeps.project
   .settings(crossScalaVersions := crossScalaVersions.value.filter(_.startsWith("2.12")))
 
 lazy val guardrail = modules.guardrail.project
-  .customDependsOn(core)
-  .customDependsOn(javaDropwizard)
-  .customDependsOn(javaSpringMvc)
-  .customDependsOn(javaSupport)
-  .customDependsOn(javaAsyncHttp)
-  .customDependsOn(scalaAkkaHttp)
-  .customDependsOn(scalaDropwizard)
-  .customDependsOn(scalaEndpoints)
-  .customDependsOn(scalaHttp4s)
-  .customDependsOn(scalaSupport)
+  .providedModuleDep(core, Some(guardrailCore))
+  .providedModuleDep(javaDropwizard, Some(guardrailJavaDropwizard))
+  .providedModuleDep(javaSpringMvc, Some(guardrailJavaSpringMvc))
+  .providedModuleDep(javaSupport, Some(guardrailJavaSupport))
+  .providedModuleDep(javaAsyncHttp, Some(guardrailJavaAsyncHttp))
+  .providedModuleDep(scalaAkkaHttp, Some(guardrailScalaAkkaHttp))
+  .providedModuleDep(scalaDropwizard, Some(guardrailScalaDropwizard))
+  .providedModuleDep(scalaEndpoints, Some(guardrailScalaEndpoints))
+  .providedModuleDep(scalaHttp4s, Some(guardrailScalaHttp4s))
+  .providedModuleDep(scalaSupport, Some(guardrailScalaSupport))
 
 lazy val samples = (project in file("modules/samples"))
   .settings(publish / skip := true)
@@ -143,46 +159,46 @@ lazy val samples = (project in file("modules/samples"))
 lazy val core = modules.core.project
 
 lazy val cli = modules.cli.project
-  .customDependsOn(guardrail)
+  .providedModuleDep(guardrail, Some(guardrailGuardrail))
 
 lazy val javaSupport = modules.javaSupport.project
-  .customDependsOn(core)
+  .directModuleDep(core, Some(guardrailCore))
 
 lazy val javaAsyncHttp = modules.javaAsyncHttp.project
-  .customDependsOn(javaSupport)
+  .providedModuleDep(javaSupport, Some(guardrailJavaSupport))
 
 lazy val dropwizardSample = modules.javaDropwizard.sample
   .settings(javaSampleSettings)
 lazy val dropwizardVavrSample = modules.javaDropwizard.sampleVavr
   .settings(javaSampleSettings)
 lazy val javaDropwizard = modules.javaDropwizard.project
-  .customDependsOn(javaSupport)
-  .customDependsOn(javaAsyncHttp)
+  .providedModuleDep(javaSupport, Some(guardrailJavaSupport))
+  .providedModuleDep(javaAsyncHttp, Some(guardrailJavaAsyncHttp))
 
 lazy val javaSpringMvcSample = modules.javaSpringMvc.sample
   .settings(javaSampleSettings)
 lazy val javaSpringMvc = modules.javaSpringMvc.project
-  .customDependsOn(javaSupport)
+  .providedModuleDep(javaSupport, Some(guardrailJavaSupport))
 
 lazy val scalaSupport = modules.scalaSupport.project
-  .customDependsOn(core)
+  .directModuleDep(core, Some(guardrailCore))
 
 lazy val scalaAkkaHttpSample = modules.scalaAkkaHttp.sample
 lazy val scalaAkkaHttpJacksonSample = modules.scalaAkkaHttp.sampleJackson
 lazy val scalaAkkaHttp = modules.scalaAkkaHttp.project
-  .customDependsOn(scalaSupport)
+  .providedModuleDep(scalaSupport, Some(guardrailScalaSupport))
 
 lazy val scalaEndpointsSample = modules.scalaEndpoints.sample
 lazy val scalaEndpoints = modules.scalaEndpoints.project
-  .customDependsOn(scalaSupport)
+  .providedModuleDep(scalaSupport, Some(guardrailScalaSupport))
 
 lazy val scalaHttp4sSample = modules.scalaHttp4s.sample
 lazy val scalaHttp4s = modules.scalaHttp4s.project
-  .customDependsOn(scalaSupport)
+  .providedModuleDep(scalaSupport, Some(guardrailScalaSupport))
 
 lazy val scalaDropwizardSample = modules.scalaDropwizard.sample
 lazy val scalaDropwizard = modules.scalaDropwizard.project
-  .customDependsOn(scalaSupport)
+  .providedModuleDep(scalaSupport, Some(guardrailScalaSupport))
 
 lazy val microsite = baseModule("microsite", "microsite", file("modules/microsite"))
   .settings(
@@ -190,7 +206,7 @@ lazy val microsite = baseModule("microsite", "microsite", file("modules/microsit
     mdocExtraArguments += "--no-link-hygiene",
     scalacOptions -= "-Xfatal-warnings"
   )
-  .customDependsOn(guardrail)
+  .internalModuleDep(guardrail)
 
 watchSources ++= (baseDirectory.value / "modules/sample/src/test" ** "*.scala").get
 watchSources ++= (baseDirectory.value / "modules/sample/src/test" ** "*.java").get

--- a/build.sbt
+++ b/build.sbt
@@ -132,7 +132,6 @@ lazy val allDeps = modules.allDeps.project
   .settings(crossScalaVersions := crossScalaVersions.value.filter(_.startsWith("2.12")))
 
 lazy val guardrail = modules.guardrail.project
-  .providedModuleDep(core, Some(guardrailCore))
   .providedModuleDep(javaDropwizard, Some(guardrailJavaDropwizard))
   .providedModuleDep(javaSpringMvc, Some(guardrailJavaSpringMvc))
   .providedModuleDep(javaSupport, Some(guardrailJavaSupport))
@@ -165,20 +164,20 @@ lazy val javaSupport = modules.javaSupport.project
   .directModuleDep(core, Some(guardrailCore))
 
 lazy val javaAsyncHttp = modules.javaAsyncHttp.project
-  .providedModuleDep(javaSupport, Some(guardrailJavaSupport))
+  .directModuleDep(javaSupport, Some(guardrailJavaSupport))
 
 lazy val dropwizardSample = modules.javaDropwizard.sample
   .settings(javaSampleSettings)
 lazy val dropwizardVavrSample = modules.javaDropwizard.sampleVavr
   .settings(javaSampleSettings)
 lazy val javaDropwizard = modules.javaDropwizard.project
-  .providedModuleDep(javaSupport, Some(guardrailJavaSupport))
-  .providedModuleDep(javaAsyncHttp, Some(guardrailJavaAsyncHttp))
+  .directModuleDep(javaSupport, Some(guardrailJavaSupport))
+  .directModuleDep(javaAsyncHttp, Some(guardrailJavaAsyncHttp))
 
 lazy val javaSpringMvcSample = modules.javaSpringMvc.sample
   .settings(javaSampleSettings)
 lazy val javaSpringMvc = modules.javaSpringMvc.project
-  .providedModuleDep(javaSupport, Some(guardrailJavaSupport))
+  .directModuleDep(javaSupport, Some(guardrailJavaSupport))
 
 lazy val scalaSupport = modules.scalaSupport.project
   .directModuleDep(core, Some(guardrailCore))
@@ -186,19 +185,19 @@ lazy val scalaSupport = modules.scalaSupport.project
 lazy val scalaAkkaHttpSample = modules.scalaAkkaHttp.sample
 lazy val scalaAkkaHttpJacksonSample = modules.scalaAkkaHttp.sampleJackson
 lazy val scalaAkkaHttp = modules.scalaAkkaHttp.project
-  .providedModuleDep(scalaSupport, Some(guardrailScalaSupport))
+  .directModuleDep(scalaSupport, Some(guardrailScalaSupport))
 
 lazy val scalaEndpointsSample = modules.scalaEndpoints.sample
 lazy val scalaEndpoints = modules.scalaEndpoints.project
-  .providedModuleDep(scalaSupport, Some(guardrailScalaSupport))
+  .directModuleDep(scalaSupport, Some(guardrailScalaSupport))
 
 lazy val scalaHttp4sSample = modules.scalaHttp4s.sample
 lazy val scalaHttp4s = modules.scalaHttp4s.project
-  .providedModuleDep(scalaSupport, Some(guardrailScalaSupport))
+  .directModuleDep(scalaSupport, Some(guardrailScalaSupport))
 
 lazy val scalaDropwizardSample = modules.scalaDropwizard.sample
 lazy val scalaDropwizard = modules.scalaDropwizard.project
-  .providedModuleDep(scalaSupport, Some(guardrailScalaSupport))
+  .directModuleDep(scalaSupport, Some(guardrailScalaSupport))
 
 lazy val microsite = baseModule("microsite", "microsite", file("modules/microsite"))
   .settings(

--- a/build.sbt
+++ b/build.sbt
@@ -13,22 +13,6 @@ onLoadMessage := WelcomeMessage.welcomeMessage((guardrail / version).value)
 
 import scoverage.ScoverageKeys
 
-/**
- * Modules
- */
-
-val guardrailGuardrail = "dev.guardrail" %% "guardrail" % "0.67.0"
-val guardrailCore = "dev.guardrail" %% "guardrail-core" % "0.67.0"
-val guardrailJavaDropwizard = "dev.guardrail" %% "guardrail-java-dropwizard" % "0.66.0"
-val guardrailJavaSpringMvc = "dev.guardrail" %% "guardrail-java-spring-mvc" % "0.66.0"
-val guardrailJavaSupport = "dev.guardrail" %% "guardrail-java-support" % "0.66.0"
-val guardrailJavaAsyncHttp = "dev.guardrail" %% "guardrail-java-async-http" % "0.66.0"
-val guardrailScalaAkkaHttp = "dev.guardrail" %% "guardrail-scala-akka-http" % "0.68.0"
-val guardrailScalaDropwizard = "dev.guardrail" %% "guardrail-scala-dropwizard" % "0.66.0"
-val guardrailScalaEndpoints = "dev.guardrail" %% "guardrail-scala-endpoints" % "0.66.0"
-val guardrailScalaHttp4s = "dev.guardrail" %% "guardrail-scala-http4s" % "0.66.0"
-val guardrailScalaSupport = "dev.guardrail" %% "guardrail-scala-support" % "0.67.0"
-
 lazy val runJavaExample: TaskKey[Unit] = taskKey[Unit]("Run java generator with example args")
 fullRunTask(
   runJavaExample,
@@ -132,15 +116,15 @@ lazy val allDeps = modules.allDeps.project
   .settings(crossScalaVersions := crossScalaVersions.value.filter(_.startsWith("2.12")))
 
 lazy val guardrail = modules.guardrail.project
-  .providedModuleDep(javaDropwizard, guardrailJavaDropwizard)
-  .providedModuleDep(javaSpringMvc, guardrailJavaSpringMvc)
-  .providedModuleDep(javaSupport, guardrailJavaSupport)
-  .providedModuleDep(javaAsyncHttp, guardrailJavaAsyncHttp)
-  .providedModuleDep(scalaAkkaHttp, guardrailScalaAkkaHttp)
-  .providedModuleDep(scalaDropwizard, guardrailScalaDropwizard)
-  .providedModuleDep(scalaEndpoints, guardrailScalaEndpoints)
-  .providedModuleDep(scalaHttp4s, guardrailScalaHttp4s)
-  .providedModuleDep(scalaSupport, guardrailScalaSupport)
+  .providedModuleDep(javaDropwizard, guardrailJavaDropwizardVersion)
+  .providedModuleDep(javaSpringMvc, guardrailJavaSpringMvcVersion)
+  .providedModuleDep(javaSupport, guardrailJavaSupportVersion)
+  .providedModuleDep(javaAsyncHttp, guardrailJavaAsyncHttpVersion)
+  .providedModuleDep(scalaAkkaHttp, guardrailScalaAkkaHttpVersion)
+  .providedModuleDep(scalaDropwizard, guardrailScalaDropwizardVersion)
+  .providedModuleDep(scalaEndpoints, guardrailScalaEndpointsVersion)
+  .providedModuleDep(scalaHttp4s, guardrailScalaHttp4sVersion)
+  .providedModuleDep(scalaSupport, guardrailScalaSupportVersion)
 
 lazy val samples = (project in file("modules/samples"))
   .settings(publish / skip := true)
@@ -158,46 +142,46 @@ lazy val samples = (project in file("modules/samples"))
 lazy val core = modules.core.project
 
 lazy val cli = modules.cli.project
-  .providedModuleDep(guardrail, guardrailGuardrail)
+  .providedModuleDep(guardrail, guardrailVersion)
 
 lazy val javaSupport = modules.javaSupport.project
-  .directModuleDep(core, guardrailCore)
+  .directModuleDep(core, guardrailCoreVersion)
 
 lazy val javaAsyncHttp = modules.javaAsyncHttp.project
-  .directModuleDep(javaSupport, guardrailJavaSupport)
+  .directModuleDep(javaSupport, guardrailJavaSupportVersion)
 
 lazy val dropwizardSample = modules.javaDropwizard.sample
   .settings(javaSampleSettings)
 lazy val dropwizardVavrSample = modules.javaDropwizard.sampleVavr
   .settings(javaSampleSettings)
 lazy val javaDropwizard = modules.javaDropwizard.project
-  .directModuleDep(javaSupport, guardrailJavaSupport)
-  .directModuleDep(javaAsyncHttp, guardrailJavaAsyncHttp)
+  .directModuleDep(javaSupport, guardrailJavaSupportVersion)
+  .directModuleDep(javaAsyncHttp, guardrailJavaAsyncHttpVersion)
 
 lazy val javaSpringMvcSample = modules.javaSpringMvc.sample
   .settings(javaSampleSettings)
 lazy val javaSpringMvc = modules.javaSpringMvc.project
-  .directModuleDep(javaSupport, guardrailJavaSupport)
+  .directModuleDep(javaSupport, guardrailJavaSupportVersion)
 
 lazy val scalaSupport = modules.scalaSupport.project
-  .directModuleDep(core, guardrailCore)
+  .directModuleDep(core, guardrailCoreVersion)
 
 lazy val scalaAkkaHttpSample = modules.scalaAkkaHttp.sample
 lazy val scalaAkkaHttpJacksonSample = modules.scalaAkkaHttp.sampleJackson
 lazy val scalaAkkaHttp = modules.scalaAkkaHttp.project
-  .directModuleDep(scalaSupport, guardrailScalaSupport)
+  .directModuleDep(scalaSupport, guardrailScalaSupportVersion)
 
 lazy val scalaEndpointsSample = modules.scalaEndpoints.sample
 lazy val scalaEndpoints = modules.scalaEndpoints.project
-  .directModuleDep(scalaSupport, guardrailScalaSupport)
+  .directModuleDep(scalaSupport, guardrailScalaSupportVersion)
 
 lazy val scalaHttp4sSample = modules.scalaHttp4s.sample
 lazy val scalaHttp4s = modules.scalaHttp4s.project
-  .directModuleDep(scalaSupport, guardrailScalaSupport)
+  .directModuleDep(scalaSupport, guardrailScalaSupportVersion)
 
 lazy val scalaDropwizardSample = modules.scalaDropwizard.sample
 lazy val scalaDropwizard = modules.scalaDropwizard.project
-  .directModuleDep(scalaSupport, guardrailScalaSupport)
+  .directModuleDep(scalaSupport, guardrailScalaSupportVersion)
 
 lazy val microsite = baseModule("microsite", "microsite", file("modules/microsite"))
   .settings(

--- a/build.sbt
+++ b/build.sbt
@@ -132,15 +132,15 @@ lazy val allDeps = modules.allDeps.project
   .settings(crossScalaVersions := crossScalaVersions.value.filter(_.startsWith("2.12")))
 
 lazy val guardrail = modules.guardrail.project
-  .providedModuleDep(javaDropwizard, Some(guardrailJavaDropwizard))
-  .providedModuleDep(javaSpringMvc, Some(guardrailJavaSpringMvc))
-  .providedModuleDep(javaSupport, Some(guardrailJavaSupport))
-  .providedModuleDep(javaAsyncHttp, Some(guardrailJavaAsyncHttp))
-  .providedModuleDep(scalaAkkaHttp, Some(guardrailScalaAkkaHttp))
-  .providedModuleDep(scalaDropwizard, Some(guardrailScalaDropwizard))
-  .providedModuleDep(scalaEndpoints, Some(guardrailScalaEndpoints))
-  .providedModuleDep(scalaHttp4s, Some(guardrailScalaHttp4s))
-  .providedModuleDep(scalaSupport, Some(guardrailScalaSupport))
+  .providedModuleDep(javaDropwizard, guardrailJavaDropwizard)
+  .providedModuleDep(javaSpringMvc, guardrailJavaSpringMvc)
+  .providedModuleDep(javaSupport, guardrailJavaSupport)
+  .providedModuleDep(javaAsyncHttp, guardrailJavaAsyncHttp)
+  .providedModuleDep(scalaAkkaHttp, guardrailScalaAkkaHttp)
+  .providedModuleDep(scalaDropwizard, guardrailScalaDropwizard)
+  .providedModuleDep(scalaEndpoints, guardrailScalaEndpoints)
+  .providedModuleDep(scalaHttp4s, guardrailScalaHttp4s)
+  .providedModuleDep(scalaSupport, guardrailScalaSupport)
 
 lazy val samples = (project in file("modules/samples"))
   .settings(publish / skip := true)
@@ -158,46 +158,46 @@ lazy val samples = (project in file("modules/samples"))
 lazy val core = modules.core.project
 
 lazy val cli = modules.cli.project
-  .providedModuleDep(guardrail, Some(guardrailGuardrail))
+  .providedModuleDep(guardrail, guardrailGuardrail)
 
 lazy val javaSupport = modules.javaSupport.project
-  .directModuleDep(core, Some(guardrailCore))
+  .directModuleDep(core, guardrailCore)
 
 lazy val javaAsyncHttp = modules.javaAsyncHttp.project
-  .directModuleDep(javaSupport, Some(guardrailJavaSupport))
+  .directModuleDep(javaSupport, guardrailJavaSupport)
 
 lazy val dropwizardSample = modules.javaDropwizard.sample
   .settings(javaSampleSettings)
 lazy val dropwizardVavrSample = modules.javaDropwizard.sampleVavr
   .settings(javaSampleSettings)
 lazy val javaDropwizard = modules.javaDropwizard.project
-  .directModuleDep(javaSupport, Some(guardrailJavaSupport))
-  .directModuleDep(javaAsyncHttp, Some(guardrailJavaAsyncHttp))
+  .directModuleDep(javaSupport, guardrailJavaSupport)
+  .directModuleDep(javaAsyncHttp, guardrailJavaAsyncHttp)
 
 lazy val javaSpringMvcSample = modules.javaSpringMvc.sample
   .settings(javaSampleSettings)
 lazy val javaSpringMvc = modules.javaSpringMvc.project
-  .directModuleDep(javaSupport, Some(guardrailJavaSupport))
+  .directModuleDep(javaSupport, guardrailJavaSupport)
 
 lazy val scalaSupport = modules.scalaSupport.project
-  .directModuleDep(core, Some(guardrailCore))
+  .directModuleDep(core, guardrailCore)
 
 lazy val scalaAkkaHttpSample = modules.scalaAkkaHttp.sample
 lazy val scalaAkkaHttpJacksonSample = modules.scalaAkkaHttp.sampleJackson
 lazy val scalaAkkaHttp = modules.scalaAkkaHttp.project
-  .directModuleDep(scalaSupport, Some(guardrailScalaSupport))
+  .directModuleDep(scalaSupport, guardrailScalaSupport)
 
 lazy val scalaEndpointsSample = modules.scalaEndpoints.sample
 lazy val scalaEndpoints = modules.scalaEndpoints.project
-  .directModuleDep(scalaSupport, Some(guardrailScalaSupport))
+  .directModuleDep(scalaSupport, guardrailScalaSupport)
 
 lazy val scalaHttp4sSample = modules.scalaHttp4s.sample
 lazy val scalaHttp4s = modules.scalaHttp4s.project
-  .directModuleDep(scalaSupport, Some(guardrailScalaSupport))
+  .directModuleDep(scalaSupport, guardrailScalaSupport)
 
 lazy val scalaDropwizardSample = modules.scalaDropwizard.sample
 lazy val scalaDropwizard = modules.scalaDropwizard.project
-  .directModuleDep(scalaSupport, Some(guardrailScalaSupport))
+  .directModuleDep(scalaSupport, guardrailScalaSupport)
 
 lazy val microsite = baseModule("microsite", "microsite", file("modules/microsite"))
   .settings(

--- a/project/src/main/scala/Build.scala
+++ b/project/src/main/scala/Build.scala
@@ -12,6 +12,18 @@ import xerial.sbt.Sonatype.autoImport._
 import sbtversionpolicy.SbtVersionPolicyPlugin.autoImport._
 
 object Build {
+  val guardrailVersion = SettingKey[ModuleID]("guardrail-version")
+  val guardrailCoreVersion = SettingKey[ModuleID]("guardrail-core-version")
+  val guardrailJavaDropwizardVersion = SettingKey[ModuleID]("guardrail-java-dropwizard-version")
+  val guardrailJavaSpringMvcVersion = SettingKey[ModuleID]("guardrail-java-spring-mvc-version")
+  val guardrailJavaSupportVersion = SettingKey[ModuleID]("guardrail-java-support-version")
+  val guardrailJavaAsyncHttpVersion = SettingKey[ModuleID]("guardrail-java-async-http-version")
+  val guardrailScalaAkkaHttpVersion = SettingKey[ModuleID]("guardrail-scala-akka-http-version")
+  val guardrailScalaDropwizardVersion = SettingKey[ModuleID]("guardrail-scala-dropwizard-version")
+  val guardrailScalaEndpointsVersion = SettingKey[ModuleID]("guardrail-scala-endpoints-version")
+  val guardrailScalaHttp4sVersion = SettingKey[ModuleID]("guardrail-scala-http4s-version")
+  val guardrailScalaSupportVersion = SettingKey[ModuleID]("guardrail-scala-support-version")
+
   def buildSampleProject(name: String, extraLibraryDependencies: Seq[sbt.librarymanagement.ModuleID]) =
     Project(s"sample-${name}", file(s"modules/sample-${name}"))
       .settings(commonSettings)
@@ -184,7 +196,7 @@ object Build {
 
     private[this] def isRelease = sys.env.contains("GUARDRAIL_RELEASE_MODULE")
 
-    def directModuleDep(other: Project, realDependencySpec: ModuleID): Project = {
+    def directModuleDep(other: Project, realDependencySpec: SettingKey[ModuleID]): Project = {
       val base =
         project
           .settings(libraryDependencySchemes += "dev.guardrail" % other.id % "early-semver")
@@ -195,10 +207,10 @@ object Build {
           base
             .dependsOn(other)
             .accumulateClasspath(other)
-        )(dep => base.settings(libraryDependencies += dep))
+        )(dep => base.settings(libraryDependencies += dep.value))
     }
 
-    def providedModuleDep(other: Project, realDependencySpec: ModuleID): Project = {
+    def providedModuleDep(other: Project, realDependencySpec: SettingKey[ModuleID]): Project = {
       val base =
         project
           .settings(libraryDependencySchemes += "dev.guardrail" % other.id % "early-semver")
@@ -209,7 +221,7 @@ object Build {
           base
             .dependsOn(other % Provided)
             .accumulateClasspath(other)
-        )(dep => base.settings(libraryDependencies += dep % Provided))
+        )(dep => base.settings(libraryDependencies += dep.value % Provided))
     }
   }
 }

--- a/project/src/main/scala/Build.scala
+++ b/project/src/main/scala/Build.scala
@@ -176,10 +176,34 @@ object Build {
           (current ++ fromOther).distinct
         })
 
-    def customDependsOn(other: Project): Project =
+    def internalModuleDep(other: Project): Project =
       project
         .settings(libraryDependencySchemes += "dev.guardrail" % other.id % "early-semver")
         .dependsOn(other % Provided)
         .accumulateClasspath(other)
+
+    def directModuleDep(other: Project, realDependencySpec: Some[ModuleID]): Project = {
+      val base =
+        project
+          .settings(libraryDependencySchemes += "dev.guardrail" % other.id % "early-semver")
+
+      realDependencySpec.fold(
+        base
+          .dependsOn(other)
+          .accumulateClasspath(other)
+      )(dep => base.settings(libraryDependencies += dep))
+    }
+
+    def providedModuleDep(other: Project, realDependencySpec: Some[ModuleID]): Project = {
+      val base =
+        project
+          .settings(libraryDependencySchemes += "dev.guardrail" % other.id % "early-semver")
+
+      realDependencySpec.fold(
+        base
+          .dependsOn(other % Provided)
+          .accumulateClasspath(other)
+      )(dep => base.settings(libraryDependencies += dep % Provided))
+    }
   }
 }

--- a/project/src/main/scala/Build.scala
+++ b/project/src/main/scala/Build.scala
@@ -182,24 +182,24 @@ object Build {
         .dependsOn(other % Provided)
         .accumulateClasspath(other)
 
-    def directModuleDep(other: Project, realDependencySpec: Some[ModuleID]): Project = {
+    def directModuleDep(other: Project, realDependencySpec: ModuleID): Project = {
       val base =
         project
           .settings(libraryDependencySchemes += "dev.guardrail" % other.id % "early-semver")
 
-      realDependencySpec.fold(
+      Some(realDependencySpec).fold(
         base
           .dependsOn(other)
           .accumulateClasspath(other)
       )(dep => base.settings(libraryDependencies += dep))
     }
 
-    def providedModuleDep(other: Project, realDependencySpec: Some[ModuleID]): Project = {
+    def providedModuleDep(other: Project, realDependencySpec: ModuleID): Project = {
       val base =
         project
           .settings(libraryDependencySchemes += "dev.guardrail" % other.id % "early-semver")
 
-      realDependencySpec.fold(
+      Some(realDependencySpec).fold(
         base
           .dependsOn(other % Provided)
           .accumulateClasspath(other)

--- a/project/src/main/scala/Build.scala
+++ b/project/src/main/scala/Build.scala
@@ -198,7 +198,7 @@ object Build {
 
     def directModuleDep(other: Project, realDependencySpec: SettingKey[ModuleID]): Project =
       Some(realDependencySpec)
-        .filterNot(_ => isRelease)
+        .filter(_ => isRelease) // Only use published jars during release
         .fold(project.dependsOn(other))(dep =>
           project
             .settings(libraryDependencySchemes += "dev.guardrail" % other.id % "early-semver")
@@ -207,7 +207,7 @@ object Build {
 
     def providedModuleDep(other: Project, realDependencySpec: SettingKey[ModuleID]): Project =
       Some(realDependencySpec)
-        .filterNot(_ => isRelease)
+        .filter(_ => isRelease) // Only use published jars during release
         .fold(
           project
             .dependsOn(other % Provided)

--- a/project/src/main/scala/Build.scala
+++ b/project/src/main/scala/Build.scala
@@ -182,16 +182,20 @@ object Build {
         .dependsOn(other % Provided)
         .accumulateClasspath(other)
 
+    private[this] def isRelease = sys.env.contains("GUARDRAIL_RELEASE_MODULE")
+
     def directModuleDep(other: Project, realDependencySpec: ModuleID): Project = {
       val base =
         project
           .settings(libraryDependencySchemes += "dev.guardrail" % other.id % "early-semver")
 
-      Some(realDependencySpec).fold(
-        base
-          .dependsOn(other)
-          .accumulateClasspath(other)
-      )(dep => base.settings(libraryDependencies += dep))
+      Some(realDependencySpec)
+        .filterNot(_ => isRelease)
+        .fold(
+          base
+            .dependsOn(other)
+            .accumulateClasspath(other)
+        )(dep => base.settings(libraryDependencies += dep))
     }
 
     def providedModuleDep(other: Project, realDependencySpec: ModuleID): Project = {
@@ -199,11 +203,13 @@ object Build {
         project
           .settings(libraryDependencySchemes += "dev.guardrail" % other.id % "early-semver")
 
-      Some(realDependencySpec).fold(
-        base
-          .dependsOn(other % Provided)
-          .accumulateClasspath(other)
-      )(dep => base.settings(libraryDependencies += dep % Provided))
+      Some(realDependencySpec)
+        .filterNot(_ => isRelease)
+        .fold(
+          base
+            .dependsOn(other % Provided)
+            .accumulateClasspath(other)
+        )(dep => base.settings(libraryDependencies += dep % Provided))
     }
   }
 }

--- a/project/src/main/scala/modules/cli.scala
+++ b/project/src/main/scala/modules/cli.scala
@@ -7,4 +7,7 @@ import sbt.Keys._
 
 object cli {
   val project = commonModule("cli")
+    .settings(
+      guardrailVersion := "dev.guardrail" %% "guardrail" % "0.67.0"
+    )
 }

--- a/project/src/main/scala/modules/guardrail.scala
+++ b/project/src/main/scala/modules/guardrail.scala
@@ -7,4 +7,16 @@ import sbt.Keys._
 
 object guardrail {
   val project = baseModule("guardrail", "guardrail", file("modules/codegen"))
+    .settings(
+      guardrailJavaAsyncHttpVersion := "dev.guardrail" %% "guardrail-java-dropwizard" % "0.66.0",
+      guardrailJavaDropwizardVersion := "dev.guardrail" %% "guardrail-java-dropwizard" % "0.66.0",
+      guardrailJavaSpringMvcVersion := "dev.guardrail" %% "guardrail-java-dropwizard" % "0.66.0",
+      guardrailJavaSupportVersion := "dev.guardrail" %% "guardrail-java-dropwizard" % "0.66.0",
+
+      guardrailScalaAkkaHttpVersion := "dev.guardrail" %% "guardrail-scala-akka-http" % "0.68.0",
+      guardrailScalaDropwizardVersion := "dev.guardrail" %% "guardrail-scala-dropwizard" % "0.66.0",
+      guardrailScalaEndpointsVersion := "dev.guardrail" %% "guardrail-scala-endpoints" % "0.66.0",
+      guardrailScalaHttp4sVersion := "dev.guardrail" %% "guardrail-scala-http4s" % "0.66.0",
+      guardrailScalaSupportVersion := "dev.guardrail" %% "guardrail-scala-support" % "0.67.0"
+    )
 }

--- a/project/src/main/scala/modules/javaAsyncHttp.scala
+++ b/project/src/main/scala/modules/javaAsyncHttp.scala
@@ -7,4 +7,7 @@ import sbt.Keys._
 
 object javaAsyncHttp {
   val project = commonModule("java-async-http")
+    .settings(
+      guardrailJavaSupportVersion := "dev.guardrail" %% "guardrail-java-support" % "0.66.0"
+    )
 }

--- a/project/src/main/scala/modules/javaDropwizard.scala
+++ b/project/src/main/scala/modules/javaDropwizard.scala
@@ -41,6 +41,10 @@ object javaDropwizard {
 
 
   val project = commonModule("java-dropwizard")
+      .settings(
+        guardrailJavaSupportVersion := "dev.guardrail" %% "guardrail-java-support" % "0.66.0",
+        guardrailJavaAsyncHttpVersion := "dev.guardrail" %% "guardrail-java-async-http" % "0.66.0"
+      )
 
   val sample = buildSampleProject("dropwizard", dependencies).settings(scalacOptions -= "-Xfatal-warnings")
   val sampleVavr = buildSampleProject("dropwizardVavr", dependenciesVavr).settings(scalacOptions -= "-Xfatal-warnings")

--- a/project/src/main/scala/modules/javaSpringMvc.scala
+++ b/project/src/main/scala/modules/javaSpringMvc.scala
@@ -23,6 +23,9 @@ object javaSpringMvc {
   ).map(_.cross(CrossVersion.for3Use2_13))
 
   val project = commonModule("java-spring-mvc")
+      .settings(
+        guardrailJavaSupportVersion := "dev.guardrail" %% "guardrail-java-support" % "0.66.0"
+      )
 
   val sample = buildSampleProject("springMvc", dependencies).settings(scalacOptions -= "-Xfatal-warnings")
 }

--- a/project/src/main/scala/modules/javaSupport.scala
+++ b/project/src/main/scala/modules/javaSupport.scala
@@ -37,4 +37,7 @@ object javaSupport {
         libraryDependencies ++= eclipseFormatterDependencies,
         libraryDependencies += "com.github.javaparser" % "javaparser-symbol-solver-core" % "3.22.1"
       )
+    .settings(
+      guardrailCoreVersion := "dev.guardrail" %% "guardrail-core" % "0.67.0"
+    )
 }

--- a/project/src/main/scala/modules/scalaAkkaHttp.scala
+++ b/project/src/main/scala/modules/scalaAkkaHttp.scala
@@ -53,6 +53,9 @@ object scalaAkkaHttp {
   ).map(_.cross(CrossVersion.for3Use2_13))
 
   val project = commonModule("scala-akka-http")
+    .settings(
+      guardrailScalaSupportVersion := "dev.guardrail" %% "guardrail-scala-support" % "0.67.0"
+    )
 
   val sample =
     buildSampleProject("akkaHttp", dependencies)

--- a/project/src/main/scala/modules/scalaDropwizard.scala
+++ b/project/src/main/scala/modules/scalaDropwizard.scala
@@ -36,6 +36,9 @@ object scalaDropwizard {
   ).map(_.cross(CrossVersion.for3Use2_13))
 
   val project = commonModule("scala-dropwizard")
+    .settings(
+      guardrailScalaSupportVersion := "dev.guardrail" %% "guardrail-scala-support" % "0.67.0"
+    )
 
   val sample = buildSampleProject("dropwizardScala", dependencies).settings(scalacOptions -= "-Xfatal-warnings")
 }

--- a/project/src/main/scala/modules/scalaEndpoints.scala
+++ b/project/src/main/scala/modules/scalaEndpoints.scala
@@ -21,6 +21,9 @@ object scalaEndpoints {
 
 
   val project = commonModule("scala-endpoints")
+    .settings(
+      guardrailScalaSupportVersion := "dev.guardrail" %% "guardrail-scala-support" % "0.67.0"
+    )
 
   val sample = buildSampleProject("endpoints", dependencies)
 }

--- a/project/src/main/scala/modules/scalaHttp4s.scala
+++ b/project/src/main/scala/modules/scalaHttp4s.scala
@@ -30,6 +30,9 @@ object scalaHttp4s {
   ).map(_.cross(CrossVersion.for3Use2_13))
 
   val project = commonModule("scala-http4s")
+    .settings(
+      guardrailScalaSupportVersion := "dev.guardrail" %% "guardrail-scala-support" % "0.67.0"
+    )
 
   val sample = buildSampleProject("http4s", dependencies)
 }

--- a/project/src/main/scala/modules/scalaSupport.scala
+++ b/project/src/main/scala/modules/scalaSupport.scala
@@ -11,4 +11,7 @@ object scalaSupport {
       .settings(
         libraryDependencies += "org.scalameta" %% "scalameta" % "4.4.29"
       )
+      .settings(
+        guardrailCoreVersion := "dev.guardrail" %% "guardrail-core" % "0.67.0"
+      )
 }


### PR DESCRIPTION
So the experiment with using MiMa to ensure ABI compatibility across modules was unsuccessful, and the build must be stable, so for the time being just go directly to explicit dependencies and rely on scala-steward to bump.