### PR TITLE
Move http4s response defs to local scope

### DIFF
--- a/modules/sample-http4s/src/test/scala/core/Http4s/Http4sCustomExtractorTest.scala
+++ b/modules/sample-http4s/src/test/scala/core/Http4s/Http4sCustomExtractorTest.scala
@@ -1,7 +1,8 @@
 package core.Http4s
 
 import _root_.customExtraction.client.{ http4s => cdefs }
-import _root_.customExtraction.server.http4s.users.{ GetUserResponse, UsersHandler, UsersResource }
+import _root_.customExtraction.server.http4s.users.{ UsersHandler, UsersResource }
+import _root_.customExtraction.server.http4s.users.UsersResource.GetUserResponse
 import cats.effect.IO
 import customExtraction.client.http4s.users.UsersClient
 import customExtraction.server.http4s.definitions.{ User, UserAddress }

--- a/modules/sample-http4s/src/test/scala/core/Http4s/Http4sDebugBodyTest.scala
+++ b/modules/sample-http4s/src/test/scala/core/Http4s/Http4sDebugBodyTest.scala
@@ -2,6 +2,7 @@ package core.Http4s
 
 import _root_.debugBody.client.{ http4s => generatedClient }
 import _root_.debugBody.server.http4s._
+import _root_.debugBody.server.http4s.Resource._
 import _root_.debugBody.server.http4s.definitions._
 import cats.effect.IO
 import cats.effect.IO._

--- a/modules/sample-http4s/src/test/scala/core/Http4s/Http4sFullTracerTest.scala
+++ b/modules/sample-http4s/src/test/scala/core/Http4s/Http4sFullTracerTest.scala
@@ -1,8 +1,10 @@
 package core.Http4s
 
 import _root_.tracer.client.{ http4s => cdefs }
-import _root_.tracer.server.http4s.addresses.{ AddressesHandler, AddressesResource, GetAddressResponse, GetAddressesResponse }
-import _root_.tracer.server.http4s.users.{ GetUserResponse, UsersHandler, UsersResource }
+import _root_.tracer.server.http4s.addresses.{ AddressesHandler, AddressesResource }
+import _root_.tracer.server.http4s.addresses.AddressesResource.{ GetAddressResponse, GetAddressesResponse }
+import _root_.tracer.server.http4s.users.{ UsersHandler, UsersResource }
+import _root_.tracer.server.http4s.users.UsersResource.GetUserResponse
 import _root_.tracer.server.{ http4s => sdefs }
 import _root_.tracer.client.http4s.users.UsersClient
 import _root_.tracer.client.http4s.addresses.AddressesClient
@@ -43,9 +45,9 @@ class Http4sFullTracerTest extends AnyFunSuite with Matchers with EitherValues w
           def getAddress(respond: GetAddressResponse.type)(id: String)(traceBuilder: TraceBuilder[IO]) =
             IO.pure(if (id == "addressId") {
               respond.Ok(sdefs.definitions.Address(Some("line1"), Some("line2"), Some("line3")))
-            } else sdefs.addresses.GetAddressResponse.NotFound)
+            } else GetAddressResponse.NotFound)
           def getAddresses(respond: GetAddressesResponse.type)()(traceBuilder: TraceBuilder[IO]) =
-            IO.pure(sdefs.addresses.GetAddressesResponse.NotFound)
+            IO.pure(GetAddressesResponse.NotFound)
         }
       )
 

--- a/modules/sample-http4s/src/test/scala/core/Http4s/Http4sMixedContentTypesTest.scala
+++ b/modules/sample-http4s/src/test/scala/core/Http4s/Http4sMixedContentTypesTest.scala
@@ -1,6 +1,7 @@
 package core.Http4s
 
 import _root_.mixedContentTypes.client.{ http4s => generatedClient }
+import _root_.mixedContentTypes.server.http4s.Resource._
 import _root_.mixedContentTypes.server.http4s._
 import _root_.mixedContentTypes.server.http4s.definitions.Error
 import cats.effect.IO

--- a/modules/sample-http4s/src/test/scala/core/Http4s/Http4sNonStringEnumerationTest.scala
+++ b/modules/sample-http4s/src/test/scala/core/Http4s/Http4sNonStringEnumerationTest.scala
@@ -21,6 +21,7 @@ import org.scalatest.matchers.should.Matchers
 import _root_.enumerations.client.http4s.foo.{ DoFooResponse => ClientDoFooResponse, FooClient }
 import _root_.enumerations.client.http4s.{ definitions => cdefs }
 import _root_.enumerations.server.http4s.foo._
+import _root_.enumerations.server.http4s.foo.FooResource._
 import _root_.enumerations.server.http4s.{ definitions => sdefs }
 
 class Http4sNonStringEnumerationTest extends AnyFunSuite with Matchers with EitherValues {

--- a/modules/sample-http4s/src/test/scala/core/Http4s/Http4sRawServerTest.scala
+++ b/modules/sample-http4s/src/test/scala/core/Http4s/Http4sRawServerTest.scala
@@ -4,7 +4,8 @@ import org.http4s.dsl.io._
 import org.http4s.circe._
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.funsuite.AnyFunSuite
-import _root_.raw.server.http4s.foo.{ DoFooResponse, FooHandler, FooResource }
+import _root_.raw.server.http4s.foo.{ FooHandler, FooResource }
+import _root_.raw.server.http4s.foo.FooResource.DoFooResponse
 import _root_.raw.server.http4s.{ definitions => sdefs }
 import cats.effect.IO
 import org.http4s.{ EntityEncoder, Response }

--- a/modules/sample-http4s/src/test/scala/core/Http4s/Http4sRoundTripTest.scala
+++ b/modules/sample-http4s/src/test/scala/core/Http4s/Http4sRoundTripTest.scala
@@ -6,6 +6,7 @@ import java.util.Locale.US
 import _root_.examples.client.http4s.pet.PetClient
 import _root_.examples.client.{ http4s => cdefs }
 import _root_.examples.server.http4s.pet._
+import _root_.examples.server.http4s.pet.PetResource._
 import _root_.examples.server.{ http4s => sdefs }
 import cats.effect.IO
 import cats.effect.IO._
@@ -38,7 +39,7 @@ class Http4sRoundTripTest extends AnyFunSuite with Matchers with EitherValues {
 
   test("round-trip: definition query, unit response") {
     val httpService = new PetResource().routes(new PetHandler[IO] {
-      def addPet(respond: AddPetResponse.type)(body: sdefs.definitions.Pet): IO[sdefs.pet.AddPetResponse] =
+      def addPet(respond: AddPetResponse.type)(body: sdefs.definitions.Pet): IO[sdefs.pet.PetResource.AddPetResponse] =
         body match {
           case sdefs.definitions.Pet(
               `id`,
@@ -93,7 +94,7 @@ class Http4sRoundTripTest extends AnyFunSuite with Matchers with EitherValues {
     val httpService = new PetResource().routes(new PetHandler[IO] {
       def findPetsByStatusEnum(
           respond: FindPetsByStatusEnumResponse.type
-      )(_status: sdefs.definitions.PetStatus): IO[sdefs.pet.FindPetsByStatusEnumResponse] =
+      )(_status: sdefs.definitions.PetStatus): IO[sdefs.pet.PetResource.FindPetsByStatusEnumResponse] =
         IO.pure(petStatus.fold(Vector.empty[sdefs.definitions.Pet])({ value =>
             if (_status.value == value) {
               Vector(
@@ -155,7 +156,7 @@ class Http4sRoundTripTest extends AnyFunSuite with Matchers with EitherValues {
 
   test("round-trip: 404 response") {
     val httpService = new PetResource().routes(new PetHandler[IO] {
-      def findPetsByStatus(respond: FindPetsByStatusResponse.type)(status: Iterable[String]): IO[sdefs.pet.FindPetsByStatusResponse] =
+      def findPetsByStatus(respond: FindPetsByStatusResponse.type)(status: Iterable[String]): IO[sdefs.pet.PetResource.FindPetsByStatusResponse] =
         IO.pure(respond.NotFound)
 
       def addPet(respond: AddPetResponse.type)(body: sdefs.definitions.Pet) = ???
@@ -193,7 +194,7 @@ class Http4sRoundTripTest extends AnyFunSuite with Matchers with EitherValues {
           includeChildren: Option[Boolean],
           status: Option[sdefs.definitions.PetStatus],
           _apiKey: Option[String] = None
-      ): IO[sdefs.pet.DeletePetResponse] =
+      ): IO[sdefs.pet.PetResource.DeletePetResponse] =
         if (_petId == petId && _apiKey.contains(apiKey) && status.contains(sdefs.definitions.PetStatus.Pending))
           IO.pure(respond.Ok)
         else IO.pure(respond.NotFound)

--- a/modules/sample-http4s/src/test/scala/core/issues/Issue121.scala
+++ b/modules/sample-http4s/src/test/scala/core/issues/Issue121.scala
@@ -21,7 +21,8 @@ class Issue121Suite extends AnyFunSuite with Matchers with EitherValues with Sca
   override implicit val patienceConfig = PatienceConfig(10 seconds, 1 second)
 
   test("http4s server can respond with 204") {
-    import issues.issue121.server.http4s.{ DeleteFooResponse, Handler, Resource }
+    import issues.issue121.server.http4s.{ Handler, Resource }
+    import issues.issue121.server.http4s.Resource.DeleteFooResponse
 
     val route = new Resource[IO]().routes(new Handler[IO] {
       override def deleteFoo(respond: DeleteFooResponse.type)(id: Long): IO[DeleteFooResponse] =

--- a/modules/sample-http4s/src/test/scala/core/issues/Issue1229.scala
+++ b/modules/sample-http4s/src/test/scala/core/issues/Issue1229.scala
@@ -1,8 +1,10 @@
 package core.issues
 
 import _root_.department.client.http4s.department.{ DepartmentClient, GetDepartmentResponse => ClientGDR, SearchDepartmentsResponse => ClientSDR }
+import _root_.department.client.http4s.department.{ DepartmentClient, GetDepartmentResponse => ClientGDR, SearchDepartmentsResponse => ClientSDR }
 import _root_.department.client.http4s.{ definitions => cdefs }
 import _root_.department.server.http4s.department._
+import _root_.department.server.http4s.department.DepartmentResource._
 import _root_.department.server.http4s.{ definitions => sdefs }
 import cats.effect.IO
 import cats.effect.IO._

--- a/modules/sample-http4s/src/test/scala/core/issues/Issue148.scala
+++ b/modules/sample-http4s/src/test/scala/core/issues/Issue148.scala
@@ -21,6 +21,7 @@ class Issue148Suite extends AnyFunSuite with Matchers with EitherValues with Sca
     import cats.effect.IO
     import issues.issue148.server.http4s.definitions._
     import issues.issue148.server.http4s._
+    import issues.issue148.server.http4s.Resource._
     import org.http4s._
     import org.http4s.client.Client
     import org.http4s.headers._

--- a/modules/sample-http4s/src/test/scala/core/issues/Issue455.scala
+++ b/modules/sample-http4s/src/test/scala/core/issues/Issue455.scala
@@ -20,7 +20,8 @@ class Issue455Suite extends AnyFunSuite with Matchers with EitherValues with Sca
 
   test("Circe NPE: https://github.com/circe/circe/issues/561") {
     val route = {
-      import issues.issue455.server.http4s.{ BooResponse, Handler, Resource }
+      import issues.issue455.server.http4s.{ Handler, Resource }
+      import issues.issue455.server.http4s.Resource.BooResponse
       import issues.issue455.server.http4s.definitions.RecursiveData
       new Resource[IO].routes(new Handler[IO] {
         val recData                                                              = RecursiveData(3, "three", Some(RecursiveData(2, "two", Some(RecursiveData(1, "one", None)))))

--- a/modules/sample-http4s/src/test/scala/core/issues/Issue542.scala
+++ b/modules/sample-http4s/src/test/scala/core/issues/Issue542.scala
@@ -22,7 +22,8 @@ class Issue542Suite extends AnyFunSuite with Matchers with EitherValues with Sca
   override implicit val patienceConfig = PatienceConfig(10 seconds, 1 second)
 
   test("base64 bytes can be sent") {
-    import base64.server.http4s.{ FooResponse, Handler, Resource }
+    import base64.server.http4s.{ Handler, Resource }
+    import base64.server.http4s.Resource.FooResponse
     import base64.server.http4s.definitions.Foo
     import base64.server.http4s.Implicits.Base64String
 

--- a/modules/sample-http4s/src/test/scala/generators/Http4s/Client/contentType/Http4sTextPlainTest.scala
+++ b/modules/sample-http4s/src/test/scala/generators/Http4s/Client/contentType/Http4sTextPlainTest.scala
@@ -2,8 +2,8 @@ package generators.Http4s.Client.contentType
 
 import _root_.tests.contentTypes.textPlain.client.http4s.foo.FooClient
 import _root_.tests.contentTypes.textPlain.client.{ http4s => cdefs }
-import _root_.tests.contentTypes.textPlain.server.http4s.foo.{ DoBarResponse, DoBazResponse, DoFooResponse, FooHandler, FooResource }
-import _root_.tests.contentTypes.textPlain.server.{ http4s => sdefs }
+import _root_.tests.contentTypes.textPlain.server.http4s.foo.{ FooHandler, FooResource }
+import _root_.tests.contentTypes.textPlain.server.http4s.foo.FooResource.{ DoBarResponse, DoBazResponse, DoFooResponse }
 import org.scalatest.EitherValues
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
@@ -48,14 +48,14 @@ class Http4sTextPlainTest extends AnyFunSuite with Matchers with EitherValues {
 
   test("Plain text should be emitted for required parameters") {
     val route: HttpRoutes[IO] = new FooResource[IO]().routes(new FooHandler[IO] {
-      def doFoo(respond: DoFooResponse.type)(body: String): IO[sdefs.foo.DoFooResponse] =
+      def doFoo(respond: DoFooResponse.type)(body: String): IO[DoFooResponse] =
         if (body == "sample") {
           IO.pure(respond.Created("response"))
         } else {
           IO.pure(respond.NotAcceptable)
         }
-      def doBar(respond: DoBarResponse.type)(body: Option[String]): IO[sdefs.foo.DoBarResponse] = ???
-      def doBaz(respond: DoBazResponse.type)(body: Option[String]): IO[sdefs.foo.DoBazResponse] = ???
+      def doBar(respond: DoBarResponse.type)(body: Option[String]): IO[DoBarResponse] = ???
+      def doBaz(respond: DoBazResponse.type)(body: Option[String]): IO[DoBazResponse] = ???
     })
 
     val client: Client[IO] = Client.fromHttpApp(route.orNotFound)
@@ -65,14 +65,14 @@ class Http4sTextPlainTest extends AnyFunSuite with Matchers with EitherValues {
 
   test("Plain text should be emitted for present optional parameters") {
     val route: HttpRoutes[IO] = new FooResource[IO]().routes(new FooHandler[IO] {
-      def doFoo(respond: DoFooResponse.type)(body: String): IO[sdefs.foo.DoFooResponse] = ???
-      def doBar(respond: DoBarResponse.type)(body: Option[String]): IO[sdefs.foo.DoBarResponse] =
+      def doFoo(respond: DoFooResponse.type)(body: String): IO[DoFooResponse] = ???
+      def doBar(respond: DoBarResponse.type)(body: Option[String]): IO[DoBarResponse] =
         if (body.contains("sample")) {
           IO.pure(respond.Created("response"))
         } else {
           IO.pure(respond.NotAcceptable)
         }
-      def doBaz(respond: DoBazResponse.type)(body: Option[String]): IO[sdefs.foo.DoBazResponse] = ???
+      def doBaz(respond: DoBazResponse.type)(body: Option[String]): IO[DoBazResponse] = ???
     })
 
     val client: Client[IO] = Client.fromHttpApp(route.orNotFound)
@@ -82,14 +82,14 @@ class Http4sTextPlainTest extends AnyFunSuite with Matchers with EitherValues {
 
   test("Plain text should be emitted for missing optional parameters") {
     val route: HttpRoutes[IO] = new FooResource[IO]().routes(new FooHandler[IO] {
-      def doFoo(respond: DoFooResponse.type)(body: String): IO[sdefs.foo.DoFooResponse] = ???
-      def doBar(respond: DoBarResponse.type)(body: Option[String]): IO[sdefs.foo.DoBarResponse] =
+      def doFoo(respond: DoFooResponse.type)(body: String): IO[DoFooResponse] = ???
+      def doBar(respond: DoBarResponse.type)(body: Option[String]): IO[DoBarResponse] =
         if (body.isEmpty) {
           IO.pure(respond.Created("response"))
         } else {
           IO.pure(respond.NotAcceptable)
         }
-      def doBaz(respond: DoBazResponse.type)(body: Option[String]): IO[sdefs.foo.DoBazResponse] = ???
+      def doBaz(respond: DoBazResponse.type)(body: Option[String]): IO[DoBazResponse] = ???
     })
 
     val client: Client[IO] = Client.fromHttpApp(route.orNotFound)

--- a/modules/sample-http4s/src/test/scala/generators/Http4s/RoundTrip/Http4sCustomHeadersTest.scala
+++ b/modules/sample-http4s/src/test/scala/generators/Http4s/RoundTrip/Http4sCustomHeadersTest.scala
@@ -9,7 +9,8 @@ import org.scalatest.matchers.should.Matchers
 
 import tests.customTypes.customHeader.client.http4s.{ definitions => cdefs, Client }
 import tests.customTypes.customHeader.server.http4s.Implicits.Formatter
-import tests.customTypes.customHeader.server.http4s.{ definitions => sdefs, GetFooResponse, Handler, Resource }
+import tests.customTypes.customHeader.server.http4s.{ definitions => sdefs, Handler, Resource }
+import tests.customTypes.customHeader.server.http4s.Resource.GetFooResponse
 
 class Http4sCustomHeadersTest extends AnyFlatSpec with Matchers with EitherValues {
 

--- a/modules/sample-http4s/src/test/scala/generators/Http4s/RoundTrip/Http4sFormDataTest.scala
+++ b/modules/sample-http4s/src/test/scala/generators/Http4s/RoundTrip/Http4sFormDataTest.scala
@@ -4,6 +4,7 @@ import cats.effect.IO
 import form.client.http4s.foo.FooClient
 import form.client.{ http4s => cdefs }
 import form.server.http4s.foo._
+import form.server.http4s.foo.FooResource._
 import form.server.{ http4s => sdefs }
 import org.http4s.client.Client
 import org.http4s.implicits._


### PR DESCRIPTION
The change repeats the same solution as in akka-http generator. The main problem is solves is to make it possible to generate both a server and a client to the same package. The best solution would be to reuse the same response definitions on both sides but it requires a wider change