### PR TITLE
When releasing, explicitly depend on published jar

### DIFF
--- a/.github/release-drafter-cli.yml
+++ b/.github/release-drafter-cli.yml
@@ -3,6 +3,8 @@ tag-template: 'cli-v$RESOLVED_VERSION'
 tag-prefix: cli-v
 include-paths:
   - "modules/cli/src/main/"
+  - "build.sbt"
+  - "project/src/main/scala/Build.scala"
   - "project/src/main/scala/modules/cli.scala"
 # NB: Managed by support/regenerate-release-drafter.sh
 categories:

--- a/.github/release-drafter-core.yml
+++ b/.github/release-drafter-core.yml
@@ -3,6 +3,8 @@ tag-template: 'core-v$RESOLVED_VERSION'
 tag-prefix: core-v
 include-paths:
   - "modules/core/src/main/"
+  - "build.sbt"
+  - "project/src/main/scala/Build.scala"
   - "project/src/main/scala/modules/core.scala"
 # NB: Managed by support/regenerate-release-drafter.sh
 categories:

--- a/.github/release-drafter-guardrail.yml
+++ b/.github/release-drafter-guardrail.yml
@@ -3,6 +3,8 @@ tag-template: 'guardrail-v$RESOLVED_VERSION'
 tag-prefix: guardrail-v
 include-paths:
   - "modules/codegen/src/main/"
+  - "build.sbt"
+  - "project/src/main/scala/Build.scala"
   - "project/src/main/scala/modules/guardrail.scala"
 # NB: Managed by support/regenerate-release-drafter.sh
 categories:

--- a/.github/release-drafter-java-async-http.yml
+++ b/.github/release-drafter-java-async-http.yml
@@ -3,6 +3,8 @@ tag-template: 'java-async-http-v$RESOLVED_VERSION'
 tag-prefix: java-async-http-v
 include-paths:
   - "modules/java-async-http/src/main/"
+  - "build.sbt"
+  - "project/src/main/scala/Build.scala"
   - "project/src/main/scala/modules/javaAsyncHttp.scala"
 # NB: Managed by support/regenerate-release-drafter.sh
 categories:

--- a/.github/release-drafter-java-dropwizard.yml
+++ b/.github/release-drafter-java-dropwizard.yml
@@ -3,6 +3,8 @@ tag-template: 'java-dropwizard-v$RESOLVED_VERSION'
 tag-prefix: java-dropwizard-v
 include-paths:
   - "modules/java-dropwizard/src/main/"
+  - "build.sbt"
+  - "project/src/main/scala/Build.scala"
   - "project/src/main/scala/modules/javaDropwizard.scala"
 # NB: Managed by support/regenerate-release-drafter.sh
 categories:

--- a/.github/release-drafter-java-spring-mvc.yml
+++ b/.github/release-drafter-java-spring-mvc.yml
@@ -3,6 +3,8 @@ tag-template: 'java-spring-mvc-v$RESOLVED_VERSION'
 tag-prefix: java-spring-mvc-v
 include-paths:
   - "modules/java-spring-mvc/src/main/"
+  - "build.sbt"
+  - "project/src/main/scala/Build.scala"
   - "project/src/main/scala/modules/javaSpringMvc.scala"
 # NB: Managed by support/regenerate-release-drafter.sh
 categories:

--- a/.github/release-drafter-java-support.yml
+++ b/.github/release-drafter-java-support.yml
@@ -3,6 +3,8 @@ tag-template: 'java-support-v$RESOLVED_VERSION'
 tag-prefix: java-support-v
 include-paths:
   - "modules/java-support/src/main/"
+  - "build.sbt"
+  - "project/src/main/scala/Build.scala"
   - "project/src/main/scala/modules/javaSupport.scala"
 # NB: Managed by support/regenerate-release-drafter.sh
 categories:

--- a/.github/release-drafter-scala-akka-http.yml
+++ b/.github/release-drafter-scala-akka-http.yml
@@ -3,6 +3,8 @@ tag-template: 'scala-akka-http-v$RESOLVED_VERSION'
 tag-prefix: scala-akka-http-v
 include-paths:
   - "modules/scala-akka-http/src/main/"
+  - "build.sbt"
+  - "project/src/main/scala/Build.scala"
   - "project/src/main/scala/modules/scalaAkkaHttp.scala"
 # NB: Managed by support/regenerate-release-drafter.sh
 categories:

--- a/.github/release-drafter-scala-dropwizard.yml
+++ b/.github/release-drafter-scala-dropwizard.yml
@@ -3,6 +3,8 @@ tag-template: 'scala-dropwizard-v$RESOLVED_VERSION'
 tag-prefix: scala-dropwizard-v
 include-paths:
   - "modules/scala-dropwizard/src/main/"
+  - "build.sbt"
+  - "project/src/main/scala/Build.scala"
   - "project/src/main/scala/modules/scalaDropwizard.scala"
 # NB: Managed by support/regenerate-release-drafter.sh
 categories:

--- a/.github/release-drafter-scala-endpoints.yml
+++ b/.github/release-drafter-scala-endpoints.yml
@@ -3,6 +3,8 @@ tag-template: 'scala-endpoints-v$RESOLVED_VERSION'
 tag-prefix: scala-endpoints-v
 include-paths:
   - "modules/scala-endpoints/src/main/"
+  - "build.sbt"
+  - "project/src/main/scala/Build.scala"
   - "project/src/main/scala/modules/scalaEndpoints.scala"
 # NB: Managed by support/regenerate-release-drafter.sh
 categories:

--- a/.github/release-drafter-scala-http4s.yml
+++ b/.github/release-drafter-scala-http4s.yml
@@ -3,6 +3,8 @@ tag-template: 'scala-http4s-v$RESOLVED_VERSION'
 tag-prefix: scala-http4s-v
 include-paths:
   - "modules/scala-http4s/src/main/"
+  - "build.sbt"
+  - "project/src/main/scala/Build.scala"
   - "project/src/main/scala/modules/scalaHttp4s.scala"
 # NB: Managed by support/regenerate-release-drafter.sh
 categories:

--- a/.github/release-drafter-scala-support.yml
+++ b/.github/release-drafter-scala-support.yml
@@ -3,6 +3,8 @@ tag-template: 'scala-support-v$RESOLVED_VERSION'
 tag-prefix: scala-support-v
 include-paths:
   - "modules/scala-support/src/main/"
+  - "build.sbt"
+  - "project/src/main/scala/Build.scala"
   - "project/src/main/scala/modules/scalaSupport.scala"
 # NB: Managed by support/regenerate-release-drafter.sh
 categories:

--- a/support/regenerate-release-drafter.sh
+++ b/support/regenerate-release-drafter.sh
@@ -151,15 +151,15 @@ write() {
 reinitialize_release
 reinitialize_release_drafter
 
-write core              guardrail-core              modules/core/              build.sbt  project/src/main/scala/Build.scala  project/src/main/scala/modules/core.scala
-write java-async-http   guardrail-java-async-http   modules/java-async-http/   build.sbt  project/src/main/scala/Build.scala  project/src/main/scala/modules/javaAsyncHttp.scala
-write java-dropwizard   guardrail-java-dropwizard   modules/java-dropwizard/   build.sbt  project/src/main/scala/Build.scala  project/src/main/scala/modules/javaDropwizard.scala
-write java-spring-mvc   guardrail-java-spring-mvc   modules/java-spring-mvc/   build.sbt  project/src/main/scala/Build.scala  project/src/main/scala/modules/javaSpringMvc.scala
-write java-support      guardrail-java-support      modules/java-support/      build.sbt  project/src/main/scala/Build.scala  project/src/main/scala/modules/javaSupport.scala
-write scala-akka-http   guardrail-scala-akka-http   modules/scala-akka-http/   build.sbt  project/src/main/scala/Build.scala  project/src/main/scala/modules/scalaAkkaHttp.scala
-write scala-dropwizard  guardrail-scala-dropwizard  modules/scala-dropwizard/  build.sbt  project/src/main/scala/Build.scala  project/src/main/scala/modules/scalaDropwizard.scala
-write scala-endpoints   guardrail-scala-endpoints   modules/scala-endpoints/   build.sbt  project/src/main/scala/Build.scala  project/src/main/scala/modules/scalaEndpoints.scala
-write scala-http4s      guardrail-scala-http4s      modules/scala-http4s/      build.sbt  project/src/main/scala/Build.scala  project/src/main/scala/modules/scalaHttp4s.scala
-write scala-support     guardrail-scala-support     modules/scala-support/     build.sbt  project/src/main/scala/Build.scala  project/src/main/scala/modules/scalaSupport.scala
-write guardrail         guardrail                   modules/codegen/src/main/  build.sbt  project/src/main/scala/Build.scala  project/src/main/scala/modules/guardrail.scala
-write cli               guardrail-cli               modules/cli/               build.sbt  project/src/main/scala/Build.scala  project/src/main/scala/modules/cli.scala
+write core              guardrail-core              modules/core/src/main/              build.sbt  project/src/main/scala/Build.scala  project/src/main/scala/modules/core.scala
+write java-async-http   guardrail-java-async-http   modules/java-async-http/src/main/   build.sbt  project/src/main/scala/Build.scala  project/src/main/scala/modules/javaAsyncHttp.scala
+write java-dropwizard   guardrail-java-dropwizard   modules/java-dropwizard/src/main/   build.sbt  project/src/main/scala/Build.scala  project/src/main/scala/modules/javaDropwizard.scala
+write java-spring-mvc   guardrail-java-spring-mvc   modules/java-spring-mvc/src/main/   build.sbt  project/src/main/scala/Build.scala  project/src/main/scala/modules/javaSpringMvc.scala
+write java-support      guardrail-java-support      modules/java-support/src/main/      build.sbt  project/src/main/scala/Build.scala  project/src/main/scala/modules/javaSupport.scala
+write scala-akka-http   guardrail-scala-akka-http   modules/scala-akka-http/src/main/   build.sbt  project/src/main/scala/Build.scala  project/src/main/scala/modules/scalaAkkaHttp.scala
+write scala-dropwizard  guardrail-scala-dropwizard  modules/scala-dropwizard/src/main/  build.sbt  project/src/main/scala/Build.scala  project/src/main/scala/modules/scalaDropwizard.scala
+write scala-endpoints   guardrail-scala-endpoints   modules/scala-endpoints/src/main/   build.sbt  project/src/main/scala/Build.scala  project/src/main/scala/modules/scalaEndpoints.scala
+write scala-http4s      guardrail-scala-http4s      modules/scala-http4s/src/main/      build.sbt  project/src/main/scala/Build.scala  project/src/main/scala/modules/scalaHttp4s.scala
+write scala-support     guardrail-scala-support     modules/scala-support/src/main/     build.sbt  project/src/main/scala/Build.scala  project/src/main/scala/modules/scalaSupport.scala
+write guardrail         guardrail                   modules/codegen/src/main/           build.sbt  project/src/main/scala/Build.scala  project/src/main/scala/modules/guardrail.scala
+write cli               guardrail-cli               modules/cli/src/main/               build.sbt  project/src/main/scala/Build.scala  project/src/main/scala/modules/cli.scala


### PR DESCRIPTION
This will make builds more stable at the expense of pain during release.

If the pain is great enough, it may be sufficient to do a publishLocal
for dependencies from known tags instead of waiting for a repository
sync.

Initially we were just faking it by pretending that master had the same
ABI as releases because the release script triggers new releases in
order, but this was always a trick, albeit one that I believed would
work.