### PR TITLE
Add http4s 0.23.6 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,7 @@ jobs:
             { framework: 'akka-http',         project: 'sample-akkaHttp'        },
             #{ framework: 'endpoints',         project: 'sample-endpoints'       },
             { framework: 'http4s',            project: 'sample-http4s'          },
+            { framework: 'http4s-v0.22',      project: 'sample-http4s-v0_22'     },
             { framework: 'akka-http-jackson', project: 'sample-akkaHttpJackson' },
             { framework: 'dropwizard',        project: 'sample-dropwizardScala' }
           ]

--- a/build.sbt
+++ b/build.sbt
@@ -46,7 +46,7 @@ runExample := Def.inputTaskDyn {
 
 addCommandAlias("runtimeAkkaHttpSuite", "; resetSample ; runExample scala akka-http ; sample-akkaHttp / test")
 
-addCommandAlias("resetSample", "; " ++ (scalaFrameworks ++ javaFrameworks).map(x => s"sample-${x}/clean").mkString(" ; "))
+addCommandAlias("resetSample", "; " ++ (scalaFrameworks ++ javaFrameworks).map(x => s"sample-${x.projectName}/clean").mkString(" ; "))
 
 // Deprecated command
 addCommandAlias("example", "runtimeSuite")
@@ -55,13 +55,13 @@ addCommandAlias("example", "runtimeSuite")
 run / fork := true
 
 addCommandAlias("cli", "runMain dev.guardrail.cli.CLI")
-addCommandAlias("runtimeScalaSuite", "; resetSample ; runScalaExample ; " + scalaFrameworks.map(x => s"sample-${x}/test").mkString("; "))
-addCommandAlias("runtimeJavaSuite", "; resetSample ; runJavaExample ; " + javaFrameworks.map(x => s"sample-${x}/test").mkString("; "))
+addCommandAlias("runtimeScalaSuite", "; resetSample ; runScalaExample ; " + scalaFrameworks.map(x => s"sample-${x.projectName}/test").mkString("; "))
+addCommandAlias("runtimeJavaSuite", "; resetSample ; runJavaExample ; " + javaFrameworks.map(x => s"sample-${x.projectName}/test").mkString("; "))
 addCommandAlias("runtimeSuite", "; runtimeScalaSuite ; runtimeJavaSuite")
 addCommandAlias("scalaTestSuite", "; guardrail/test ; runtimeScalaSuite")
 addCommandAlias("javaTestSuite", "; guardrail/test ; runtimeJavaSuite")
-addCommandAlias("format", "; guardrail/scalafmt ; guardrail/test:scalafmt ; " + scalaFrameworks.map(x => s"sample-${x}/scalafmt ; sample-${x}/test:scalafmt").mkString("; "))
-addCommandAlias("checkFormatting", "; guardrail/scalafmtCheck ; guardrail/Test/scalafmtCheck ; " + scalaFrameworks.map(x => s"sample-${x}/scalafmtCheck ; sample-${x}/Test/scalafmtCheck").mkString("; "))
+addCommandAlias("format", "; guardrail/scalafmt ; guardrail/test:scalafmt ; " + scalaFrameworks.map(x => s"sample-${x.projectName}/scalafmt ; sample-${x.projectName}/test:scalafmt").mkString("; "))
+addCommandAlias("checkFormatting", "; guardrail/scalafmtCheck ; guardrail/Test/scalafmtCheck ; " + scalaFrameworks.map(x => s"sample-${x.projectName}/scalafmtCheck ; sample-${x.projectName}/Test/scalafmtCheck").mkString("; "))
 addCommandAlias("testSuite", "; scalaTestSuite ; javaTestSuite; microsite/compile")
 
 addCommandAlias(

--- a/build.sbt
+++ b/build.sbt
@@ -138,7 +138,8 @@ lazy val samples = (project in file("modules/samples"))
     scalaAkkaHttpSample,
     scalaDropwizardSample,
     scalaEndpointsSample,
-    scalaHttp4sSample
+    scalaHttp4sSample,
+    scalaHttp4sSampleV0_22
   )
 
 lazy val core = modules.core.project
@@ -177,6 +178,7 @@ lazy val scalaEndpointsSample = modules.scalaEndpoints.sample
 lazy val scalaEndpoints = modules.scalaEndpoints.project
   .customDependsOn(scalaSupport)
 
+lazy val scalaHttp4sSampleV0_22 = modules.scalaHttp4s.sampleV0_22
 lazy val scalaHttp4sSample = modules.scalaHttp4s.sample
 lazy val scalaHttp4s = modules.scalaHttp4s.project
   .customDependsOn(scalaSupport)

--- a/modules/codegen/src/main/scala/dev/guardrail/generators/GeneratorMappings.scala
+++ b/modules/codegen/src/main/scala/dev/guardrail/generators/GeneratorMappings.scala
@@ -36,7 +36,7 @@ object GeneratorMappings {
   private def indirectEndpoints = new LoaderIndirection[Framework[ScalaLanguage, Target]] {
     val instance = scala.endpoints.Endpoints
   }
-  private def indirectHttp4sV0_23 = new LoaderIndirection[Framework[ScalaLanguage, Target]] {
+  private def indirectHttp4s = new LoaderIndirection[Framework[ScalaLanguage, Target]] {
     val instance = new scala.http4s.Http4s(scala.http4s.Http4sVersion.V0_23)
   }
   private def indirectHttp4sV0_22 = new LoaderIndirection[Framework[ScalaLanguage, Target]] {
@@ -54,8 +54,8 @@ object GeneratorMappings {
     xs => scalaModule.flatMap(_.extract(xs)), {
       case "akka-http"         => scalaModule *> catchClassNotFound(indirectAkkaHttp, MissingDependency("guardrail-scala-akka-http"))
       case "endpoints"         => scalaModule *> catchClassNotFound(indirectEndpoints, MissingDependency("guardrail-scala-endpoints"))
-      case "http4s"            => scalaModule *> catchClassNotFound(indirectHttp4sV0_23, MissingDependency("guardrail-scala-http4s"))
-      case "http4s-v0.23"      => scalaModule *> catchClassNotFound(indirectHttp4sV0_23, MissingDependency("guardrail-scala-http4s"))
+      case "http4s"            => scalaModule *> catchClassNotFound(indirectHttp4s, MissingDependency("guardrail-scala-http4s"))
+      case "http4s-v0.23"      => scalaModule *> catchClassNotFound(indirectHttp4s, MissingDependency("guardrail-scala-http4s"))
       case "http4s-v0.22"      => scalaModule *> catchClassNotFound(indirectHttp4sV0_22, MissingDependency("guardrail-scala-http4s"))
       case "akka-http-jackson" => scalaModule *> catchClassNotFound(indirectAkkaHttpJackson, MissingDependency("guardrail-scala-akka-http"))
       case "dropwizard"        => scalaModule *> catchClassNotFound(indirectScalaDropwizard, MissingDependency("guardrail-scala-dropwizard"))

--- a/modules/codegen/src/main/scala/dev/guardrail/generators/GeneratorMappings.scala
+++ b/modules/codegen/src/main/scala/dev/guardrail/generators/GeneratorMappings.scala
@@ -36,8 +36,11 @@ object GeneratorMappings {
   private def indirectEndpoints = new LoaderIndirection[Framework[ScalaLanguage, Target]] {
     val instance = scala.endpoints.Endpoints
   }
-  private def indirectHttp4s = new LoaderIndirection[Framework[ScalaLanguage, Target]] {
-    val instance = scala.http4s.Http4s
+  private def indirectHttp4sV0_23 = new LoaderIndirection[Framework[ScalaLanguage, Target]] {
+    val instance = new scala.http4s.Http4s(scala.http4s.Http4sVersion.V0_23)
+  }
+  private def indirectHttp4sV0_22 = new LoaderIndirection[Framework[ScalaLanguage, Target]] {
+    val instance = new scala.http4s.Http4s(scala.http4s.Http4sVersion.V0_22)
   }
   private def indirectAkkaHttpJackson = new LoaderIndirection[Framework[ScalaLanguage, Target]] {
     val instance = scala.akkaHttp.AkkaHttpJackson
@@ -51,7 +54,9 @@ object GeneratorMappings {
     xs => scalaModule.flatMap(_.extract(xs)), {
       case "akka-http"         => scalaModule *> catchClassNotFound(indirectAkkaHttp, MissingDependency("guardrail-scala-akka-http"))
       case "endpoints"         => scalaModule *> catchClassNotFound(indirectEndpoints, MissingDependency("guardrail-scala-endpoints"))
-      case "http4s"            => scalaModule *> catchClassNotFound(indirectHttp4s, MissingDependency("guardrail-scala-http4s"))
+      case "http4s"            => scalaModule *> catchClassNotFound(indirectHttp4sV0_23, MissingDependency("guardrail-scala-http4s"))
+      case "http4s-v0.23"      => scalaModule *> catchClassNotFound(indirectHttp4sV0_23, MissingDependency("guardrail-scala-http4s"))
+      case "http4s-v0.22"      => scalaModule *> catchClassNotFound(indirectHttp4sV0_22, MissingDependency("guardrail-scala-http4s"))
       case "akka-http-jackson" => scalaModule *> catchClassNotFound(indirectAkkaHttpJackson, MissingDependency("guardrail-scala-akka-http"))
       case "dropwizard"        => scalaModule *> catchClassNotFound(indirectScalaDropwizard, MissingDependency("guardrail-scala-dropwizard"))
     }, {

--- a/modules/codegen/src/main/scala/dev/guardrail/generators/scala/ScalaModule.scala
+++ b/modules/codegen/src/main/scala/dev/guardrail/generators/scala/ScalaModule.scala
@@ -8,7 +8,7 @@ import dev.guardrail.generators.scala.akkaHttp.{ AkkaHttpClientGenerator, AkkaHt
 import dev.guardrail.generators.scala.circe.CirceProtocolGenerator
 import dev.guardrail.generators.scala.dropwizard.{ DropwizardClientGenerator, DropwizardGenerator, DropwizardServerGenerator }
 import dev.guardrail.generators.scala.endpoints.{ EndpointsClientGenerator, EndpointsGenerator, EndpointsServerGenerator }
-import dev.guardrail.generators.scala.http4s.{ Http4sClientGenerator, Http4sGenerator, Http4sServerGenerator }
+import dev.guardrail.generators.scala.http4s.{ Http4sClientGenerator, Http4sGenerator, Http4sServerGenerator, Http4sVersion }
 import dev.guardrail.generators.scala.jackson.JacksonProtocolGenerator
 import dev.guardrail.terms.client.ClientTerms
 import dev.guardrail.terms.server.ServerTerms
@@ -70,13 +70,23 @@ object ScalaModule extends AbstractModule[ScalaLanguage] {
     EndpointsGenerator()
   )
 
+  def http4sV0_22(implicit Cl: CollectionsLibTerms[ScalaLanguage, Target]): (
+      ClientTerms[ScalaLanguage, Target],
+      ServerTerms[ScalaLanguage, Target],
+      FrameworkTerms[ScalaLanguage, Target]
+  ) = (
+    Http4sClientGenerator(),
+    Http4sServerGenerator(Http4sVersion.V0_22),
+    Http4sGenerator()
+  )
+
   def http4s(implicit Cl: CollectionsLibTerms[ScalaLanguage, Target]): (
       ClientTerms[ScalaLanguage, Target],
       ServerTerms[ScalaLanguage, Target],
       FrameworkTerms[ScalaLanguage, Target]
   ) = (
     Http4sClientGenerator(),
-    Http4sServerGenerator(),
+    Http4sServerGenerator(Http4sVersion.V0_23),
     Http4sGenerator()
   )
 
@@ -105,6 +115,8 @@ object ScalaModule extends AbstractModule[ScalaLanguage] {
         ("akka-http", catchClassNotFound(akkaHttp(modelGeneratorType), MissingDependency("guardrail-scala-akka-http"))),
         ("akka-http-v10.1", catchClassNotFound(akkaHttpV10_1(modelGeneratorType), MissingDependency("guardrail-scala-akka-http"))),
         ("http4s", catchClassNotFound(http4s, MissingDependency("guardrail-scala-http4s"))),
+        ("http4s-v0.23", catchClassNotFound(http4s, MissingDependency("guardrail-scala-http4s"))),
+        ("http4s-v0.22", catchClassNotFound(http4sV0_22, MissingDependency("guardrail-scala-http4s"))),
         ("endpoints", catchClassNotFound(endpoints(modelGeneratorType), MissingDependency("guardrail-scala-endpoints"))),
         ("dropwizard", catchClassNotFound(dropwizard, MissingDependency("guardrail-scala-dropwizard")))
       )

--- a/modules/codegen/src/test/scala/tests/core/TrackerTests.scala
+++ b/modules/codegen/src/test/scala/tests/core/TrackerTests.scala
@@ -3,6 +3,7 @@ package tests.core
 import dev.guardrail.core.{ Tracker, TrackerTestExtensions }
 import dev.guardrail.core.implicits._
 import dev.guardrail.generators.scala.http4s.Http4s
+import dev.guardrail.generators.scala.http4s.Http4sVersion
 import dev.guardrail.{ CodegenTarget, Context, UserError }
 import org.scalacheck.{ Arbitrary, Gen }
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
@@ -141,7 +142,7 @@ Tracker should:
         |          description: Success
         |""".stripMargin
       val (_, UserError("Missing operationId (.paths./foo.operations.GET.operationId)")) =
-        runInvalidSwaggerSpec(swagger)(Context.empty, CodegenTarget.Server, Http4s)
+        runInvalidSwaggerSpec(swagger)(Context.empty, CodegenTarget.Server, new Http4s(Http4sVersion.V0_23))
     }
 
     "responses" in {
@@ -154,7 +155,7 @@ Tracker should:
         |      operationId: foo
         |""".stripMargin
       val (_, UserError("No responses defined for foo (.paths./foo.operations.GET.responses)")) =
-        runInvalidSwaggerSpec(swagger)(Context.empty, CodegenTarget.Server, Http4s)
+        runInvalidSwaggerSpec(swagger)(Context.empty, CodegenTarget.Server, new Http4s(Http4sVersion.V0_23))
     }
   }
 }

--- a/modules/codegen/src/test/scala/tests/core/TypesTest.scala
+++ b/modules/codegen/src/test/scala/tests/core/TypesTest.scala
@@ -10,6 +10,7 @@ import dev.guardrail.Context
 import dev.guardrail.generators.ProtocolDefinitions
 import dev.guardrail.generators.scala.akkaHttp.AkkaHttp
 import dev.guardrail.generators.scala.http4s.Http4s
+import dev.guardrail.generators.scala.http4s.Http4sVersion
 import dev.guardrail.generators.scala.syntax.companionForStaticDefns
 import dev.guardrail.terms.protocol.ClassDefinition
 
@@ -359,7 +360,7 @@ class TypesTest extends AnyFunSuite with Matchers with SwaggerSpecRunner {
       ProtocolDefinitions(ClassDefinition(_, _, _, cls, staticDefns, _) :: Nil, _, _, _, _),
       _,
       _
-    ) = runSwaggerSpec(swagger)(Context.empty, Http4s)
+    ) = runSwaggerSpec(swagger)(Context.empty, new Http4s(Http4sVersion.V0_23))
 
     val cmp = companionForStaticDefns(staticDefns)
 

--- a/modules/microsite/docs/scala/http4s/generating-a-server.md
+++ b/modules/microsite/docs/scala/http4s/generating-a-server.md
@@ -12,8 +12,9 @@ The following is an example from the [http4s](https://github.com/http4s/http4s) 
 
 ```scala mdoc:passthrough
 import dev.guardrail.generators.scala.http4s.Http4s
+import dev.guardrail.generators.scala.http4s.Http4sVersion
 import dev.guardrail.docs._
-DocsHelpers.renderScalaSnippet(Http4s, GeneratingAServer)("""
+DocsHelpers.renderScalaSnippet(new Http4s(Http4sVersion.V0_23), GeneratingAServer)("""
     |// The `Handler` trait is fully abstracted from the underlying http framework. As a result, with the exception of some
     |// structural alterations (`F[_]` instead of `Future[_]` as the return type) the same handlers can be used with
     |// different `Resource` implementations from different framework generators. This permits greater compatibility between

--- a/modules/microsite/docs/scala/http4s/generating-clients.md
+++ b/modules/microsite/docs/scala/http4s/generating-clients.md
@@ -14,8 +14,9 @@ The following is an example from the [http4s](https://github.com/http4s/http4s) 
 
 ```scala mdoc:passthrough
 import dev.guardrail.generators.scala.http4s.Http4s
+import dev.guardrail.generators.scala.http4s.Http4sVersion
 import dev.guardrail.docs._
-DocsHelpers.renderScalaSnippet(Http4s, GeneratingClients)(
+DocsHelpers.renderScalaSnippet(new Http4s(Http4sVersion.V0_23), GeneratingClients)(
   """|// Two constructors are provided, one accepting the `httpClient` and `Async`
      |// implicitly, the other accepting an explicit `httpClient`, but still
      |// accepting the `Async` implicitly
@@ -32,6 +33,6 @@ Separation of protocol-concerns from API-level concerns
 As guardrail clients are built on top of any Http4s client type, client configuration is done the same way as you are
 already familiar with when using Http4s.
 
-Check out the docs for [Http4s Clients](https://http4s.org/v0.20/client/).
+Check out the docs for [Http4s Clients](https://http4s.org/v0.23/client/).
 
 <span style="float: left">[Prev: Generating a Server](generating-a-server)</span>

--- a/modules/microsite/src/main/scala/DocsHelpers.scala
+++ b/modules/microsite/src/main/scala/DocsHelpers.scala
@@ -80,7 +80,7 @@ object DocsHelpers {
             )
           case _ => ???
         }
-      case (Http4s, GeneratingAServer) =>
+      case (_: Http4s, GeneratingAServer) =>
         val (_, codegenDefinitions) = Target.unsafeExtract(
           Common.prepareDefinitions[ScalaLanguage, Target](CodegenTarget.Server, Context.empty, openAPI, List("definitions"), NonEmptyList.one("support"))
         )
@@ -112,7 +112,7 @@ object DocsHelpers {
             }
           """.toString)
         )
-      case (Http4s, GeneratingClients) =>
+      case (_: Http4s, GeneratingClients) =>
         val (_, codegenDefinitions) = Target.unsafeExtract(
           Common.prepareDefinitions[ScalaLanguage, Target](CodegenTarget.Client, Context.empty, openAPI, List("definitions"), NonEmptyList.one("support"))
         )

--- a/modules/sample-http4s-v0_22/src/main/scala/examples/support/PositiveLong.scala
+++ b/modules/sample-http4s-v0_22/src/main/scala/examples/support/PositiveLong.scala
@@ -1,0 +1,11 @@
+package examples.support
+
+import examples.client.http4sV022.Implicits
+import io.circe.Decoder
+
+class PositiveLong private (val value: Long) extends AnyVal
+object PositiveLong {
+  def apply(value: Long): Option[PositiveLong] = if (value >= 0) Some(new PositiveLong(value)) else None
+  implicit val showable                        = Implicits.Show.build[PositiveLong](_.value.toString())
+  implicit val decodePositiveLong              = Decoder.decodeLong.emap(num => PositiveLong.apply(num).toRight(s"${num} is not positive"))
+}

--- a/modules/sample-http4s-v0_22/src/test/scala/core/Http4s/Http4sCustomExtractorTest.scala
+++ b/modules/sample-http4s-v0_22/src/test/scala/core/Http4s/Http4sCustomExtractorTest.scala
@@ -1,0 +1,43 @@
+package core.Http4s
+
+import _root_.customExtraction.client.{ http4sV022 => cdefs }
+import _root_.customExtraction.server.http4sV022.users.{ UsersHandler, UsersResource }
+import _root_.customExtraction.server.http4sV022.users.UsersResource.GetUserResponse
+import cats.effect.IO
+import customExtraction.client.http4sV022.users.UsersClient
+import customExtraction.server.http4sV022.definitions.{ User, UserAddress }
+import org.http4s.{ HttpRoutes, Request }
+import org.http4s.client.Client
+import org.http4s.implicits._
+import org.http4s.syntax.StringSyntax
+import org.scalatest.EitherValues
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+class Http4sCustomExtractorTest extends AnyFunSuite with Matchers with EitherValues with StringSyntax {
+  type Extract = IO[String]
+  private val testString = "test"
+  private val user       = User("id", UserAddress(Some("line1"), Some("line2"), Some("line3")))
+
+  def extract: String => Request[IO] => Extract = { name => request =>
+    IO.pure(testString)
+  }
+
+  test("custom extract: injecting value into handler") {
+    val server: HttpRoutes[IO] = new UsersResource[IO, Extract](extract).routes(new UsersHandler[IO, Extract] {
+      override def getUser(respond: GetUserResponse.type)(id: String)(extracted: Extract): IO[GetUserResponse] =
+        extracted.map { str =>
+          if (str == testString) GetUserResponse.Ok(user)
+          else GetUserResponse.Ok(User("baduser", UserAddress(None, None, None)))
+        }
+    })
+
+    val client = UsersClient.httpClient(Client.fromHttpApp(server.orNotFound))
+
+    val retrieved: cdefs.users.GetUserResponse =
+      client.getUser(user.id, List.empty).attempt.unsafeRunSync().value
+
+    retrieved shouldBe cdefs.users.GetUserResponse
+      .Ok(cdefs.definitions.User("id", cdefs.definitions.UserAddress(Some("line1"), Some("line2"), Some("line3"))))
+  }
+}

--- a/modules/sample-http4s-v0_22/src/test/scala/core/Http4s/Http4sDebugBodyTest.scala
+++ b/modules/sample-http4s-v0_22/src/test/scala/core/Http4s/Http4sDebugBodyTest.scala
@@ -1,0 +1,75 @@
+package core.Http4s
+
+import _root_.debugBody.client.{ http4sV022 => generatedClient }
+import _root_.debugBody.server.http4sV022._
+import _root_.debugBody.server.http4sV022.Resource._
+import _root_.debugBody.server.http4sV022.definitions._
+import cats.effect.IO
+import cats.effect.IO._
+import org.http4s.client.Client
+import org.http4s.implicits._
+import org.scalatest.EitherValues
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+import io.circe._
+import org.http4s._
+import org.http4s.syntax._
+import org.http4s.circe.CirceInstances
+import cats.syntax.all._
+import cats.effect.syntax.all._
+import fs2._
+
+class Http4sDebugBodyTest extends AnyFunSuite with Matchers with EitherValues with CirceInstances {
+
+  private val server = new Resource[IO]()
+    .routes(
+      new Handler[IO] {
+        override def debugBody(respond: DebugBodyResponse.type)(body: Body): IO[DebugBodyResponse] =
+          IO.pure(respond.NoContent)
+      }
+    )
+    .orNotFound
+
+  private def sendRequest(server: HttpApp[IO], body: Json) = {
+    val req = Request[IO](
+      method = Method.POST,
+      uri = Uri.unsafeFromString("http://localhost:1234/bar"),
+      body = jsonEncoderOf[IO, Json].toEntity(body).body
+    )
+    Client.fromHttpApp[IO](server).run(req)
+  }
+
+  test("should fail with a helpful error message") {
+    val invalidJson = Json.obj(
+      ("invalidSomething1") -> Json.fromInt(1),
+      ("something2")        -> Json.fromString("something")
+    )
+    val request        = sendRequest(server, invalidJson)
+    val actualResponse = request.use(_.pure[IO]).unsafeRunSync()
+    val actualErrorMessages =
+      Stream
+        .resource(request)
+        .flatMap(_.bodyText)
+        .compile
+        .toList
+        .unsafeRunSync()
+
+    val expectedErrorMessage =
+      "The request body was invalid. Attempt to decode value on failed cursor: DownField(something1)"
+
+    actualErrorMessages should (have length (1))
+    actualErrorMessages.head should equal(expectedErrorMessage)
+    actualResponse.status should equal(Status.UnprocessableEntity)
+  }
+
+  test("should succeed when body is valid") {
+    val validJson = Json.obj(
+      ("something1") -> Json.fromInt(1),
+      ("something2") -> Json.fromString("something")
+    )
+    val request        = sendRequest(server, validJson)
+    val actualResponse = request.use(_.pure[IO]).unsafeRunSync()
+
+    actualResponse.status should equal(Status.NoContent)
+  }
+}

--- a/modules/sample-http4s-v0_22/src/test/scala/core/Http4s/Http4sFullTracerTest.scala
+++ b/modules/sample-http4s-v0_22/src/test/scala/core/Http4s/Http4sFullTracerTest.scala
@@ -1,0 +1,83 @@
+package core.Http4s
+
+import _root_.tracer.client.{ http4sV022 => cdefs }
+import _root_.tracer.server.http4sV022.addresses.{ AddressesHandler, AddressesResource }
+import _root_.tracer.server.http4sV022.addresses.AddressesResource.{ GetAddressResponse, GetAddressesResponse }
+import _root_.tracer.server.http4sV022.users.{ UsersHandler, UsersResource }
+import _root_.tracer.server.http4sV022.users.UsersResource.GetUserResponse
+import _root_.tracer.server.{ http4sV022 => sdefs }
+import _root_.tracer.client.http4sV022.users.UsersClient
+import _root_.tracer.client.http4sV022.addresses.AddressesClient
+import _root_.tracer.server.http4sV022.Http4sImplicits.TraceBuilder
+import cats.effect.IO
+import org.http4s.{ Header, HttpRoutes, Request }
+import org.http4s.client.Client
+import org.http4s.implicits._
+import org.http4s.syntax.StringSyntax
+import org.scalatest.EitherValues
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+import org.typelevel.ci.CIString
+
+class Http4sFullTracerTest extends AnyFunSuite with Matchers with EitherValues with StringSyntax {
+
+  val traceHeaderKey          = "tracer-label"
+  def log(line: String): Unit = ()
+
+  def trace: String => Request[IO] => TraceBuilder[IO] = { name => request =>
+    // In a real environment, this would be where you could establish a new
+    // tracing context and inject that fresh header value.
+    log(s"Expecting all requests to have ${traceHeaderKey} header.")
+    traceBuilder(request.headers.get(CIString(traceHeaderKey)).get.head.value)
+  }
+
+  def traceBuilder(parentValue: String): TraceBuilder[IO] = { name => httpClient =>
+    Client { req =>
+      httpClient.run(req.putHeaders((traceHeaderKey, parentValue)))
+    }
+  }
+
+  test("full tracer: passing headers through multiple levels") {
+    // Establish the "Address" server
+    val server2: HttpRoutes[IO] =
+      new AddressesResource(trace).routes(
+        new AddressesHandler[IO] {
+          def getAddress(respond: GetAddressResponse.type)(id: String)(traceBuilder: TraceBuilder[IO]) =
+            IO.pure(if (id == "addressId") {
+              respond.Ok(sdefs.definitions.Address(Some("line1"), Some("line2"), Some("line3")))
+            } else GetAddressResponse.NotFound)
+          def getAddresses(respond: GetAddressesResponse.type)()(traceBuilder: TraceBuilder[IO]) =
+            IO.pure(GetAddressesResponse.NotFound)
+        }
+      )
+
+    // Establish the "User" server
+    val server1: HttpRoutes[IO] =
+      new UsersResource(trace).routes(
+        new UsersHandler[IO] {
+          // ... using the "Address" server explicitly in the addressesClient
+          val addressesClient = AddressesClient.httpClient(Client.fromHttpApp(server2.orNotFound))
+          def getUser(respond: GetUserResponse.type)(id: String)(traceBuilder: TraceBuilder[IO]) =
+            addressesClient
+              .getAddress(traceBuilder, "addressId")
+              .map {
+                case cdefs.addresses.GetAddressResponse.Ok(address) =>
+                  respond.Ok(sdefs.definitions.User("1234", sdefs.definitions.UserAddress(address.line1, address.line2, address.line3)))
+                case cdefs.addresses.GetAddressResponse.NotFound => respond.NotFound
+              }
+        }
+      )
+
+    // Build a UsersClient using the User server
+    val usersClient = UsersClient.httpClient(Client.fromHttpApp(server1.orNotFound))
+    // As this is the entry point, we either have a tracing header from
+    // somewhere else, or we generate one for top-level request.
+    val testTrace = traceBuilder("top-level-request")
+
+    // Make a request against the mock servers using a hard-coded user ID
+    val retrieved: cdefs.users.GetUserResponse = usersClient.getUser(testTrace, "1234").attempt.unsafeRunSync().value
+
+    retrieved shouldBe cdefs.users.GetUserResponse
+      .Ok(cdefs.definitions.User("1234", cdefs.definitions.UserAddress(Some("line1"), Some("line2"), Some("line3"))))
+  }
+}

--- a/modules/sample-http4s-v0_22/src/test/scala/core/Http4s/Http4sMixedContentTypesTest.scala
+++ b/modules/sample-http4s-v0_22/src/test/scala/core/Http4s/Http4sMixedContentTypesTest.scala
@@ -1,0 +1,41 @@
+package core.Http4s
+
+import _root_.mixedContentTypes.client.{ http4sV022 => generatedClient }
+import _root_.mixedContentTypes.server.http4sV022.Resource._
+import _root_.mixedContentTypes.server.http4sV022._
+import _root_.mixedContentTypes.server.http4sV022.definitions.Error
+import cats.effect.IO
+import cats.effect.IO._
+import org.http4s.client.Client
+import org.http4s.implicits._
+import org.scalatest.EitherValues
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+class Http4sMixedContentTypesTest extends AnyFunSuite with Matchers with EitherValues {
+
+  test("handle text/plain") {
+    val server = new Resource[IO]().routes(new Handler[IO] {
+      override def doFoo(respond: DoFooResponse.type)(): IO[DoFooResponse] =
+        IO.pure(respond.Ok("resp"))
+    })
+
+    val client = generatedClient.Client.httpClient(Client.fromHttpApp(server.orNotFound), "http://localhost:1234")
+
+    val actual = client.doFoo(Nil).attempt.unsafeRunSync().value
+    actual shouldBe generatedClient.DoFooResponse.Ok("resp")
+  }
+
+  test("handle application/json") {
+    val server = new Resource[IO]().routes(new Handler[IO] {
+      override def doFoo(respond: DoFooResponse.type)(): IO[DoFooResponse] =
+        IO.pure(respond.BadRequest(Error(Some("err"))))
+    })
+
+    val client = generatedClient.Client.httpClient(Client.fromHttpApp(server.orNotFound), "http://localhost:1234")
+
+    val actual = client.doFoo(Nil).attempt.unsafeRunSync().value
+    actual shouldBe generatedClient.DoFooResponse.BadRequest(generatedClient.definitions.Error(Some("err")))
+  }
+
+}

--- a/modules/sample-http4s-v0_22/src/test/scala/core/Http4s/Http4sNonStringEnumerationTest.scala
+++ b/modules/sample-http4s-v0_22/src/test/scala/core/Http4s/Http4sNonStringEnumerationTest.scala
@@ -1,0 +1,117 @@
+package core.Http4s
+
+import java.security.MessageDigest
+import java.util.Locale.US
+
+import cats.effect.IO
+import cats.effect.IO._
+import fs2.Stream
+import javax.xml.bind.DatatypeConverter.printHexBinary
+import io.circe.Json
+import org.http4s.circe._
+import org.http4s.client.Client
+import org.http4s.implicits._
+import org.http4s.dsl.io._
+import org.http4s.{ HttpRoutes, Method, Request, Uri }
+import org.scalatest.exceptions.TestFailedException
+import org.scalatest.EitherValues
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+import _root_.enumerations.client.http4sV022.foo.{ DoFooResponse => ClientDoFooResponse, FooClient }
+import _root_.enumerations.client.http4sV022.{ definitions => cdefs }
+import _root_.enumerations.server.http4sV022.foo._
+import _root_.enumerations.server.http4sV022.foo.FooResource._
+import _root_.enumerations.server.http4sV022.{ definitions => sdefs }
+
+class Http4sNonStringEnumerationTest extends AnyFunSuite with Matchers with EitherValues {
+
+  def cond[A](pred: Boolean, message: String): IO[Unit] =
+    if (pred) {
+      IO.pure(())
+    } else {
+      IO.raiseError(new Throwable(message))
+    }
+
+  test("round-trip: Ensure enumerations are unpacked correctly") {
+    val expectedInt      = cdefs.IntEnum.IntEnum1
+    val expectedLong     = cdefs.LongEnum.LongEnum2
+    val expectedString   = cdefs.StringEnum.ILikeSpaces
+    val expectedBody     = cdefs.IntEnum.IntEnum3
+    val expectedResponse = cdefs.StringEnum.ILikeSpaces
+
+    val httpService = new FooResource[IO]().routes(new FooHandler[IO] {
+      def doFoo(
+          respond: DoFooResponse.type
+      )(intEnum: sdefs.IntEnum, longEnum: Option[sdefs.LongEnum], stringEnum: Option[sdefs.StringEnum], body: sdefs.IntEnum): IO[DoFooResponse] =
+        for {
+          _ <- cond(intEnum.value == expectedInt.value, "intEnum value did not match")
+          _ <- cond(longEnum.exists(_.value == expectedLong.value), "longEnum value did not match")
+          _ <- cond(stringEnum.exists(_.value == expectedString.value), "stringEnum value did not match")
+          _ <- cond(body.value == expectedBody.value, "body value did not match")
+        } yield respond.Created(sdefs.StringEnum.ILikeSpaces)
+    })
+
+    val fooClient = FooClient.httpClient(Client.fromHttpApp(httpService.orNotFound), "http://localhost:1234")
+
+    fooClient.doFoo(expectedInt, Some(expectedLong), Some(expectedString), expectedBody).attempt.unsafeRunSync() should be(
+      Right(ClientDoFooResponse.Created(expectedResponse))
+    )
+  }
+
+  test("raw client: Ensure enumerations are unpacked correctly") {
+    val expectedInt      = cdefs.IntEnum.IntEnum1
+    val expectedLong     = cdefs.LongEnum.LongEnum2
+    val expectedString   = cdefs.StringEnum.ILikeSpaces
+    val expectedBody     = cdefs.IntEnum.IntEnum3
+    val expectedResponse = cdefs.StringEnum.ILikeSpaces
+
+    val httpService = new FooResource[IO]().routes(new FooHandler[IO] {
+      def doFoo(
+          respond: DoFooResponse.type
+      )(intEnum: sdefs.IntEnum, longEnum: Option[sdefs.LongEnum], stringEnum: Option[sdefs.StringEnum], body: sdefs.IntEnum): IO[DoFooResponse] =
+        for {
+          _ <- cond(intEnum.value == expectedInt.value, "intEnum value did not match")
+          _ <- cond(longEnum.exists(_.value == expectedLong.value), "longEnum value did not match")
+          _ <- cond(stringEnum.exists(_.value == expectedString.value), "stringEnum value did not match")
+          _ <- cond(body.value == expectedBody.value, "body value did not match")
+        } yield respond.Created(sdefs.StringEnum.ILikeSpaces)
+    })
+
+    val client = Client.fromHttpApp(httpService.orNotFound)
+
+    val uri = Uri().withPath(Uri.Path.unsafeFromString("/foo/1")).withQueryParam("longEnum", "2").withQueryParam("stringEnum", "i like spaces")
+    client.expect[Json](Request[IO](method = Method.POST, uri = uri).withEntity("3")).attempt.unsafeRunSync() should be(
+      Right(Json.fromString(expectedResponse.value))
+    )
+  }
+
+  object LongParamMatcher   extends OptionalQueryParamDecoderMatcher[Long]("longEnum")
+  object StringParamMatcher extends OptionalQueryParamDecoderMatcher[String]("stringEnum")
+
+  test("raw server: Ensure enumerations are unpacked correctly") {
+    val expectedInt      = cdefs.IntEnum.IntEnum1
+    val expectedLong     = cdefs.LongEnum.LongEnum2
+    val expectedString   = cdefs.StringEnum.ILikeSpaces
+    val expectedBody     = cdefs.IntEnum.IntEnum3
+    val expectedResponse = cdefs.StringEnum.ILikeSpaces
+
+    val httpService = HttpRoutes.of[IO] {
+      case req @ Method.POST -> Root / "foo" / intEnum :? LongParamMatcher(longEnum) :? StringParamMatcher(stringEnum) =>
+        for {
+          body <- req.as[Json]
+          _    <- cond(intEnum == expectedInt.value.toString(), "intEnum value did not match")
+          _    <- cond(longEnum.exists(_ == expectedLong.value), "longEnum value did not match")
+          _    <- cond(stringEnum.exists(_ == expectedString.value), "stringEnum value did not match")
+          _    <- cond(body == Json.fromInt(expectedBody.value), "body value did not match")
+          resp <- Created(Json.fromString(expectedResponse.value))
+        } yield resp
+    }
+
+    val fooClient = FooClient.httpClient(Client.fromHttpApp(httpService.orNotFound), "http://localhost:1234")
+
+    fooClient.doFoo(expectedInt, Some(expectedLong), Some(expectedString), expectedBody).attempt.unsafeRunSync() should be(
+      Right(ClientDoFooResponse.Created(expectedResponse))
+    )
+  }
+}

--- a/modules/sample-http4s-v0_22/src/test/scala/core/Http4s/Http4sRawServerTest.scala
+++ b/modules/sample-http4s-v0_22/src/test/scala/core/Http4s/Http4sRawServerTest.scala
@@ -1,0 +1,20 @@
+package core.Http4s
+
+import org.http4s.dsl.io._
+import org.http4s.circe._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.funsuite.AnyFunSuite
+import _root_.raw.server.http4sV022.foo.{ FooHandler, FooResource }
+import _root_.raw.server.http4sV022.foo.FooResource.DoFooResponse
+import _root_.raw.server.http4sV022.{ definitions => sdefs }
+import cats.effect.IO
+import org.http4s.{ EntityEncoder, Response }
+
+class Http4sRawServerTest extends AnyFunSuite with Matchers {
+  test("raw server response") {
+    implicit val fooEncoder: EntityEncoder[IO, sdefs.Foo] = jsonEncoderOf[IO, sdefs.Foo]
+    new FooResource[IO]().routes(new FooHandler[IO] {
+      override def doFoo(respond: DoFooResponse.type)(): IO[Response[IO]] = Ok(sdefs.Foo(1234L))
+    })
+  }
+}

--- a/modules/sample-http4s-v0_22/src/test/scala/core/Http4s/Http4sRoundTripTest.scala
+++ b/modules/sample-http4s-v0_22/src/test/scala/core/Http4s/Http4sRoundTripTest.scala
@@ -1,0 +1,298 @@
+package core.Http4s
+
+import java.security.MessageDigest
+import java.util.Locale.US
+
+import _root_.examples.client.http4sV022.pet.PetClient
+import _root_.examples.client.{ http4sV022 => cdefs }
+import _root_.examples.server.http4sV022.pet._
+import _root_.examples.server.http4sV022.pet.PetResource._
+import _root_.examples.server.{ http4sV022 => sdefs }
+import cats.effect.IO
+import cats.effect.IO._
+import fs2.Stream
+import javax.xml.bind.DatatypeConverter.printHexBinary
+import org.http4s.client.Client
+import org.http4s.implicits._
+import org.scalatest.exceptions.TestFailedException
+import org.scalatest.EitherValues
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+import examples.support.PositiveLong
+
+class Http4sRoundTripTest extends AnyFunSuite with Matchers with EitherValues {
+
+  // Placeholder until property testing
+  val id: Option[Long]             = None
+  val categoryId: Option[Long]     = None
+  val categoryName: Option[String] = None
+  val name: String                 = ""
+  val photoUrls: Vector[String]    = Vector.empty
+  val tag1id: Option[Long]         = None
+  val tag1name: Option[String]     = None
+  val tag2id: Option[Long]         = None
+  val tag2name: Option[String]     = None
+  val tag3id: Option[Long]         = None
+  val tag3name: Option[String]     = None
+  val petStatus: Option[String]    = Some("pending")
+
+  test("round-trip: definition query, unit response") {
+    val httpService = new PetResource().routes(new PetHandler[IO] {
+      def addPet(respond: AddPetResponse.type)(body: sdefs.definitions.Pet): IO[sdefs.pet.PetResource.AddPetResponse] =
+        body match {
+          case sdefs.definitions.Pet(
+              `id`,
+              Some(sdefs.definitions.Category(`categoryId`, `categoryName`)),
+              `name`,
+              `photoUrls`,
+              None,
+              Some(sdefs.definitions.PetStatus.Pending)
+              ) =>
+            IO.pure(respond.Created)
+          case _ => throw new TestFailedException("Parameters didn't match", 11)
+        }
+      def deletePet(
+          respond: DeletePetResponse.type
+      )(_petId: Long, includeChildren: Option[Boolean], status: Option[sdefs.definitions.PetStatus], apiKey: Option[String])                  = ???
+      def findPetsByStatus(respond: FindPetsByStatusResponse.type)(status: Iterable[String])                                                  = ???
+      def findPetsByStatusEnum(respond: FindPetsByStatusEnumResponse.type)(status: sdefs.definitions.PetStatus)                               = ???
+      def findPetsByTags(respond: FindPetsByTagsResponse.type)(tags: Iterable[String])                                                        = ???
+      def getPetById(respond: GetPetByIdResponse.type)(petId: Long)                                                                           = ???
+      def updatePet(respond: UpdatePetResponse.type)(body: sdefs.definitions.Pet)                                                             = ???
+      def updatePetWithForm(respond: UpdatePetWithFormResponse.type)(petId: Long, name: Option[String] = None, status: Option[String] = None) = ???
+      def uploadFile(respond: UploadFileResponse.type)(
+          petId: PositiveLong,
+          additionalMetadata: Option[String] = None,
+          file: Option[fs2.Stream[IO, Byte]] = None,
+          file2: fs2.Stream[IO, Byte],
+          file3: fs2.Stream[IO, Byte],
+          longValue: Long,
+          customValue: PositiveLong,
+          customOptionalValue: Option[PositiveLong] = None
+      ) = ???
+    })
+
+    val petClient = PetClient.httpClient(Client.fromHttpApp(httpService.orNotFound))
+
+    petClient
+      .addPet(
+        cdefs.definitions.Pet(
+          id = id,
+          category = Some(cdefs.definitions.Category(categoryId, categoryName)),
+          name = name,
+          photoUrls = photoUrls,
+          tags = None,
+          status = Some(cdefs.definitions.PetStatus.Pending)
+        )
+      )
+      .attempt
+      .unsafeRunSync() should be(Right(cdefs.pet.AddPetResponse.Created))
+  }
+
+  test("round-trip: enum query, Vector of definition response") {
+    val httpService = new PetResource().routes(new PetHandler[IO] {
+      def findPetsByStatusEnum(
+          respond: FindPetsByStatusEnumResponse.type
+      )(_status: sdefs.definitions.PetStatus): IO[sdefs.pet.PetResource.FindPetsByStatusEnumResponse] =
+        IO.pure(petStatus.fold(Vector.empty[sdefs.definitions.Pet])({ value =>
+            if (_status.value == value) {
+              Vector(
+                sdefs.definitions.Pet(
+                  id = id,
+                  category = Some(sdefs.definitions.Category(categoryId, categoryName)),
+                  name = name,
+                  photoUrls = photoUrls,
+                  tags = None,
+                  status = sdefs.definitions.PetStatus.from(value)
+                )
+              )
+            } else {
+              throw new TestFailedException("Parameters didn't match", 11)
+            }
+          }))
+          .map(respond.Ok)
+
+      def addPet(respond: AddPetResponse.type)(body: sdefs.definitions.Pet) = ???
+      def deletePet(
+          respond: DeletePetResponse.type
+      )(_petId: Long, includeChildren: Option[Boolean], status: Option[sdefs.definitions.PetStatus], apiKey: Option[String])                  = ???
+      def findPetsByStatus(respond: FindPetsByStatusResponse.type)(status: Iterable[String])                                                  = ???
+      def findPetsByTags(respond: FindPetsByTagsResponse.type)(tags: Iterable[String])                                                        = ???
+      def getPetById(respond: GetPetByIdResponse.type)(petId: Long)                                                                           = ???
+      def updatePet(respond: UpdatePetResponse.type)(body: sdefs.definitions.Pet)                                                             = ???
+      def updatePetWithForm(respond: UpdatePetWithFormResponse.type)(petId: Long, name: Option[String] = None, status: Option[String] = None) = ???
+      def uploadFile(respond: UploadFileResponse.type)(
+          petId: PositiveLong,
+          additionalMetadata: Option[String] = None,
+          file: Option[fs2.Stream[IO, Byte]] = None,
+          file2: fs2.Stream[IO, Byte],
+          file3: fs2.Stream[IO, Byte],
+          longValue: Long,
+          customValue: PositiveLong,
+          customOptionalValue: Option[PositiveLong] = None
+      ) = ???
+    })
+
+    val petClient = PetClient.httpClient(Client.fromHttpApp(httpService.orNotFound))
+
+    petClient.findPetsByStatusEnum(cdefs.definitions.PetStatus.Pending).attempt.unsafeRunSync() should be(
+      Right(
+        cdefs.pet.FindPetsByStatusEnumResponse.Ok(
+          Vector(
+            cdefs.definitions.Pet(
+              id = id,
+              category = Some(cdefs.definitions.Category(categoryId, categoryName)),
+              name = name,
+              photoUrls = photoUrls,
+              tags = None,
+              status = Some(cdefs.definitions.PetStatus.Pending)
+            )
+          )
+        )
+      )
+    )
+  }
+
+  test("round-trip: 404 response") {
+    val httpService = new PetResource().routes(new PetHandler[IO] {
+      def findPetsByStatus(respond: FindPetsByStatusResponse.type)(status: Iterable[String]): IO[sdefs.pet.PetResource.FindPetsByStatusResponse] =
+        IO.pure(respond.NotFound)
+
+      def addPet(respond: AddPetResponse.type)(body: sdefs.definitions.Pet) = ???
+      def deletePet(
+          respond: DeletePetResponse.type
+      )(_petId: Long, includeChildren: Option[Boolean], status: Option[sdefs.definitions.PetStatus], apiKey: Option[String])                  = ???
+      def findPetsByStatusEnum(respond: FindPetsByStatusEnumResponse.type)(status: sdefs.definitions.PetStatus)                               = ???
+      def findPetsByTags(respond: FindPetsByTagsResponse.type)(tags: Iterable[String])                                                        = ???
+      def getPetById(respond: GetPetByIdResponse.type)(petId: Long)                                                                           = ???
+      def updatePet(respond: UpdatePetResponse.type)(body: sdefs.definitions.Pet)                                                             = ???
+      def updatePetWithForm(respond: UpdatePetWithFormResponse.type)(petId: Long, name: Option[String] = None, status: Option[String] = None) = ???
+      def uploadFile(respond: UploadFileResponse.type)(
+          petId: PositiveLong,
+          additionalMetadata: Option[String] = None,
+          file: Option[fs2.Stream[IO, Byte]] = None,
+          file2: fs2.Stream[IO, Byte],
+          file3: fs2.Stream[IO, Byte],
+          longValue: Long,
+          customValue: PositiveLong,
+          customOptionalValue: Option[PositiveLong] = None
+      ) = ???
+    })
+
+    val petClient = PetClient.httpClient(Client.fromHttpApp(httpService.orNotFound))
+
+    petClient.findPetsByStatus(Vector("bogus")).attempt.unsafeRunSync() should be(Right(cdefs.pet.FindPetsByStatusResponse.NotFound))
+  }
+
+  test("round-trip: Raw type parameters") {
+    val petId: Long    = 123L
+    val apiKey: String = "foobar"
+    val httpService = new PetResource().routes(new PetHandler[IO] {
+      def deletePet(respond: DeletePetResponse.type)(
+          _petId: Long,
+          includeChildren: Option[Boolean],
+          status: Option[sdefs.definitions.PetStatus],
+          _apiKey: Option[String] = None
+      ): IO[sdefs.pet.PetResource.DeletePetResponse] =
+        if (_petId == petId && _apiKey.contains(apiKey) && status.contains(sdefs.definitions.PetStatus.Pending))
+          IO.pure(respond.Ok)
+        else IO.pure(respond.NotFound)
+
+      def addPet(respond: AddPetResponse.type)(body: sdefs.definitions.Pet)                                                                   = ???
+      def findPetsByStatus(respond: FindPetsByStatusResponse.type)(status: Iterable[String])                                                  = ???
+      def findPetsByStatusEnum(respond: FindPetsByStatusEnumResponse.type)(status: sdefs.definitions.PetStatus)                               = ???
+      def findPetsByTags(respond: FindPetsByTagsResponse.type)(tags: Iterable[String])                                                        = ???
+      def getPetById(respond: GetPetByIdResponse.type)(petId: Long)                                                                           = ???
+      def updatePet(respond: UpdatePetResponse.type)(body: sdefs.definitions.Pet)                                                             = ???
+      def updatePetWithForm(respond: UpdatePetWithFormResponse.type)(petId: Long, name: Option[String] = None, status: Option[String] = None) = ???
+      def uploadFile(respond: UploadFileResponse.type)(
+          petId: PositiveLong,
+          additionalMetadata: Option[String] = None,
+          file: Option[fs2.Stream[IO, Byte]] = None,
+          file2: fs2.Stream[IO, Byte],
+          file3: fs2.Stream[IO, Byte],
+          longValue: Long,
+          customValue: PositiveLong,
+          customOptionalValue: Option[PositiveLong] = None
+      ) = ???
+    })
+
+    val petClient = PetClient.httpClient(Client.fromHttpApp(httpService.orNotFound))
+
+    val result = petClient.deletePet(petId, Some(true), Some(cdefs.definitions.PetStatus.Pending), Some(apiKey)).attempt.unsafeRunSync()
+    result.left
+      .foreach({ err =>
+        throw new TestFailedException(err.toString, 11)
+      })
+  }
+
+  test("round-trip: File uploads") {
+    val petId: Long    = 123L
+    val apiKey: String = "foobar"
+    val httpService = new PetResource().routes(new PetHandler[IO] {
+      def addPet(respond: AddPetResponse.type)(body: sdefs.definitions.Pet) = ???
+      def deletePet(
+          respond: DeletePetResponse.type
+      )(_petId: Long, includeChildren: Option[Boolean], status: Option[sdefs.definitions.PetStatus], apiKey: Option[String])                  = ???
+      def findPetsByStatus(respond: FindPetsByStatusResponse.type)(status: Iterable[String])                                                  = ???
+      def findPetsByStatusEnum(respond: FindPetsByStatusEnumResponse.type)(status: sdefs.definitions.PetStatus)                               = ???
+      def findPetsByTags(respond: FindPetsByTagsResponse.type)(tags: Iterable[String])                                                        = ???
+      def getPetById(respond: GetPetByIdResponse.type)(petId: Long)                                                                           = ???
+      def updatePet(respond: UpdatePetResponse.type)(body: sdefs.definitions.Pet)                                                             = ???
+      def updatePetWithForm(respond: UpdatePetWithFormResponse.type)(petId: Long, name: Option[String] = None, status: Option[String] = None) = ???
+      def uploadFile(respond: UploadFileResponse.type)(
+          petId: PositiveLong,
+          additionalMetadata: Option[String] = None,
+          file: Option[fs2.Stream[IO, Byte]] = None,
+          file2: fs2.Stream[IO, Byte],
+          file3: fs2.Stream[IO, Byte],
+          longValue: Long,
+          customValue: PositiveLong,
+          customOptionalValue: Option[PositiveLong] = None
+      ) =
+        for {
+          f1Content <- file.fold(IO.pure(Vector.empty[Byte]))(_.compile.toVector)
+          f1Length = if (f1Content.nonEmpty) Some(f1Content.length) else None
+          f2Content <- file2.compile.toVector
+          f2Length = if (f2Content.nonEmpty) {
+            Some(f2Content.length)
+          } else None
+          f3Content <- file3.compile.toVector
+          f3Length = if (f3Content.nonEmpty) {
+            Some(f3Content.length)
+          } else None
+
+          hash = printHexBinary(MessageDigest.getInstance("SHA-256").digest(f3Content.toArray)).toLowerCase(US)
+          _    = assert(hash == "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", "Empty file hash does not match")
+
+          code = f1Length.count(_ > 0) + (if (f2Content.nonEmpty) 1 else 0) + (if (f3Content.nonEmpty) 1 else 0)
+
+        } yield respond.Ok(sdefs.definitions.ApiResponse(code = Some(code), message = Some(s"${f1Length} ${f2Length} ${f3Length}")))
+    })
+
+    val petClient = PetClient.httpClient(Client.fromHttpApp(httpService.orNotFound))
+
+    val result = petClient
+      .uploadFile(
+        PositiveLong(petId).get,
+        Some("Additional metadata"),
+        None,
+        ("file2", Stream.empty),
+        ("file3", Stream.empty),
+        5L,
+        PositiveLong(10L).get,
+        PositiveLong(20L)
+      )
+      .attempt
+      .unsafeRunSync
+    result
+      .fold(
+        { err =>
+          throw new TestFailedException(err.toString, 11)
+        }, {
+          case cdefs.pet.UploadFileResponse.Ok(value) => assert(value.code.contains(0), "Unexpected number of file uploads!")
+        }
+      )
+  }
+}

--- a/modules/sample-http4s-v0_22/src/test/scala/core/issues/Issue121.scala
+++ b/modules/sample-http4s-v0_22/src/test/scala/core/issues/Issue121.scala
@@ -1,0 +1,71 @@
+package core.issues
+
+import cats.effect.IO
+import cats.data.Kleisli
+import org.http4s._
+import org.http4s.client.{ Client => Http4sClient }
+import org.http4s.blaze.client._
+import org.http4s.headers._
+import org.http4s.implicits._
+import org.http4s.multipart._
+import cats.instances.future._
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.time.SpanSugar._
+import org.scalatest.EitherValues
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+import io.circe._
+
+class Issue121Suite extends AnyFunSuite with Matchers with EitherValues with ScalaFutures {
+  override implicit val patienceConfig = PatienceConfig(10 seconds, 1 second)
+
+  test("http4s server can respond with 204") {
+    import issues.issue121.server.http4sV022.{ Handler, Resource }
+    import issues.issue121.server.http4sV022.Resource.DeleteFooResponse
+
+    val route = new Resource[IO]().routes(new Handler[IO] {
+      override def deleteFoo(respond: DeleteFooResponse.type)(id: Long): IO[DeleteFooResponse] =
+        IO.pure(respond.NoContent)
+    })
+
+    val client = Http4sClient.fromHttpApp[IO](route.orNotFound)
+
+    val req = Request[IO](method = Method.DELETE, uri = Uri.unsafeFromString("/entity")).withEntity(UrlForm("id" -> "1234"))
+
+    client
+      .run(req)
+      .use({
+        case Status.NoContent(resp) =>
+          IO.pure({
+            resp.status should equal(Status.NoContent)
+            resp.contentType should equal(None)
+            resp.contentLength should equal(None)
+            ()
+          })
+      })
+      .unsafeRunSync()
+  }
+
+  test("http4s client can respond with 204") {
+    import issues.issue121.client.http4sV022.Client
+
+    def noContentResponse: Http4sClient[IO] =
+      Http4sClient.fromHttpApp[IO](Kleisli.pure(Response[IO](Status.NoContent)))
+
+    /* Correct mime type
+     * Missing content
+     */
+    Client
+      .httpClient(noContentResponse, "http://localhost:80")
+      .deleteFoo(1234)
+      .attempt
+      .unsafeRunSync()
+      .fold(
+        _ => fail("Error"),
+        _.fold(
+          handleNoContent = ()
+        )
+      )
+  }
+}

--- a/modules/sample-http4s-v0_22/src/test/scala/core/issues/Issue1218.scala
+++ b/modules/sample-http4s-v0_22/src/test/scala/core/issues/Issue1218.scala
@@ -1,0 +1,112 @@
+package core.issues
+
+import scala.language.{ higherKinds, reflectiveCalls }
+
+import cats.effect.IO
+import cats.data.{ Kleisli, ValidatedNel }
+import org.http4s._
+import org.http4s.client.{ Client => Http4sClient }
+import org.http4s.blaze.client._
+import org.http4s.headers._
+import org.http4s.implicits._
+import org.http4s.multipart._
+import cats.instances.future._
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.time.SpanSugar._
+import org.scalatest.EitherValues
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+import io.circe._
+import org.scalatest.enablers.Aggregating
+import org.scalactic.Equality
+import org.http4s.dsl.impl.{ OptionalMultiQueryParamDecoderMatcher, QueryParamDecoderMatcher }
+
+class Issue1218Suite extends AnyFunSuite with Matchers with EitherValues with ScalaFutures {
+  override implicit val patienceConfig = PatienceConfig(10 seconds, 1 second)
+
+  // Hackily provide Aggregating instance for Option
+  implicit def aggregatingOption[A](implicit ev: Equality[A]): Aggregating[Option[A]] = new Aggregating[Option[A]] {
+    val proxy = Aggregating.aggregatingNatureOfGenTraversable[A, Iterable](ev)
+
+    def containsAllOf(aggregation: Option[A], eles: _root_.scala.collection.Seq[Any]): Boolean        = proxy.containsAllOf(aggregation, eles)
+    def containsAtLeastOneOf(aggregation: Option[A], eles: _root_.scala.collection.Seq[Any]): Boolean = proxy.containsAtLeastOneOf(aggregation, eles)
+    def containsAtMostOneOf(aggregation: Option[A], eles: _root_.scala.collection.Seq[Any]): Boolean  = proxy.containsAtMostOneOf(aggregation, eles)
+    def containsOnly(aggregation: Option[A], eles: _root_.scala.collection.Seq[Any]): Boolean         = proxy.containsOnly(aggregation, eles)
+    def containsTheSameElementsAs(leftAggregation: Option[A], rightAggregation: _root_.scala.collection.GenTraversable[Any]): Boolean =
+      proxy.containsTheSameElementsAs(leftAggregation, rightAggregation)
+  }
+
+  class CompareQueryParamDecoderMatcherHolder[A, Container[_]](val dummy: Boolean = true) {
+    def apply[
+        Ours <: { def unapply(params: Map[String, _root_.scala.collection.Seq[String]]): Option[Container[A]] }
+    ](
+        ours: Ours,
+        key: String
+    )(implicit ev1: Equality[A], ev2: Aggregating[Container[A]], ev3: QueryParamDecoder[A]): Map[String, _root_.scala.collection.Seq[String]] => Unit = {
+      cases =>
+        val theirs = new QueryParamDecoderMatcher[A](key) {}
+
+        cases.foreach {
+          case (label, values) =>
+            val params = Map(key -> values)
+            ours.unapply(params) should contain theSameElementsAs (theirs.unapplySeq(params))
+        }
+    }
+  }
+  def compareQPDM[A, Container[_]]: CompareQueryParamDecoderMatcherHolder[A, Container] = new CompareQueryParamDecoderMatcherHolder[A, Container]()
+
+  class CompareOptionalMultiQueryParamDecoderMatcherHolder[A, Container[_]](val dummy: Boolean = true) {
+    def apply[
+        Ours <: { def unapply(params: Map[String, collection.Seq[String]]): Option[Option[Container[A]]] }
+    ](ours: Ours, key: String)(implicit ev1: Equality[A], ev2: Aggregating[Container[A]], ev3: QueryParamDecoder[A]): Map[String, Seq[String]] => Unit = {
+      cases =>
+        val theirs = new OptionalMultiQueryParamDecoderMatcher[A](key) {}
+
+        cases.foreach {
+          case (label, values) =>
+            val params = Map(key -> values)
+            ours.unapply(params) should contain theSameElementsAs (theirs.unapply(params).collectFirst {
+              case cats.data.Validated.Valid(value) => Option(value).filter(_.nonEmpty)
+            })
+        }
+    }
+  }
+  def compareOMQPDM[A, Container[_]]: CompareOptionalMultiQueryParamDecoderMatcherHolder[A, Container] =
+    new CompareOptionalMultiQueryParamDecoderMatcherHolder[A, Container]()
+
+  test("All query parameter matchers behave the same as in-built ones") {
+    val resource = new issues.issue1218.server.http4sV022.Resource[IO]()
+
+    val stringCases = Map[String, Seq[String]](
+      "empty"     -> Seq.empty,
+      "single"    -> Seq("foo"),
+      "double"    -> Seq("foo", "bar"),
+      "repeating" -> Seq("foo", "foo")
+    )
+
+    val longCases = Map[String, Seq[String]](
+      "empty"     -> Seq.empty,
+      "single"    -> Seq("123"),
+      "double"    -> Seq("123", "234"),
+      "repeating" -> Seq("123", "123")
+    )
+
+    compareOMQPDM[Long, Iterable](resource.DoFooOptrefidxseqMatcher, "optrefidxseq").apply(longCases)
+    compareOMQPDM[Long, List](resource.DoFooOptreflistMatcher, "optreflist").apply(longCases)
+    compareOMQPDM[Long, Seq](resource.DoFooOptrefseqMatcher, "optrefseq").apply(longCases)
+    compareOMQPDM[Long, Vector](resource.DoFooOptrefvecMatcher, "optrefvec").apply(longCases)
+    compareOMQPDM[String, Iterable](resource.DoFooOptidxseqMatcher, "optidxseq").apply(stringCases)
+    compareOMQPDM[String, Iterable](resource.DoFooOptlistMatcher, "optlist").apply(stringCases)
+    compareOMQPDM[String, Iterable](resource.DoFooOptseqMatcher, "optseq").apply(stringCases)
+    compareOMQPDM[String, Iterable](resource.DoFooOptvectorMatcher, "optvector").apply(stringCases)
+    compareQPDM[Long, IndexedSeq](resource.DoFooRefidxseqMatcher, "refidxseq").apply(longCases)
+    compareQPDM[Long, List](resource.DoFooReflistMatcher, "reflist").apply(longCases)
+    compareQPDM[Long, Seq](resource.DoFooRefseqMatcher, "refseq").apply(longCases)
+    compareQPDM[Long, Vector](resource.DoFooRefvecMatcher, "refvec").apply(longCases)
+    compareQPDM[String, Iterable](resource.DoFooIdxseqMatcher, "idxseq").apply(stringCases)
+    compareQPDM[String, Iterable](resource.DoFooListMatcher, "list").apply(stringCases)
+    compareQPDM[String, Iterable](resource.DoFooSeqMatcher, "seq").apply(stringCases)
+    compareQPDM[String, Iterable](resource.DoFooVectorMatcher, "vector").apply(stringCases)
+  }
+}

--- a/modules/sample-http4s-v0_22/src/test/scala/core/issues/Issue1229.scala
+++ b/modules/sample-http4s-v0_22/src/test/scala/core/issues/Issue1229.scala
@@ -1,0 +1,40 @@
+package core.issues
+
+import _root_.department.client.http4sV022.department.{ DepartmentClient, GetDepartmentResponse => ClientGDR, SearchDepartmentsResponse => ClientSDR }
+import _root_.department.client.http4sV022.department.{ DepartmentClient, GetDepartmentResponse => ClientGDR, SearchDepartmentsResponse => ClientSDR }
+import _root_.department.client.http4sV022.{ definitions => cdefs }
+import _root_.department.server.http4sV022.department._
+import _root_.department.server.http4sV022.department.DepartmentResource._
+import _root_.department.server.http4sV022.{ definitions => sdefs }
+import cats.effect.IO
+import cats.effect.IO._
+import org.http4s.client.Client
+import org.http4s.implicits._
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+class Issue1229Suite extends AnyFunSuite with Matchers {
+  test("round-trip: definition query, unit response") {
+    val httpService = new DepartmentResource().routes(new DepartmentHandler[IO] {
+      val fooDept                                                                                               = sdefs.Department("123", "foo", "bar")
+      def getDepartment(respond: GetDepartmentResponse.type)(id: String): cats.effect.IO[GetDepartmentResponse] = IO.pure(respond.Ok(fooDept))
+      def searchDepartments(
+          respond: SearchDepartmentsResponse.type
+      )(query: Option[String], page: Int, pageSize: Int, sort: Option[Iterable[String]]): cats.effect.IO[SearchDepartmentsResponse] =
+        IO.pure(respond.Ok(sdefs.DepartmentSearchResponse(Vector(fooDept), 0, 0, 0)))
+    })
+
+    val departmentClient = DepartmentClient.httpClient(Client.fromHttpApp(httpService.orNotFound), "http://localhost")
+
+    val fooDept = cdefs.Department("123", "foo", "bar")
+    departmentClient
+      .getDepartment(fooDept.id)
+      .attempt
+      .unsafeRunSync() should be(Right(ClientGDR.Ok(fooDept)))
+
+    departmentClient
+      .searchDepartments(None, 0, 0, None)
+      .attempt
+      .unsafeRunSync() should be(Right(ClientSDR.Ok(cdefs.DepartmentSearchResponse(Vector(fooDept), 0, 0, 0))))
+  }
+}

--- a/modules/sample-http4s-v0_22/src/test/scala/core/issues/Issue148.scala
+++ b/modules/sample-http4s-v0_22/src/test/scala/core/issues/Issue148.scala
@@ -1,0 +1,268 @@
+package core.issues
+
+import io.circe._
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.time.SpanSugar._
+import org.scalatest.EitherValues
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+/** Changes
+  *
+  * - Server request body validation
+  * - Client responses
+  *   - No content vs Partial content vs Invalid content
+  * - Polymorphic discriminator error messages
+  */
+class Issue148Suite extends AnyFunSuite with Matchers with EitherValues with ScalaFutures {
+  override implicit val patienceConfig = PatienceConfig(10 seconds, 1 second)
+
+  test("http4s server request body validation") {
+    import cats.effect.IO
+    import issues.issue148.server.http4sV022.definitions._
+    import issues.issue148.server.http4sV022._
+    import issues.issue148.server.http4sV022.Resource._
+    import org.http4s._
+    import org.http4s.client.Client
+    import org.http4s.headers._
+    import org.http4s.implicits._
+    import org.http4s.multipart._
+
+    val route = new Resource[IO]().routes(new Handler[IO] {
+      override def createFoo(respond: CreateFooResponse.type)(body: Foo, xHeader: Boolean, xOptionalHeader: Option[Boolean]): IO[CreateFooResponse] =
+        IO.pure(respond.Ok(body))
+      override def getFoo(respond: GetFooResponse.type)(): IO[GetFooResponse] =
+        IO.pure(respond.Ok(Bar("bar")))
+      override def updateFoo(respond: UpdateFooResponse.type)(name: Boolean, bar: Option[Boolean]): IO[UpdateFooResponse] =
+        IO.pure(respond.Accepted(Bar("bar")))
+    })
+
+    val client = Client.fromHttpApp[IO](route.orNotFound)
+    def failedResponseBody(req: Request[IO]): String =
+      client
+        .run(req)
+        .use({
+          case Status.BadRequest(resp) =>
+            resp.as[String]
+          case Status.UnprocessableEntity(resp) =>
+            resp.as[String]
+        })
+        .unsafeRunSync()
+
+    def makeJsonRequest(body: String): Request[IO] =
+      Request[IO](method = Method.POST, uri = Uri.unsafeFromString("/test"))
+        .withEntity(body)(
+          EntityEncoder[IO, String]
+            .withContentType(`Content-Type`(MediaType.application.json).withCharset(DefaultCharset))
+        )
+
+    def makeFormRequest(body: Multipart[IO]): Request[IO] =
+      Request[IO](method = Method.PUT, uri = Uri.unsafeFromString("/test"))
+        .withEntity(body)
+
+    /* Correct mime type
+     * Missing content
+     */
+    failedResponseBody(makeJsonRequest("")) should equal("The request body was malformed.")
+
+    /* Correct mime type
+     * Invalid JSON
+     */
+    failedResponseBody(makeJsonRequest("{")) should equal("The request body was malformed.")
+
+    /* Correct mime type
+     * Valid JSON
+     * Missing discriminator
+     */
+    failedResponseBody(makeJsonRequest("{}")) should equal(
+      "The request body was invalid. Attempt to decode value on failed cursor: DownField(type)"
+    )
+
+    /* Correct mime type
+     * Valid JSON
+     * Invalid discriminator
+     */
+    failedResponseBody(makeJsonRequest("""{"type": "blep"}""")) should equal(
+      "The request body was invalid. Unknown value blep (valid: Bar): DownField(type)"
+    )
+
+    /* Correct mime type
+     * Valid JSON
+     * Valid discriminator
+     * Missing "name" field
+     */
+    failedResponseBody(makeJsonRequest("""{"type": "Bar"}""")) should equal(
+      "The request body was invalid. Attempt to decode value on failed cursor: DownField(name)"
+    )
+
+    val validEntity = """{"type": "Bar", "name": "bar"}"""
+
+    /* Correct mime type
+     * Valid JSON
+     * Valid discriminator
+     * Valid "name" field
+     * Invalid "x-header" value
+     */
+    failedResponseBody(
+      makeJsonRequest(validEntity).withHeaders(
+        Headers(
+          ("x-header", "foo")
+        )
+      )
+    ) should equal("Invalid data")
+
+    /* Correct mime type
+     * Valid JSON
+     * Valid discriminator
+     * Valid "name" field
+     * Valid "x-header" value
+     * Invalid "x-optional-header" value
+     */
+    // TODO: https://github.com/guardrail-dev/guardrail/issues/155
+    // `x-header` is currently never parsed correctly due to #155
+    // Once this is fixed, this test will still fail due to `x-optional-header`,
+    // but this is intentional for this test case.
+    failedResponseBody(
+      makeJsonRequest(validEntity).withHeaders(
+        Headers(
+          ("x-header", "false"),
+          ("x-optional-header", "foo")
+        )
+      )
+    ) should equal("Invalid data")
+
+    /* Correct entity mime type
+     * Invalid mime type for "foo" body part
+     */
+    // TODO: https://github.com/guardrail-dev/guardrail/issues/155
+    failedResponseBody(
+      makeFormRequest(
+        Multipart(
+          Vector(
+            Part.formData[IO]("foo", "blep")
+          )
+        )
+      )
+    ) should equal("The request body was malformed.")
+
+    /* Correct entity mime type
+     * Valid mime type for "foo" body part
+     * Invalid content for "foo" body part
+     */
+    // TODO: https://github.com/guardrail-dev/guardrail/issues/155
+    failedResponseBody(
+      makeFormRequest(
+        Multipart(
+          Vector(
+            Part.formData[IO]("foo", "blep", ("Content-Type", "application/json"))
+          )
+        )
+      )
+    ) should equal("The request body was malformed.")
+
+    /* Correct entity mime type
+     * Valid mime type for "foo" body part
+     * Valid content for "foo" body part
+     * Invalid mime type for "bar" body part
+     */
+    // TODO: https://github.com/guardrail-dev/guardrail/issues/155
+    failedResponseBody(
+      makeFormRequest(
+        Multipart(
+          Vector(
+            Part.formData[IO]("foo", "false", ("Content-Type", "application/json")),
+            Part.formData[IO]("bar", "blep")
+          )
+        )
+      )
+    ) should equal("The request body was malformed.")
+
+    /* Correct entity mime type
+     * Valid mime type for "foo" body part
+     * Valid content for "foo" body part
+     * Valid mime type for "bar" body part
+     * Invalid content for "bar" body part
+     */
+    // TODO: https://github.com/guardrail-dev/guardrail/issues/155
+    failedResponseBody(
+      makeFormRequest(
+        Multipart(
+          Vector(
+            Part.formData[IO]("foo", "false", ("Content-Type", "application/json")),
+            Part.formData[IO]("bar", "blep", ("Content-Type", "application/json"))
+          )
+        )
+      )
+    ) should equal("The request body was malformed.")
+  }
+
+  test("http4s client response body validation") {
+    import cats.data.Kleisli
+    import cats.effect.IO
+    import issues.issue148.client.http4sV022.Client
+    import org.http4s._
+    import org.http4s.client.{ Client => Http4sClient }
+    import org.http4s.headers._
+
+    def jsonResponse(str: String): Http4sClient[IO] =
+      Http4sClient.fromHttpApp[IO](
+        Kleisli.pure(
+          Response[IO](Status.Ok)
+            .withEntity(str)(
+              EntityEncoder[IO, String]
+                .withContentType(`Content-Type`(MediaType.application.json).withCharset(DefaultCharset))
+            )
+        )
+      )
+
+    /* Correct mime type
+     * Missing content
+     */
+    Client.httpClient(jsonResponse(""), "http://localhost:80").getFoo().attempt.unsafeRunSync() match {
+      case Left(MalformedMessageBodyFailure(details, cause)) => details should equal("Invalid JSON: empty body")
+      case ex                                                => fail(s"Unknown: ${ex}")
+    }
+
+    /* Correct mime type
+     * Invalid JSON
+     */
+    Client.httpClient(jsonResponse("{"), "http://localhost:80").getFoo().attempt.unsafeRunSync() match {
+      case Left(MalformedMessageBodyFailure(details, cause)) => details should equal("Invalid JSON")
+      case ex                                                => fail(s"Unknown: ${ex}")
+    }
+
+    /* Correct mime type
+     * Valid JSON
+     * Missing discriminator
+     */
+    Client.httpClient(jsonResponse("{}"), "http://localhost:80").getFoo().attempt.unsafeRunSync() match {
+      case Left(InvalidMessageBodyFailure(_, Some(DecodingFailure(message, history)))) =>
+        message shouldBe "Attempt to decode value on failed cursor"
+        history should equal(List(CursorOp.DownField("type")))
+      case ex => fail(s"Unknown: ${ex}")
+    }
+
+    /* Correct mime type
+     * Valid JSON
+     * Invalid discriminator
+     */
+    Client.httpClient(jsonResponse("""{"type": "blep"}"""), "http://localhost:80").getFoo().attempt.unsafeRunSync() match {
+      case Left(InvalidMessageBodyFailure(_, Some(DecodingFailure(message, history)))) =>
+        message shouldBe "Unknown value blep (valid: Bar)"
+        history should equal(List(CursorOp.DownField("type")))
+      case ex => fail(s"Unknown: ${ex}")
+    }
+
+    /* Correct mime type
+     * Valid JSON
+     * Valid discriminator
+     * Missing "name" field
+     */
+    Client.httpClient(jsonResponse("""{"type": "Bar"}"""), "http://localhost:80").getFoo().attempt.unsafeRunSync() match {
+      case Left(InvalidMessageBodyFailure(_, Some(DecodingFailure(message, history)))) =>
+        message shouldBe "Attempt to decode value on failed cursor"
+        history should equal(List(CursorOp.DownField("name")))
+      case ex => fail(s"Unknown: ${ex}")
+    }
+  }
+}

--- a/modules/sample-http4s-v0_22/src/test/scala/core/issues/Issue455.scala
+++ b/modules/sample-http4s-v0_22/src/test/scala/core/issues/Issue455.scala
@@ -1,0 +1,42 @@
+package core.issues
+
+import cats.implicits._
+import org.http4s.implicits._
+import org.scalatest.EitherValues
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.time.SpanSugar._
+import scala.concurrent.Future
+import cats.effect.Async
+import cats.effect.implicits._
+import cats.effect.IO
+import org.http4s.client.{ Client => Http4sClient }
+
+class Issue455Suite extends AnyFunSuite with Matchers with EitherValues with ScalaFutures {
+  override implicit val patienceConfig = PatienceConfig(10 seconds, 1 second)
+
+  test("Circe NPE: https://github.com/circe/circe/issues/561") {
+    val route = {
+      import issues.issue455.server.http4sV022.{ Handler, Resource }
+      import issues.issue455.server.http4sV022.Resource.BooResponse
+      import issues.issue455.server.http4sV022.definitions.RecursiveData
+      new Resource[IO].routes(new Handler[IO] {
+        val recData                                                              = RecursiveData(3, "three", Some(RecursiveData(2, "two", Some(RecursiveData(1, "one", None)))))
+        def boo(respond: BooResponse.type)(body: RecursiveData): IO[BooResponse] = IO.pure(respond.Ok(recData))
+      })
+    }
+    {
+      import issues.issue455.client.http4sV022.Client
+      import issues.issue455.client.http4sV022.definitions.RecursiveData
+      val recData = RecursiveData(3, "three", Some(RecursiveData(2, "two", Some(RecursiveData(1, "one", None)))))
+      val client  = Client.httpClient(Http4sClient.fromHttpApp[IO](route.orNotFound))
+      val resp    = client.boo(recData).unsafeToFuture.futureValue
+      resp.fold(handleOk = {
+        case `recData` => ()
+        case data      => fail(s"${data} != ${recData}")
+      })
+    }
+  }
+}

--- a/modules/sample-http4s-v0_22/src/test/scala/core/issues/Issue542.scala
+++ b/modules/sample-http4s-v0_22/src/test/scala/core/issues/Issue542.scala
@@ -1,0 +1,79 @@
+package core.issues
+
+import cats.effect.IO
+import cats.data.Kleisli
+import org.http4s._
+import org.http4s.circe._
+import org.http4s.client.{ Client => Http4sClient }
+import org.http4s.headers._
+import org.http4s.implicits._
+import cats.instances.future._
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.time.SpanSugar._
+import org.scalatest.EitherValues
+import org.scalatest.OptionValues
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+import tests.scalatest.EitherTValues
+
+import scala.language.reflectiveCalls // TODO: Was a change in http4s introduced such that we're using it incorrectly now? Why is this necessary?
+
+class Issue542Suite extends AnyFunSuite with Matchers with EitherValues with ScalaFutures with EitherTValues with OptionValues {
+  override implicit val patienceConfig = PatienceConfig(10 seconds, 1 second)
+
+  test("base64 bytes can be sent") {
+    import base64.server.http4sV022.{ Handler, Resource }
+    import base64.server.http4sV022.Resource.FooResponse
+    import base64.server.http4sV022.definitions.Foo
+    import base64.server.http4sV022.Implicits.Base64String
+
+    val route = new Resource[IO]().routes(new Handler[IO] {
+      def foo(respond: FooResponse.type)(): IO[FooResponse] = IO.pure(respond.Ok(Foo(Some(new Base64String("foo".getBytes())))))
+    })
+
+    val client = Http4sClient.fromHttpApp[IO](route.orNotFound)
+
+    val req = Request[IO](method = Method.GET, uri = Uri.unsafeFromString("/foo"))
+
+    client
+      .run(req)
+      .use({
+        case Status.Ok(resp) =>
+          resp.status should equal(Status.Ok)
+          resp.contentType should equal(Some(`Content-Type`(MediaType.application.json)))
+          resp.contentLength should equal(Some(16))
+          jsonOf[IO, Foo].decode(resp, strict = false).rightValue
+      })
+      .unsafeRunSync()
+      .value
+      .value
+      .data should equal("foo".getBytes())
+  }
+
+  test("base64 bytes can be received") {
+    import base64.client.http4sV022.Client
+    import base64.client.http4sV022.definitions.Foo
+    import base64.client.http4sV022.Implicits.Base64String
+    import org.http4s.dsl._
+
+    def staticClient: Http4sClient[IO] = {
+      implicit val fooOkEncoder = jsonEncoderOf[IO, Foo]
+      val response = new Http4sDsl[IO] {
+        def route: HttpApp[IO] = Kleisli.liftF(Ok(Foo(Some(Base64String("foo".getBytes())))))
+      }
+      Http4sClient.fromHttpApp[IO](response.route)
+    }
+
+    Client
+      .httpClient(staticClient, "http://localhost:80")
+      .foo()
+      .attempt
+      .unsafeRunSync()
+      .fold(
+        _ => fail("Error"),
+        _.fold(
+          handleOk = _.value.value.data should equal("foo".getBytes())
+        )
+      )
+  }
+}

--- a/modules/sample-http4s-v0_22/src/test/scala/generators/Http4s/Client/contentType/Http4sTextPlainTest.scala
+++ b/modules/sample-http4s-v0_22/src/test/scala/generators/Http4s/Client/contentType/Http4sTextPlainTest.scala
@@ -1,0 +1,99 @@
+package generators.Http4s.Client.contentType
+
+import _root_.tests.contentTypes.textPlain.client.http4sV022.foo.FooClient
+import _root_.tests.contentTypes.textPlain.client.{ http4sV022 => cdefs }
+import _root_.tests.contentTypes.textPlain.server.http4sV022.foo.{ FooHandler, FooResource }
+import _root_.tests.contentTypes.textPlain.server.http4sV022.foo.FooResource.{ DoBarResponse, DoBazResponse, DoFooResponse }
+import org.scalatest.EitherValues
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+import org.http4s.dsl.io._
+import org.http4s.headers._
+import cats.effect.IO
+import org.http4s.client.Client
+import org.http4s.{ Charset, HttpRoutes, MediaType }
+
+class Http4sTextPlainTest extends AnyFunSuite with Matchers with EitherValues {
+  import org.http4s.implicits._
+  test("Plain text should be emitted for required parameters (raw)") {
+    val route: HttpRoutes[IO] = HttpRoutes.of {
+      case req @ POST -> Root / "foo" =>
+        if (req.contentType.contains(`Content-Type`(MediaType.text.plain, Charset.`UTF-8`))) {
+          for {
+            value <- req.as[String]
+            resp  <- if (value == "sample") Created("response") else NotAcceptable()
+          } yield resp
+        } else NotAcceptable()
+    }
+    val client: Client[IO] = Client.fromHttpApp(route.orNotFound)
+    val fooClient          = FooClient.httpClient(client)
+    fooClient.doFoo("sample").attempt.unsafeRunSync().value shouldBe cdefs.foo.DoFooResponse.Created("response")
+  }
+
+  test("Plain text should be emitted for optional parameters (raw)") {
+    val route: HttpRoutes[IO] = HttpRoutes.of {
+      case req @ POST -> Root / "bar" =>
+        if (req.contentType.contains(`Content-Type`(MediaType.text.plain, Charset.`UTF-8`))) {
+          for {
+            value <- req.as[String]
+            resp  <- if (value == "sample") Created("response") else NotAcceptable()
+          } yield resp
+        } else NotAcceptable()
+    }
+    val client: Client[IO] = Client.fromHttpApp(route.orNotFound)
+    val fooClient          = FooClient.httpClient(client)
+    fooClient.doBar(Some("sample")).attempt.unsafeRunSync().value shouldBe cdefs.foo.DoBarResponse.Created("response")
+  }
+
+  test("Plain text should be emitted for required parameters") {
+    val route: HttpRoutes[IO] = new FooResource[IO]().routes(new FooHandler[IO] {
+      def doFoo(respond: DoFooResponse.type)(body: String): IO[DoFooResponse] =
+        if (body == "sample") {
+          IO.pure(respond.Created("response"))
+        } else {
+          IO.pure(respond.NotAcceptable)
+        }
+      def doBar(respond: DoBarResponse.type)(body: Option[String]): IO[DoBarResponse] = ???
+      def doBaz(respond: DoBazResponse.type)(body: Option[String]): IO[DoBazResponse] = ???
+    })
+
+    val client: Client[IO] = Client.fromHttpApp(route.orNotFound)
+    val fooClient          = FooClient.httpClient(client)
+    fooClient.doFoo("sample").attempt.unsafeRunSync().value shouldBe cdefs.foo.DoFooResponse.Created("response")
+  }
+
+  test("Plain text should be emitted for present optional parameters") {
+    val route: HttpRoutes[IO] = new FooResource[IO]().routes(new FooHandler[IO] {
+      def doFoo(respond: DoFooResponse.type)(body: String): IO[DoFooResponse] = ???
+      def doBar(respond: DoBarResponse.type)(body: Option[String]): IO[DoBarResponse] =
+        if (body.contains("sample")) {
+          IO.pure(respond.Created("response"))
+        } else {
+          IO.pure(respond.NotAcceptable)
+        }
+      def doBaz(respond: DoBazResponse.type)(body: Option[String]): IO[DoBazResponse] = ???
+    })
+
+    val client: Client[IO] = Client.fromHttpApp(route.orNotFound)
+    val fooClient          = FooClient.httpClient(client)
+    fooClient.doBar(Some("sample")).attempt.unsafeRunSync().value shouldBe cdefs.foo.DoBarResponse.Created("response")
+  }
+
+  test("Plain text should be emitted for missing optional parameters") {
+    val route: HttpRoutes[IO] = new FooResource[IO]().routes(new FooHandler[IO] {
+      def doFoo(respond: DoFooResponse.type)(body: String): IO[DoFooResponse] = ???
+      def doBar(respond: DoBarResponse.type)(body: Option[String]): IO[DoBarResponse] =
+        if (body.isEmpty) {
+          IO.pure(respond.Created("response"))
+        } else {
+          IO.pure(respond.NotAcceptable)
+        }
+      def doBaz(respond: DoBazResponse.type)(body: Option[String]): IO[DoBazResponse] = ???
+    })
+
+    val client: Client[IO] = Client.fromHttpApp(route.orNotFound)
+    val fooClient          = FooClient.httpClient(client)
+    fooClient.doBar(None).attempt.unsafeRunSync().value shouldBe cdefs.foo.DoBarResponse.Created("response")
+  }
+}

--- a/modules/sample-http4s-v0_22/src/test/scala/generators/Http4s/RoundTrip/Http4sCustomHeadersTest.scala
+++ b/modules/sample-http4s-v0_22/src/test/scala/generators/Http4s/RoundTrip/Http4sCustomHeadersTest.scala
@@ -1,0 +1,43 @@
+package generators.Http4s.RoundTrip
+
+import cats.effect.IO
+import org.http4s.client.{ Client => Http4sClient }
+import org.http4s.implicits._
+import org.scalatest.EitherValues
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import tests.customTypes.customHeader.client.http4sV022.{ definitions => cdefs, Client }
+import tests.customTypes.customHeader.server.http4sV022.Implicits.Formatter
+import tests.customTypes.customHeader.server.http4sV022.{ definitions => sdefs, Handler, Resource }
+import tests.customTypes.customHeader.server.http4sV022.Resource.GetFooResponse
+
+class Http4sCustomHeadersTest extends AnyFlatSpec with Matchers with EitherValues {
+
+  it should "encode custom headers" in {
+    Formatter.show(sdefs.Bar.V1) shouldBe "v1"
+    Formatter.show(sdefs.Bar.ILikeSpaces) shouldBe "i like spaces"
+  }
+
+  it should "round-trip encoded values" in {
+    val client = Client.httpClient(
+      Http4sClient.fromHttpApp(
+        new Resource[IO]()
+          .routes(new Handler[IO] {
+            override def getFoo(
+                respond: GetFooResponse.type
+            )(header: String, longHeader: Long, customHeader: sdefs.Bar, customOptionHeader: Option[sdefs.Bar], missingCustomOptionHeader: Option[sdefs.Bar])
+                : IO[GetFooResponse] =
+              (header, longHeader, customHeader, customOptionHeader, missingCustomOptionHeader) match {
+                case ("foo", 5L, sdefs.Bar.V1, Some(sdefs.Bar.V2), None) => IO.pure(respond.Ok)
+                case _                                                   => IO.pure(respond.BadRequest)
+              }
+          })
+          .orNotFound
+      )
+    )
+
+    client.getFoo("foo", 5L, cdefs.Bar.V1, Some(cdefs.Bar.V2), None).attempt.unsafeRunSync().value
+  }
+
+}

--- a/modules/sample-http4s-v0_22/src/test/scala/generators/Http4s/RoundTrip/Http4sFormDataTest.scala
+++ b/modules/sample-http4s-v0_22/src/test/scala/generators/Http4s/RoundTrip/Http4sFormDataTest.scala
@@ -1,0 +1,117 @@
+package generators.Http4s.RoundTrip
+
+import cats.effect.IO
+import form.client.http4sV022.foo.FooClient
+import form.client.{ http4sV022 => cdefs }
+import form.server.http4sV022.foo._
+import form.server.http4sV022.foo.FooResource._
+import form.server.{ http4sV022 => sdefs }
+import org.http4s.client.Client
+import org.http4s.implicits._
+import org.http4s.{ Method, Request, Status, Uri, UrlForm }
+import org.scalatest.EitherValues
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+class Http4sFormDataTest extends AnyFunSuite with Matchers with EitherValues {
+
+  test("present required form param") {
+    val fooClient = FooClient.httpClient(
+      Client.fromHttpApp(
+        new FooResource[IO]()
+          .routes(new FooHandler[IO] {
+            def doFoo(respond: DoFooResponse.type)(status: sdefs.definitions.Status, description: String): IO[DoFooResponse] =
+              if (status == sdefs.definitions.Status.Ok) {
+                IO.pure(respond.Ok)
+              } else {
+                IO.pure(respond.NotAcceptable)
+              }
+            def doBar(respond: DoBarResponse.type)(status: Option[sdefs.definitions.Status], description: Option[String]): IO[DoBarResponse] = ???
+            def doBaz(respond: DoBazResponse.type)(status: Iterable[String], description: Option[Iterable[String]]): IO[DoBazResponse]       = ???
+          })
+          .orNotFound
+      )
+    )
+    fooClient.doFoo(cdefs.definitions.Status.Ok, "Description").attempt.unsafeRunSync().value shouldBe cdefs.foo.DoFooResponse.Ok
+  }
+
+  test("missing required form param") {
+    val client = Client.fromHttpApp(
+      new FooResource[IO]()
+        .routes(new FooHandler[IO] {
+          def doFoo(respond: DoFooResponse.type)(status: sdefs.definitions.Status, description: String): IO[DoFooResponse] =
+            if (status == sdefs.definitions.Status.Ok) {
+              IO.pure(respond.Ok)
+            } else {
+              IO.pure(respond.NotAcceptable)
+            }
+          def doBar(respond: DoBarResponse.type)(status: Option[sdefs.definitions.Status], description: Option[String]): IO[DoBarResponse] = ???
+          def doBaz(respond: DoBazResponse.type)(status: Iterable[String], description: Option[Iterable[String]]): IO[DoBazResponse]       = ???
+        })
+        .orNotFound
+    )
+    val req = Request[IO](method = Method.POST, uri = Uri.unsafeFromString("http://localhost:1234/foo")).withEntity(UrlForm.empty)
+    client.run(req).use(r => IO(r.status)).unsafeRunSync() shouldBe Status.BadRequest
+  }
+
+  test("present optional form param") {
+    val fooClient = FooClient.httpClient(
+      Client.fromHttpApp(
+        new FooResource[IO]()
+          .routes(new FooHandler[IO] {
+            def doFoo(respond: DoFooResponse.type)(status: sdefs.definitions.Status, description: String): IO[DoFooResponse] = ???
+            def doBar(respond: DoBarResponse.type)(status: Option[sdefs.definitions.Status], description: Option[String]): IO[DoBarResponse] =
+              if (status.contains(sdefs.definitions.Status.Ok)) {
+                IO.pure(respond.Ok)
+              } else {
+                IO.pure(respond.NotAcceptable)
+              }
+            def doBaz(respond: DoBazResponse.type)(status: Iterable[String], description: Option[Iterable[String]]): IO[DoBazResponse] = ???
+          })
+          .orNotFound
+      )
+    )
+    fooClient.doBar(Some(cdefs.definitions.Status.Ok)).attempt.unsafeRunSync().value shouldBe cdefs.foo.DoBarResponse.Ok
+  }
+
+  test("missing optional form param") {
+    val fooClient = FooClient.httpClient(
+      Client.fromHttpApp(
+        new FooResource[IO]()
+          .routes(new FooHandler[IO] {
+            def doFoo(respond: DoFooResponse.type)(status: sdefs.definitions.Status, description: String): IO[DoFooResponse] = ???
+
+            def doBar(respond: DoBarResponse.type)(status: Option[sdefs.definitions.Status], description: Option[String]): IO[DoBarResponse] =
+              if (status.isEmpty) {
+                IO.pure(respond.Ok)
+              } else {
+                IO.pure(respond.NotAcceptable)
+              }
+            def doBaz(respond: DoBazResponse.type)(status: Iterable[String], description: Option[Iterable[String]]): IO[DoBazResponse] = ???
+          })
+          .orNotFound
+      )
+    )
+    fooClient.doBar(None).attempt.unsafeRunSync().value shouldBe cdefs.foo.DoBarResponse.Ok
+  }
+
+  test("present required multi form String param") {
+    val fooClient = FooClient.httpClient(
+      Client.fromHttpApp(
+        new FooResource[IO]()
+          .routes(new FooHandler[IO] {
+            def doFoo(respond: DoFooResponse.type)(status: sdefs.definitions.Status, description: String): IO[DoFooResponse]                 = ???
+            def doBar(respond: DoBarResponse.type)(status: Option[sdefs.definitions.Status], description: Option[String]): IO[DoBarResponse] = ???
+            def doBaz(respond: DoBazResponse.type)(status: Iterable[String], description: Option[Iterable[String]]): IO[DoBazResponse] =
+              if (status.size == 1 && status.iterator.next() == sdefs.definitions.Status.Ok.toString) {
+                IO.pure(respond.Ok)
+              } else {
+                IO.pure(respond.NotAcceptable)
+              }
+          })
+          .orNotFound
+      )
+    )
+    fooClient.doBaz(Seq(cdefs.definitions.Status.Ok.toString)).attempt.unsafeRunSync().value shouldBe cdefs.foo.DoBazResponse.Ok
+  }
+}

--- a/modules/sample-http4s-v0_22/src/test/scala/generators/circe/NullableTest.scala
+++ b/modules/sample-http4s-v0_22/src/test/scala/generators/circe/NullableTest.scala
@@ -1,0 +1,77 @@
+package generators.circe
+
+import org.scalatest.EitherValues
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+import issues.issue315.client.http4sV022.definitions._
+import issues.issue315.client.http4sV022.support._
+import io.circe._
+import io.circe.syntax._
+class NullableTest extends AnyFunSuite with Matchers with EitherValues {
+  val constant   = "constant"
+  val defaultObj = TestObject(required = constant, optionalNullable = Presence.Absent)
+
+  test("Nullability should be implemented correctly for required nullable") {
+    val json = defaultObj.asJson
+    getKey(json, "required-nullable") should equal(Some(Json.Null))
+    json.as[TestObject].value should equal(defaultObj)
+
+    val obj2  = defaultObj.copy(requiredNullable = Some(constant))
+    val json2 = obj2.asJson
+    getKey(json2, "required-nullable") should equal(Some(Json.fromString(constant)))
+    json2.as[TestObject].value should equal(obj2)
+
+    dropKey(json, "required-nullable").as[TestObject] should be('left)
+  }
+
+  test("Nullability should be implemented correctly for optional") {
+    val json = defaultObj.asJson
+    getKey(json, "optional") should equal(None)
+    json.asObject.get.keys should not contain ("optional")
+    json.as[TestObject].value should equal(defaultObj)
+
+    val obj2  = defaultObj.copy(optional = Presence.Present(constant))
+    val json2 = obj2.asJson
+    getKey(json2, "optional") should equal(Some(Json.fromString(constant)))
+    json2.as[TestObject].value should equal(obj2)
+
+    val updated = json.asObject.get.add("optional", Json.Null)
+    updated.asJson.as[TestObject] should be('left)
+  }
+
+  test("Nullability should be implemented correctly for optional legacy") {
+    val json = defaultObj.asJson
+    getKey(json, "legacy") should equal(Some(Json.Null))
+    json.asObject.get.keys should contain("legacy")
+    json.as[TestObject].value should equal(defaultObj)
+    val updated = json.asObject.get.add("legacy", Json.Null)
+    updated.asJson.as[TestObject].value should equal(defaultObj)
+
+    val obj2  = defaultObj.copy(legacy = Some(constant))
+    val json2 = obj2.asJson
+    getKey(json2, "legacy") should equal(Some(Json.fromString(constant)))
+    json2.as[TestObject].value should equal(obj2)
+  }
+
+  test("Nullability should be implemented correctly for optional nullable") {
+    val json = defaultObj.asJson
+    getKey(json, "optional-nullable") should equal(None)
+    json.asObject.get.keys should not contain ("optional-nullable")
+    json.as[TestObject].value should equal(defaultObj)
+
+    val objPresent  = defaultObj.copy(optionalNullable = Presence.Present(None))
+    val jsonPresent = objPresent.asJson
+    getKey(jsonPresent, "optional-nullable") should equal(Some(Json.Null))
+    jsonPresent.as[TestObject].value should equal(objPresent)
+
+    val objValue  = defaultObj.copy(optionalNullable = Presence.Present(Some(constant)))
+    val jsonValue = objValue.asJson
+    getKey(jsonValue, "optional-nullable") should equal(Some(Json.fromString(constant)))
+    jsonValue.as[TestObject].value should equal(objValue)
+  }
+
+  private def getKey(json: Json, key: String): Option[Json] = json.hcursor.downField(key).as[Json].toOption
+  private def dropKey(json: Json, key: String): Json =
+    json.mapObject(_.filterKeys(_ != key))
+}

--- a/modules/sample-http4s-v0_22/src/test/scala/scalatest/EitherTValues.scala
+++ b/modules/sample-http4s-v0_22/src/test/scala/scalatest/EitherTValues.scala
@@ -1,0 +1,26 @@
+package tests.scalatest
+
+import cats.Functor
+import cats.data.EitherT
+import org.scalactic.source
+import org.scalatest._
+import org.scalatest.exceptions.{ StackDepthException, TestFailedException }
+import scala.language.higherKinds
+import scala.language.implicitConversions
+
+trait EitherTValues {
+
+  implicit def convertEitherTToValuable[F[_]: Functor, L, R](eitherT: EitherT[F, L, R]) = new EitherTValuable(eitherT)
+
+  class EitherTValuable[F[_]: Functor, L, R](eitherT: EitherT[F, L, R]) {
+    def leftValue(implicit pos: source.Position): F[L] =
+      eitherT.fold(identity, { _ =>
+        throw new TestFailedException((_: StackDepthException) => Option.empty[String], Option.empty[Throwable], pos)
+      })
+
+    def rightValue(implicit pos: source.Position): F[R] =
+      eitherT.fold({ _ =>
+        throw new TestFailedException((_: StackDepthException) => Option.empty[String], Option.empty[Throwable], pos)
+      }, identity)
+  }
+}

--- a/modules/sample-http4s-v0_22/src/test/scala/swagger/Escaping.scala
+++ b/modules/sample-http4s-v0_22/src/test/scala/swagger/Escaping.scala
@@ -1,0 +1,14 @@
+package swagger
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.funsuite.AnyFunSuite
+import examples.client.http4sV022.Implicits
+import examples.client.http4sV022.Http4sImplicits._
+
+class EscapingTest extends AnyFunSuite with Matchers {
+  test("Properly escape parameters") {
+    Implicits.Formatter.addPath("foo bar baz") shouldEqual "foo%20bar%20baz"
+    Implicits.Formatter.addPath("foo/bar") shouldEqual "foo%2Fbar"
+    Implicits.Formatter.addArg("my key", "3=foo/bar baz!") shouldEqual "&my%20key=3%3Dfoo/bar%20baz%21"
+  }
+}

--- a/modules/sample-http4s/src/test/scala/core/Http4s/Http4sCustomExtractorTest.scala
+++ b/modules/sample-http4s/src/test/scala/core/Http4s/Http4sCustomExtractorTest.scala
@@ -4,6 +4,7 @@ import _root_.customExtraction.client.{ http4s => cdefs }
 import _root_.customExtraction.server.http4s.users.{ UsersHandler, UsersResource }
 import _root_.customExtraction.server.http4s.users.UsersResource.GetUserResponse
 import cats.effect.IO
+import cats.effect.unsafe.implicits.global
 import customExtraction.client.http4s.users.UsersClient
 import customExtraction.server.http4s.definitions.{ User, UserAddress }
 import org.http4s.{ HttpRoutes, Request }

--- a/modules/sample-http4s/src/test/scala/core/Http4s/Http4sDebugBodyTest.scala
+++ b/modules/sample-http4s/src/test/scala/core/Http4s/Http4sDebugBodyTest.scala
@@ -6,6 +6,7 @@ import _root_.debugBody.server.http4s.Resource._
 import _root_.debugBody.server.http4s.definitions._
 import cats.effect.IO
 import cats.effect.IO._
+import cats.effect.unsafe.implicits.global
 import org.http4s.client.Client
 import org.http4s.implicits._
 import org.scalatest.EitherValues

--- a/modules/sample-http4s/src/test/scala/core/Http4s/Http4sFullTracerTest.scala
+++ b/modules/sample-http4s/src/test/scala/core/Http4s/Http4sFullTracerTest.scala
@@ -10,6 +10,7 @@ import _root_.tracer.client.http4s.users.UsersClient
 import _root_.tracer.client.http4s.addresses.AddressesClient
 import _root_.tracer.server.http4s.Http4sImplicits.TraceBuilder
 import cats.effect.IO
+import cats.effect.unsafe.implicits.global
 import org.http4s.{ Header, HttpRoutes, Request }
 import org.http4s.client.Client
 import org.http4s.implicits._

--- a/modules/sample-http4s/src/test/scala/core/Http4s/Http4sMixedContentTypesTest.scala
+++ b/modules/sample-http4s/src/test/scala/core/Http4s/Http4sMixedContentTypesTest.scala
@@ -6,6 +6,7 @@ import _root_.mixedContentTypes.server.http4s._
 import _root_.mixedContentTypes.server.http4s.definitions.Error
 import cats.effect.IO
 import cats.effect.IO._
+import cats.effect.unsafe.implicits.global
 import org.http4s.client.Client
 import org.http4s.implicits._
 import org.scalatest.EitherValues

--- a/modules/sample-http4s/src/test/scala/core/Http4s/Http4sNonStringEnumerationTest.scala
+++ b/modules/sample-http4s/src/test/scala/core/Http4s/Http4sNonStringEnumerationTest.scala
@@ -5,6 +5,7 @@ import java.util.Locale.US
 
 import cats.effect.IO
 import cats.effect.IO._
+import cats.effect.unsafe.implicits.global
 import fs2.Stream
 import javax.xml.bind.DatatypeConverter.printHexBinary
 import io.circe.Json

--- a/modules/sample-http4s/src/test/scala/core/Http4s/Http4sRoundTripTest.scala
+++ b/modules/sample-http4s/src/test/scala/core/Http4s/Http4sRoundTripTest.scala
@@ -10,6 +10,7 @@ import _root_.examples.server.http4s.pet.PetResource._
 import _root_.examples.server.{ http4s => sdefs }
 import cats.effect.IO
 import cats.effect.IO._
+import cats.effect.unsafe.implicits.global
 import fs2.Stream
 import javax.xml.bind.DatatypeConverter.printHexBinary
 import org.http4s.client.Client

--- a/modules/sample-http4s/src/test/scala/core/issues/Issue121.scala
+++ b/modules/sample-http4s/src/test/scala/core/issues/Issue121.scala
@@ -1,6 +1,7 @@
 package core.issues
 
 import cats.effect.IO
+import cats.effect.unsafe.implicits.global
 import cats.data.Kleisli
 import org.http4s._
 import org.http4s.client.{ Client => Http4sClient }

--- a/modules/sample-http4s/src/test/scala/core/issues/Issue1229.scala
+++ b/modules/sample-http4s/src/test/scala/core/issues/Issue1229.scala
@@ -8,6 +8,7 @@ import _root_.department.server.http4s.department.DepartmentResource._
 import _root_.department.server.http4s.{ definitions => sdefs }
 import cats.effect.IO
 import cats.effect.IO._
+import cats.effect.unsafe.implicits.global
 import org.http4s.client.Client
 import org.http4s.implicits._
 import org.scalatest.funsuite.AnyFunSuite

--- a/modules/sample-http4s/src/test/scala/core/issues/Issue148.scala
+++ b/modules/sample-http4s/src/test/scala/core/issues/Issue148.scala
@@ -6,6 +6,7 @@ import org.scalatest.time.SpanSugar._
 import org.scalatest.EitherValues
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
+import cats.effect.unsafe.implicits.global
 
 /** Changes
   *

--- a/modules/sample-http4s/src/test/scala/core/issues/Issue455.scala
+++ b/modules/sample-http4s/src/test/scala/core/issues/Issue455.scala
@@ -9,10 +9,10 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.time.SpanSugar._
 import scala.concurrent.Future
-import scala.concurrent.ExecutionContext.Implicits.global
 import cats.effect.Async
 import cats.effect.implicits._
 import cats.effect.IO
+import cats.effect.unsafe.implicits.global
 import org.http4s.client.{ Client => Http4sClient }
 
 class Issue455Suite extends AnyFunSuite with Matchers with EitherValues with ScalaFutures {

--- a/modules/sample-http4s/src/test/scala/core/issues/Issue542.scala
+++ b/modules/sample-http4s/src/test/scala/core/issues/Issue542.scala
@@ -1,6 +1,7 @@
 package core.issues
 
 import cats.effect.IO
+import cats.effect.unsafe.implicits.global
 import cats.data.Kleisli
 import org.http4s._
 import org.http4s.circe._

--- a/modules/sample-http4s/src/test/scala/generators/Http4s/Client/contentType/Http4sTextPlainTest.scala
+++ b/modules/sample-http4s/src/test/scala/generators/Http4s/Client/contentType/Http4sTextPlainTest.scala
@@ -11,6 +11,7 @@ import org.scalatest.matchers.should.Matchers
 import org.http4s.dsl.io._
 import org.http4s.headers._
 import cats.effect.IO
+import cats.effect.unsafe.implicits.global
 import org.http4s.client.Client
 import org.http4s.{ Charset, HttpRoutes, MediaType }
 

--- a/modules/sample-http4s/src/test/scala/generators/Http4s/RoundTrip/Http4sCustomHeadersTest.scala
+++ b/modules/sample-http4s/src/test/scala/generators/Http4s/RoundTrip/Http4sCustomHeadersTest.scala
@@ -1,6 +1,7 @@
 package generators.Http4s.RoundTrip
 
 import cats.effect.IO
+import cats.effect.unsafe.implicits.global
 import org.http4s.client.{ Client => Http4sClient }
 import org.http4s.implicits._
 import org.scalatest.EitherValues

--- a/modules/sample-http4s/src/test/scala/generators/Http4s/RoundTrip/Http4sFormDataTest.scala
+++ b/modules/sample-http4s/src/test/scala/generators/Http4s/RoundTrip/Http4sFormDataTest.scala
@@ -1,6 +1,7 @@
 package generators.Http4s.RoundTrip
 
 import cats.effect.IO
+import cats.effect.unsafe.implicits.global
 import form.client.http4s.foo.FooClient
 import form.client.{ http4s => cdefs }
 import form.server.http4s.foo._

--- a/modules/scala-http4s/src/main/scala/dev/guardrail/generators/scala/http4s/Http4s.scala
+++ b/modules/scala-http4s/src/main/scala/dev/guardrail/generators/scala/http4s/Http4s.scala
@@ -7,12 +7,12 @@ import dev.guardrail.generators.scala.circe.CirceProtocolGenerator
 import dev.guardrail.generators.scala.ScalaGenerator
 import dev.guardrail.generators.scala.ScalaCollectionsGenerator
 
-object Http4s extends Framework[ScalaLanguage, Target] {
+class Http4s(version: Http4sVersion) extends Framework[ScalaLanguage, Target] {
   implicit def CollectionsLibInterp = ScalaCollectionsGenerator()
   implicit def ProtocolInterp       = CirceProtocolGenerator(CirceModelGenerator.V012)
   implicit def ClientInterp         = Http4sClientGenerator()
   implicit def FrameworkInterp      = Http4sGenerator()
-  implicit def ServerInterp         = Http4sServerGenerator()
+  implicit def ServerInterp         = Http4sServerGenerator(version)
   implicit def SwaggerInterp        = SwaggerGenerator[ScalaLanguage]()
   implicit def LanguageInterp       = ScalaGenerator()
 }

--- a/modules/scala-http4s/src/main/scala/dev/guardrail/generators/scala/http4s/Http4s.scala
+++ b/modules/scala-http4s/src/main/scala/dev/guardrail/generators/scala/http4s/Http4s.scala
@@ -16,3 +16,5 @@ class Http4s(version: Http4sVersion) extends Framework[ScalaLanguage, Target] {
   implicit def SwaggerInterp        = SwaggerGenerator[ScalaLanguage]()
   implicit def LanguageInterp       = ScalaGenerator()
 }
+
+object Http4s extends Http4s(Http4sVersion.V0_23)

--- a/modules/scala-http4s/src/main/scala/dev/guardrail/generators/scala/http4s/Http4sServerGenerator.scala
+++ b/modules/scala-http4s/src/main/scala/dev/guardrail/generators/scala/http4s/Http4sServerGenerator.scala
@@ -24,7 +24,8 @@ import _root_.io.swagger.v3.oas.models.PathItem.HttpMethod
 import _root_.io.swagger.v3.oas.models.Operation
 
 object Http4sServerGenerator {
-  def apply()(implicit Cl: CollectionsLibTerms[ScalaLanguage, Target]): ServerTerms[ScalaLanguage, Target] = new Http4sServerGenerator
+  def apply(version: Http4sVersion)(implicit Cl: CollectionsLibTerms[ScalaLanguage, Target]): ServerTerms[ScalaLanguage, Target] =
+    new Http4sServerGenerator(version)
 
   def generateUrlPathExtractors(
       path: Tracker[String],
@@ -44,8 +45,14 @@ object Http4sServerGenerator {
     } yield (trailingSlashed, queryParams)
 }
 
-class Http4sServerGenerator private (implicit Cl: CollectionsLibTerms[ScalaLanguage, Target]) extends ServerTerms[ScalaLanguage, Target] {
+class Http4sServerGenerator private (version: Http4sVersion)(implicit Cl: CollectionsLibTerms[ScalaLanguage, Target])
+    extends ServerTerms[ScalaLanguage, Target] {
   val customExtractionTypeName: Type.Name = Type.Name("E")
+
+  private val bodyUtf8Decode = version match {
+    case Http4sVersion.V0_22 => q"utf8Decode"
+    case Http4sVersion.V0_23 => q"utf8.decode"
+  }
 
   def splitOperationParts(operationId: String): (List[String], String) = {
     val parts = operationId.split('.')
@@ -441,7 +448,7 @@ class Http4sServerGenerator private (implicit Cl: CollectionsLibTerms[ScalaLangu
                 Target.pure(
                   Param(
                     Some(
-                      enumerator"${Pat.Var(Term.Name(s"${arg.argName.value}Option"))} <- multipart.parts.find(_.name.contains(${arg.argName.toLit})).map(_.body.through(utf8Decode).compile.foldMonoid).sequence"
+                      enumerator"${Pat.Var(Term.Name(s"${arg.argName.value}Option"))} <- multipart.parts.find(_.name.contains(${arg.argName.toLit})).map(_.body.through($bodyUtf8Decode).compile.foldMonoid).sequence"
                     ),
                     Some(
                       (
@@ -456,7 +463,7 @@ class Http4sServerGenerator private (implicit Cl: CollectionsLibTerms[ScalaLangu
                 Target.pure(
                   Param(
                     Some(
-                      enumerator"${Pat.Var(Term.Name(s"${arg.argName.value}Option"))} <- multipart.parts.find(_.name.contains(${arg.argName.toLit})).map(_.body.through(utf8Decode).compile.foldMonoid.flatMap(str => F.fromEither(Json.fromString(str).as[$tpe]))).sequence"
+                      enumerator"${Pat.Var(Term.Name(s"${arg.argName.value}Option"))} <- multipart.parts.find(_.name.contains(${arg.argName.toLit})).map(_.body.through($bodyUtf8Decode).compile.foldMonoid.flatMap(str => F.fromEither(Json.fromString(str).as[$tpe]))).sequence"
                     ),
                     Some(
                       (
@@ -479,7 +486,7 @@ class Http4sServerGenerator private (implicit Cl: CollectionsLibTerms[ScalaLangu
                   Target.pure(
                     Param(
                       Some(
-                        enumerator"${Pat.Var(arg.paramName)} <- multipart.parts.filter(_.name.contains(${arg.argName.toLit})).map(_.body.through(utf8Decode).compile.foldMonoid).sequence"
+                        enumerator"${Pat.Var(arg.paramName)} <- multipart.parts.filter(_.name.contains(${arg.argName.toLit})).map(_.body.through($bodyUtf8Decode).compile.foldMonoid).sequence"
                       ),
                       None,
                       arg.paramName
@@ -489,7 +496,7 @@ class Http4sServerGenerator private (implicit Cl: CollectionsLibTerms[ScalaLangu
                   Target.pure(
                     Param(
                       Some(
-                        enumerator"${Pat.Var(arg.paramName)} <- multipart.parts.filter(_.name.contains(${arg.argName.toLit})).map(_.body.through(utf8Decode).compile.foldMonoid.flatMap(str => F.fromEither(Json.fromString(str).as[$tpe]))).sequence"
+                        enumerator"${Pat.Var(arg.paramName)} <- multipart.parts.filter(_.name.contains(${arg.argName.toLit})).map(_.body.through($bodyUtf8Decode).compile.foldMonoid.flatMap(str => F.fromEither(Json.fromString(str).as[$tpe]))).sequence"
                       ),
                       None,
                       arg.paramName
@@ -507,7 +514,7 @@ class Http4sServerGenerator private (implicit Cl: CollectionsLibTerms[ScalaLangu
                   Target.pure(
                     Param(
                       Some(
-                        enumerator"${Pat.Var(arg.paramName)} <- multipart.parts.filter(_.name.contains(${arg.argName.toLit})).map(_.body.through(utf8Decode).compile.foldMonoid).sequence.map(Option(_).filter(_.nonEmpty))"
+                        enumerator"${Pat.Var(arg.paramName)} <- multipart.parts.filter(_.name.contains(${arg.argName.toLit})).map(_.body.through($bodyUtf8Decode).compile.foldMonoid).sequence.map(Option(_).filter(_.nonEmpty))"
                       ),
                       None,
                       arg.paramName
@@ -517,7 +524,7 @@ class Http4sServerGenerator private (implicit Cl: CollectionsLibTerms[ScalaLangu
                   Target.pure(
                     Param(
                       Some(
-                        enumerator"${Pat.Var(arg.paramName)} <- multipart.parts.filter(_.name.contains(${arg.argName.toLit})).map(_.body.through(utf8Decode).compile.foldMonoid.flatMap(str => F.fromEither(Json.fromString(str).as[$tpe]))).sequence.map(Option(_).filter(_.nonEmpty))"
+                        enumerator"${Pat.Var(arg.paramName)} <- multipart.parts.filter(_.name.contains(${arg.argName.toLit})).map(_.body.through($bodyUtf8Decode).compile.foldMonoid.flatMap(str => F.fromEither(Json.fromString(str).as[$tpe]))).sequence.map(Option(_).filter(_.nonEmpty))"
                       ),
                       None,
                       arg.paramName
@@ -534,7 +541,7 @@ class Http4sServerGenerator private (implicit Cl: CollectionsLibTerms[ScalaLangu
                 Target.pure(
                   Param(
                     Some(
-                      enumerator"${Pat.Var(arg.paramName)} <- multipart.parts.find(_.name.contains(${arg.argName.toLit})).map(_.body.through(utf8Decode).compile.foldMonoid).sequence"
+                      enumerator"${Pat.Var(arg.paramName)} <- multipart.parts.find(_.name.contains(${arg.argName.toLit})).map(_.body.through($bodyUtf8Decode).compile.foldMonoid).sequence"
                     ),
                     None,
                     arg.paramName
@@ -544,7 +551,7 @@ class Http4sServerGenerator private (implicit Cl: CollectionsLibTerms[ScalaLangu
                 Target.pure(
                   Param(
                     Some(
-                      enumerator"${Pat.Var(arg.paramName)} <- multipart.parts.find(_.name.contains(${arg.argName.toLit})).map(_.body.through(utf8Decode).compile.foldMonoid.flatMap(str => F.fromEither(Json.fromString(str).as[$tpe]))).sequence"
+                      enumerator"${Pat.Var(arg.paramName)} <- multipart.parts.find(_.name.contains(${arg.argName.toLit})).map(_.body.through($bodyUtf8Decode).compile.foldMonoid.flatMap(str => F.fromEither(Json.fromString(str).as[$tpe]))).sequence"
                     ),
                     None,
                     arg.paramName

--- a/modules/scala-http4s/src/main/scala/dev/guardrail/generators/scala/http4s/Http4sServerGenerator.scala
+++ b/modules/scala-http4s/src/main/scala/dev/guardrail/generators/scala/http4s/Http4sServerGenerator.scala
@@ -24,6 +24,10 @@ import _root_.io.swagger.v3.oas.models.PathItem.HttpMethod
 import _root_.io.swagger.v3.oas.models.Operation
 
 object Http4sServerGenerator {
+  @deprecated("0.69.0", "Explicitly set Http4sVersion")
+  def apply()(implicit Cl: CollectionsLibTerms[ScalaLanguage, Target]): ServerTerms[ScalaLanguage, Target] =
+    apply(Http4sVersion.V0_23)(Cl)
+
   def apply(version: Http4sVersion)(implicit Cl: CollectionsLibTerms[ScalaLanguage, Target]): ServerTerms[ScalaLanguage, Target] =
     new Http4sServerGenerator(version)
 
@@ -47,6 +51,9 @@ object Http4sServerGenerator {
 
 class Http4sServerGenerator private (version: Http4sVersion)(implicit Cl: CollectionsLibTerms[ScalaLanguage, Target])
     extends ServerTerms[ScalaLanguage, Target] {
+
+  private def this(Cl: CollectionsLibTerms[ScalaLanguage, Target]) = this(Http4sVersion.V0_23)(Cl)
+
   val customExtractionTypeName: Type.Name = Type.Name("E")
 
   private val bodyUtf8Decode = version match {

--- a/modules/scala-http4s/src/main/scala/dev/guardrail/generators/scala/http4s/Http4sVersion.scala
+++ b/modules/scala-http4s/src/main/scala/dev/guardrail/generators/scala/http4s/Http4sVersion.scala
@@ -1,0 +1,7 @@
+package dev.guardrail.generators.scala.http4s
+
+sealed trait Http4sVersion
+object Http4sVersion {
+  case object V0_22 extends Http4sVersion
+  case object V0_23 extends Http4sVersion
+}

--- a/modules/scala-http4s/src/test/scala/core/issues/Issue222.scala
+++ b/modules/scala-http4s/src/test/scala/core/issues/Issue222.scala
@@ -8,6 +8,7 @@ import dev.guardrail.Context
 import dev.guardrail.generators.ProtocolDefinitions
 import dev.guardrail.generators.scala.ScalaLanguage
 import dev.guardrail.generators.scala.http4s.Http4s
+import dev.guardrail.generators.scala.http4s.Http4sVersion
 import dev.guardrail.terms.protocol.ClassDefinition
 import support.SwaggerSpecRunner
 
@@ -79,134 +80,140 @@ class Issue222 extends AnyFunSuite with Matchers with SwaggerSpecRunner {
        |      - "$$ref": "#/definitions/RequestFields2"
        |""".stripMargin
 
-  test("Ensure case-to-case inheritance is not generated") {
-    val (x @ ProtocolDefinitions(List(request: ClassDefinition[ScalaLanguage], requestFields: ClassDefinition[ScalaLanguage], _, _, _), _, _, _, _), _, _) =
-      runSwaggerSpec(swagger)(Context.empty, Http4s)
+  def testVersion(version: Http4sVersion) {
+    test(s"$version - Ensure case-to-case inheritance is not generated") {
+      val (x @ ProtocolDefinitions(List(request: ClassDefinition[ScalaLanguage], requestFields: ClassDefinition[ScalaLanguage], _, _, _), _, _, _, _), _, _) =
+        runSwaggerSpec(swagger)(Context.empty, new Http4s(version))
 
-    val List(reqEncoder, reqDecoder) = request.staticDefns.definitions
+      val List(reqEncoder, reqDecoder) = request.staticDefns.definitions
 
-    val expectedRequestTpe = t"""Request"""
+      val expectedRequestTpe = t"""Request"""
 
-    val expectedRequestCls = q"""case class Request(state: BigInt, id: Option[String] = None)"""
+      val expectedRequestCls = q"""case class Request(state: BigInt, id: Option[String] = None)"""
 
-    val expectedRequestEncoder =
-      q"""
+      val expectedRequestEncoder =
+        q"""
         implicit val encodeRequest: _root_.io.circe.Encoder.AsObject[Request] = {
           val readOnlyKeys = _root_.scala.Predef.Set[_root_.scala.Predef.String]()
           _root_.io.circe.Encoder.AsObject.instance[Request](a => _root_.io.circe.JsonObject.fromIterable(_root_.scala.Vector(("state", a.state.asJson), ("id", a.id.asJson)))).mapJsonObject(_.filterKeys(key => !(readOnlyKeys contains key)))
         }
       """
-    val expectedRequestDecoder =
-      q"""
+      val expectedRequestDecoder =
+        q"""
         implicit val decodeRequest: _root_.io.circe.Decoder[Request] = new _root_.io.circe.Decoder[Request] { final def apply(c: _root_.io.circe.HCursor): _root_.io.circe.Decoder.Result[Request] = for (v0 <- c.downField("state").as[BigInt]; v1 <- c.downField("id").as[Option[String]]) yield Request(v0, v1) }
       """
 
-    compare(request.tpe, expectedRequestTpe)
-    compare(request.cls, expectedRequestCls)
-    compare(reqEncoder, expectedRequestEncoder)
-    compare(reqDecoder, expectedRequestDecoder)
+      compare(request.tpe, expectedRequestTpe)
+      compare(request.cls, expectedRequestCls)
+      compare(reqEncoder, expectedRequestEncoder)
+      compare(reqDecoder, expectedRequestDecoder)
 
-    val expectedFieldsTpe = t"""RequestFields"""
-    val expectedFieldsCls = q"""case class RequestFields(state: BigInt)"""
+      val expectedFieldsTpe = t"""RequestFields"""
+      val expectedFieldsCls = q"""case class RequestFields(state: BigInt)"""
 
-    val List(fieldsEncoder, fieldsDecoder) = requestFields.staticDefns.definitions
+      val List(fieldsEncoder, fieldsDecoder) = requestFields.staticDefns.definitions
 
-    val expectedFieldsEncoder =
-      q"""
+      val expectedFieldsEncoder =
+        q"""
         implicit val encodeRequestFields: _root_.io.circe.Encoder.AsObject[RequestFields] = {
           val readOnlyKeys = _root_.scala.Predef.Set[_root_.scala.Predef.String]()
           _root_.io.circe.Encoder.AsObject.instance[RequestFields](a => _root_.io.circe.JsonObject.fromIterable(_root_.scala.Vector(("state", a.state.asJson)))).mapJsonObject(_.filterKeys(key => !(readOnlyKeys contains key)))
         }
       """
-    val expectedFieldsDecoder =
-      q"""
+      val expectedFieldsDecoder =
+        q"""
         implicit val decodeRequestFields: _root_.io.circe.Decoder[RequestFields] = new _root_.io.circe.Decoder[RequestFields] { final def apply(c: _root_.io.circe.HCursor): _root_.io.circe.Decoder.Result[RequestFields] = for (v0 <- c.downField("state").as[BigInt]) yield RequestFields(v0) }
       """
 
-    compare(requestFields.tpe, expectedFieldsTpe)
-    compare(requestFields.cls, expectedFieldsCls)
-    compare(fieldsEncoder, expectedFieldsEncoder)
-    compare(fieldsDecoder, expectedFieldsDecoder)
-  }
+      compare(requestFields.tpe, expectedFieldsTpe)
+      compare(requestFields.cls, expectedFieldsCls)
+      compare(fieldsEncoder, expectedFieldsEncoder)
+      compare(fieldsDecoder, expectedFieldsDecoder)
+    }
 
-  test("Ensure case-to-case inheritance is not generated, extends two objects") {
-    val (ProtocolDefinitions(List(_, _, request: ClassDefinition[ScalaLanguage], requestFields: ClassDefinition[ScalaLanguage], _), _, _, _, _), _, _) =
-      runSwaggerSpec(swagger)(Context.empty, Http4s)
+    test(s"$version - Ensure case-to-case inheritance is not generated, extends two objects") {
+      val (ProtocolDefinitions(List(_, _, request: ClassDefinition[ScalaLanguage], requestFields: ClassDefinition[ScalaLanguage], _), _, _, _, _), _, _) =
+        runSwaggerSpec(swagger)(Context.empty, new Http4s(version))
 
-    val List(reqEncoder, reqDecoder) = request.staticDefns.definitions
+      val List(reqEncoder, reqDecoder) = request.staticDefns.definitions
 
-    val expectedRequestTpe = t"""Request2"""
+      val expectedRequestTpe = t"""Request2"""
 
-    val expectedRequestCls = q"""case class Request2(state2: Option[BigInt] = None, id: Option[String] = None, id2: String)"""
+      val expectedRequestCls = q"""case class Request2(state2: Option[BigInt] = None, id: Option[String] = None, id2: String)"""
 
-    val expectedRequestEncoder =
-      q"""
+      val expectedRequestEncoder =
+        q"""
         implicit val encodeRequest2: _root_.io.circe.Encoder.AsObject[Request2] = {
           val readOnlyKeys = _root_.scala.Predef.Set[_root_.scala.Predef.String]()
           _root_.io.circe.Encoder.AsObject.instance[Request2](a => _root_.io.circe.JsonObject.fromIterable(_root_.scala.Vector(("state2", a.state2.asJson), ("id", a.id.asJson), ("id2", a.id2.asJson)))).mapJsonObject(_.filterKeys(key => !(readOnlyKeys contains key)))
         }
       """
-    val expectedRequestDecoder =
-      q"""
+      val expectedRequestDecoder =
+        q"""
         implicit val decodeRequest2: _root_.io.circe.Decoder[Request2] = new _root_.io.circe.Decoder[Request2] { final def apply(c: _root_.io.circe.HCursor): _root_.io.circe.Decoder.Result[Request2] = for (v0 <- c.downField("state2").as[Option[BigInt]]; v1 <- c.downField("id").as[Option[String]]; v2 <- c.downField("id2").as[String]) yield Request2(v0, v1, v2) }
       """
 
-    compare(request.tpe, expectedRequestTpe)
-    compare(request.cls, expectedRequestCls)
-    compare(reqEncoder, expectedRequestEncoder)
-    compare(reqDecoder, expectedRequestDecoder)
+      compare(request.tpe, expectedRequestTpe)
+      compare(request.cls, expectedRequestCls)
+      compare(reqEncoder, expectedRequestEncoder)
+      compare(reqDecoder, expectedRequestDecoder)
 
-    val expectedFieldsTpe = t"""RequestFields2"""
-    val expectedFieldsCls = q"""case class RequestFields2(state2: Option[BigInt] = None)"""
+      val expectedFieldsTpe = t"""RequestFields2"""
+      val expectedFieldsCls = q"""case class RequestFields2(state2: Option[BigInt] = None)"""
 
-    val List(fieldsEncoder, fieldsDecoder) = requestFields.staticDefns.definitions
+      val List(fieldsEncoder, fieldsDecoder) = requestFields.staticDefns.definitions
 
-    val expectedFieldsEncoder =
-      q"""
+      val expectedFieldsEncoder =
+        q"""
         implicit val encodeRequestFields2: _root_.io.circe.Encoder.AsObject[RequestFields2] = {
           val readOnlyKeys = _root_.scala.Predef.Set[_root_.scala.Predef.String]()
           _root_.io.circe.Encoder.AsObject.instance[RequestFields2](a => _root_.io.circe.JsonObject.fromIterable(_root_.scala.Vector(("state2", a.state2.asJson)))).mapJsonObject(_.filterKeys(key => !(readOnlyKeys contains key)))
         }
       """
-    val expectedFieldsDecoder =
-      q"""
+      val expectedFieldsDecoder =
+        q"""
         implicit val decodeRequestFields2: _root_.io.circe.Decoder[RequestFields2] = new _root_.io.circe.Decoder[RequestFields2] { final def apply(c: _root_.io.circe.HCursor): _root_.io.circe.Decoder.Result[RequestFields2] = for (v0 <- c.downField("state2").as[Option[BigInt]]) yield RequestFields2(v0) }
       """
 
-    compare(requestFields.tpe, expectedFieldsTpe)
-    compare(requestFields.cls, expectedFieldsCls)
-    compare(fieldsEncoder, expectedFieldsEncoder)
-    compare(fieldsDecoder, expectedFieldsDecoder)
-  }
+      compare(requestFields.tpe, expectedFieldsTpe)
+      compare(requestFields.cls, expectedFieldsCls)
+      compare(fieldsEncoder, expectedFieldsEncoder)
+      compare(fieldsDecoder, expectedFieldsDecoder)
+    }
 
-  test("Ensure case-to-case inheritance is not generated, extends two objects and two classes") {
-    val (ProtocolDefinitions(List(_, _, _, _, request: ClassDefinition[ScalaLanguage]), _, _, _, _), _, _) = runSwaggerSpec(swagger)(Context.empty, Http4s)
+    test(s"$version - Ensure case-to-case inheritance is not generated, extends two objects and two classes") {
+      val (ProtocolDefinitions(List(_, _, _, _, request: ClassDefinition[ScalaLanguage]), _, _, _, _), _, _) =
+        runSwaggerSpec(swagger)(Context.empty, new Http4s(version))
 
-    val List(reqEncoder, reqDecoder) = request.staticDefns.definitions
+      val List(reqEncoder, reqDecoder) = request.staticDefns.definitions
 
-    val expectedRequestTpe = t"""Request3"""
+      val expectedRequestTpe = t"""Request3"""
 
-    val expectedRequestCls = q"""case class Request3(state: BigInt, state2: Option[BigInt] = None, id: Option[String] = None, id2: String)"""
+      val expectedRequestCls = q"""case class Request3(state: BigInt, state2: Option[BigInt] = None, id: Option[String] = None, id2: String)"""
 
-    val expectedRequestEncoder =
-      q"""
+      val expectedRequestEncoder =
+        q"""
         implicit val encodeRequest3: _root_.io.circe.Encoder.AsObject[Request3] = {
           val readOnlyKeys = _root_.scala.Predef.Set[_root_.scala.Predef.String]()
           _root_.io.circe.Encoder.AsObject.instance[Request3](a => _root_.io.circe.JsonObject.fromIterable(_root_.scala.Vector(("state", a.state.asJson), ("state2", a.state2.asJson), ("id", a.id.asJson), ("id2", a.id2.asJson)))).mapJsonObject(_.filterKeys(key => !(readOnlyKeys contains key)))
         }
       """
-    val expectedRequestDecoder =
-      q"""
+      val expectedRequestDecoder =
+        q"""
         implicit val decodeRequest3: _root_.io.circe.Decoder[Request3] = new _root_.io.circe.Decoder[Request3] { final def apply(c: _root_.io.circe.HCursor): _root_.io.circe.Decoder.Result[Request3] = for (v0 <- c.downField("state").as[BigInt]; v1 <- c.downField("state2").as[Option[BigInt]]; v2 <- c.downField("id").as[Option[String]]; v3 <- c.downField("id2").as[String]) yield Request3(v0, v1, v2, v3) }
       """
 
-    compare(request.tpe, expectedRequestTpe)
-    compare(request.cls, expectedRequestCls)
-    compare(reqEncoder, expectedRequestEncoder)
-    compare(reqDecoder, expectedRequestDecoder)
+      compare(request.tpe, expectedRequestTpe)
+      compare(request.cls, expectedRequestCls)
+      compare(reqEncoder, expectedRequestEncoder)
+      compare(reqDecoder, expectedRequestDecoder)
 
+    }
   }
 
   private def compare(t1: Tree, t2: Tree)(implicit pos: org.scalactic.source.Position): Assertion =
     t1.structure shouldEqual t2.structure
+
+  testVersion(Http4sVersion.V0_22)
+  testVersion(Http4sVersion.V0_23)
 }

--- a/modules/scala-http4s/src/test/scala/core/issues/Issue223.scala
+++ b/modules/scala-http4s/src/test/scala/core/issues/Issue223.scala
@@ -9,6 +9,7 @@ import support.SwaggerSpecRunner
 import dev.guardrail.Context
 import dev.guardrail.generators.ProtocolDefinitions
 import dev.guardrail.generators.scala.http4s.Http4s
+import dev.guardrail.generators.scala.http4s.Http4sVersion
 import dev.guardrail.terms.protocol.ClassDefinition
 
 class Issue223 extends AnyFunSuite with Matchers with SwaggerSpecRunner {
@@ -32,13 +33,18 @@ class Issue223 extends AnyFunSuite with Matchers with SwaggerSpecRunner {
                            |        description: uuid of kernel
                            |""".stripMargin
 
-  test("Test uuid format generation") {
-    val (
-      ProtocolDefinitions(ClassDefinition(_, _, _, c1, _, _) :: Nil, _, _, _, _),
-      _,
-      _
-    ) = runSwaggerSpec(swagger)(Context.empty, Http4s)
+  def testVersion(version: Http4sVersion) {
+    test(s"$version - Test uuid format generation") {
+      val (
+        ProtocolDefinitions(ClassDefinition(_, _, _, c1, _, _) :: Nil, _, _, _, _),
+        _,
+        _
+      ) = runSwaggerSpec(swagger)(Context.empty, new Http4s(version))
 
-    c1.structure shouldBe q"case class Kernel(id: java.util.UUID)".structure
+      c1.structure shouldBe q"case class Kernel(id: java.util.UUID)".structure
+    }
   }
+
+  testVersion(Http4sVersion.V0_22)
+  testVersion(Http4sVersion.V0_23)
 }

--- a/modules/scala-http4s/src/test/scala/core/issues/Issue255.scala
+++ b/modules/scala-http4s/src/test/scala/core/issues/Issue255.scala
@@ -9,6 +9,7 @@ import support.SwaggerSpecRunner
 import dev.guardrail.Context
 import dev.guardrail.generators.ProtocolDefinitions
 import dev.guardrail.generators.scala.http4s.Http4s
+import dev.guardrail.generators.scala.http4s.Http4sVersion
 import dev.guardrail.terms.protocol.ClassDefinition
 
 class Issue255 extends AnyFunSuite with Matchers with SwaggerSpecRunner {
@@ -40,21 +41,26 @@ class Issue255 extends AnyFunSuite with Matchers with SwaggerSpecRunner {
                            |        x-scala-type: custom.Bytes
                            |""".stripMargin
 
-  test("Test password format generation") {
-    val (
-      ProtocolDefinitions(ClassDefinition(_, _, _, c1, _, _) :: Nil, _, _, _, _),
-      _,
-      _
-    ) = runSwaggerSpec(swagger)(Context.empty, Http4s)
+  def testVersion(version: Http4sVersion) {
+    test(s"$version - Test password format generation") {
+      val (
+        ProtocolDefinitions(ClassDefinition(_, _, _, c1, _, _) :: Nil, _, _, _, _),
+        _,
+        _
+      ) = runSwaggerSpec(swagger)(Context.empty, new Http4s(version))
 
-    val expected =
-      q"""
+      val expected =
+        q"""
         case class Foo(someEmail: Option[String] = None,
                        somePassword: Option[String] = None,
                        someFile: Option[String] = None,
                        someBinary: Option[String] = None,
                        someCustomBinary: Option[custom.Bytes] = None)
        """
-    c1.structure shouldBe expected.structure
+      c1.structure shouldBe expected.structure
+    }
   }
+
+  testVersion(Http4sVersion.V0_22)
+  testVersion(Http4sVersion.V0_23)
 }

--- a/modules/scala-http4s/src/test/scala/core/issues/Issue260.scala
+++ b/modules/scala-http4s/src/test/scala/core/issues/Issue260.scala
@@ -1,6 +1,7 @@
 package core.issues
 
 import dev.guardrail.generators.scala.http4s.Http4s
+import dev.guardrail.generators.scala.http4s.Http4sVersion
 import dev.guardrail.Context
 import dev.guardrail.generators.{ Server, Servers }
 import support.SwaggerSpecRunner
@@ -9,9 +10,11 @@ import org.scalatest.matchers.should.Matchers
 
 class Issue260 extends AnyFunSpec with Matchers with SwaggerSpecRunner {
 
-  describe("LocalDate path param is generated more than once") {
+  def testVersion(version: Http4sVersion) {
+    describe(version.toString()) {
+      describe("LocalDate path param is generated more than once") {
 
-    val swagger: String = """
+        val swagger: String = """
       | openapi: "3.0.0"
       | info:
       |   title: Generator Error Sample
@@ -66,27 +69,32 @@ class Issue260 extends AnyFunSpec with Matchers with SwaggerSpecRunner {
       |       required:
       |         - date""".stripMargin
 
-    val (
-      _, // ProtocolDefinitions
-      _, // clients
-      Servers(
-        Server(
-          _, // pkg
-          _, // extraImports
-          _, // genHandler
-          serverDefinition :: _
-        ) :: Nil,
-        _ // supportDefinitions
-      )
-    ) = runSwaggerSpec(swagger)(Context.empty, Http4s)
+        val (
+          _, // ProtocolDefinitions
+          _, // clients
+          Servers(
+            Server(
+              _, // pkg
+              _, // extraImports
+              _, // genHandler
+              serverDefinition :: _
+            ) :: Nil,
+            _ // supportDefinitions
+          )
+        ) = runSwaggerSpec(swagger)(Context.empty, new Http4s(version))
 
-    it("Ensure LocalDateVar is generated only once") {
+        it("Ensure LocalDateVar is generated only once") {
 
-      val pattern = "object LocalDateVar".r
+          val pattern = "object LocalDateVar".r
 
-      val hits = pattern.findAllIn(serverDefinition.toString()).length
+          val hits = pattern.findAllIn(serverDefinition.toString()).length
 
-      hits shouldBe 1
+          hits shouldBe 1
+        }
+      }
     }
   }
+
+  testVersion(Http4sVersion.V0_22)
+  testVersion(Http4sVersion.V0_23)
 }

--- a/modules/scala-http4s/src/test/scala/core/issues/Issue420.scala
+++ b/modules/scala-http4s/src/test/scala/core/issues/Issue420.scala
@@ -9,6 +9,7 @@ import dev.guardrail.Context
 import dev.guardrail.generators.ProtocolDefinitions
 import dev.guardrail.generators.scala.ScalaLanguage
 import dev.guardrail.generators.scala.http4s.Http4s
+import dev.guardrail.generators.scala.http4s.Http4sVersion
 import dev.guardrail.terms.protocol.ClassDefinition
 
 class Issue420 extends AnyFunSuite with Matchers with SwaggerSpecRunner {
@@ -31,16 +32,21 @@ class Issue420 extends AnyFunSuite with Matchers with SwaggerSpecRunner {
                           |      - $ref: "#/definitions/Bar"
                        |""".stripMargin
 
-  test("Test ordering") {
-    val (
-      ProtocolDefinitions(List(bar: ClassDefinition[ScalaLanguage], foo: ClassDefinition[ScalaLanguage]), _, _, _, _),
-      _,
-      _
-    ) = runSwaggerSpec(swagger)(Context.empty, Http4s)
+  def testVersion(version: Http4sVersion) {
+    test(s"$version - Test ordering") {
+      val (
+        ProtocolDefinitions(List(bar: ClassDefinition[ScalaLanguage], foo: ClassDefinition[ScalaLanguage]), _, _, _, _),
+        _,
+        _
+      ) = runSwaggerSpec(swagger)(Context.empty, new Http4s(version))
 
-    cmp(bar.cls, q"case class Bar(id: Option[String] = None)")
-    cmp(foo.cls, q"case class Foo(id: Option[String] = None, otherId: Option[String] = None)")
+      cmp(bar.cls, q"case class Bar(id: Option[String] = None)")
+      cmp(foo.cls, q"case class Foo(id: Option[String] = None, otherId: Option[String] = None)")
+    }
   }
+
+  testVersion(Http4sVersion.V0_22)
+  testVersion(Http4sVersion.V0_23)
 
   private def cmp(l: Tree, r: Tree): Unit =
     l.structure shouldBe r.structure

--- a/project/src/main/scala/RegressionTests.scala
+++ b/project/src/main/scala/RegressionTests.scala
@@ -7,6 +7,7 @@ object RegressionTests {
     "scala" -> List(
       ExampleFramework("akka-http", "akkaHttp"),
       ExampleFramework("endpoints", "endpoints", List()),
+      ExampleFramework("http4s-v0.22", "http4s-v0_22"),
       ExampleFramework("http4s", "http4s"),
       ExampleFramework("akka-http-jackson", "akkaHttpJackson"),
       ExampleFramework("dropwizard", "dropwizardScala", List("server")),
@@ -80,7 +81,7 @@ object RegressionTests {
     ExampleCase(sampleResource("issues/issue622.yaml"), "issues.issue622"),
     ExampleCase(sampleResource("issues/issue1138.yaml"), "issues.issue1138"),
     ExampleCase(sampleResource("issues/issue1260.yaml"), "issues.issue1260"),
-    ExampleCase(sampleResource("issues/issue1218.yaml"), "issues.issue1218").frameworks("scala" -> Set("http4s")),
+    ExampleCase(sampleResource("issues/issue1218.yaml"), "issues.issue1218").frameworks("scala" -> Set("http4s", "http4s-v0.22")),
     ExampleCase(sampleResource("multipart-form-data.yaml"), "multipartFormData"),
     ExampleCase(sampleResource("petstore.json"), "examples").args("--import", "examples.support.PositiveLong"),
     // ExampleCase(sampleResource("petstore-openapi-3.0.2.yaml"), "examples.petstore.openapi302").args("--import", "examples.support.PositiveLong"),
@@ -94,14 +95,14 @@ object RegressionTests {
     ExampleCase(sampleResource("server2.yaml"), "tracer").args("--tracing"),
     ExampleCase(sampleResource("pathological-parameters.yaml"), "pathological").frameworks("java" -> javaFrameworks.map(_.name).toSet, "scala" -> (scalaFrameworks.map(_.name).toSet - "endpoints")), // Blocked by https://github.com/endpoints4s/endpoints4s/issues/713
     ExampleCase(sampleResource("response-headers.yaml"), "responseHeaders"),
-    ExampleCase(sampleResource("random-content-types.yaml"), "randomContentTypes").frameworks("java" -> Set("dropwizard", "dropwizard-vavr"), "scala" -> Set("http4s", "dropwizard")),
-    ExampleCase(sampleResource("binary.yaml"), "binary").frameworks("java" -> Set("dropwizard", "dropwizard-vavr"), "scala" -> Set("http4s")),
-    ExampleCase(sampleResource("binary3.yaml"), "binary3").frameworks("scala" -> Set("http4s")),
+    ExampleCase(sampleResource("random-content-types.yaml"), "randomContentTypes").frameworks("java" -> Set("dropwizard", "dropwizard-vavr"), "scala" -> Set("http4s", "http4s-v0.22", "dropwizard")),
+    ExampleCase(sampleResource("binary.yaml"), "binary").frameworks("java" -> Set("dropwizard", "dropwizard-vavr"), "scala" -> Set("http4s", "http4s-v0.22")),
+    ExampleCase(sampleResource("binary3.yaml"), "binary3").frameworks("scala" -> Set("http4s", "http4s-v0.22")),
     ExampleCase(sampleResource("conflicting-names.yaml"), "conflictingNames"),
     ExampleCase(sampleResource("base64.yaml"), "base64").frameworks("scala" -> scalaFrameworks.map(_.name).toSet),
-    ExampleCase(sampleResource("server1.yaml"), "customExtraction").args("--custom-extraction").frameworks("scala" -> Set("akka-http", "http4s")),
+    ExampleCase(sampleResource("server1.yaml"), "customExtraction").args("--custom-extraction").frameworks("scala" -> Set("akka-http", "http4s", "http4s-v0.22")),
     ExampleCase(sampleResource("mixed-content-types-3.0.2.yaml"), "mixedContentTypes").frameworks("scala" -> scalaFrameworks.map(_.name).toSet),
-    ExampleCase(sampleResource("debug-body.yaml"), "debugBody").frameworks("scala" -> Set("http4s")),
+    ExampleCase(sampleResource("debug-body.yaml"), "debugBody").frameworks("scala" -> Set("http4s", "http4s-v0.22")),
   )
 
   def exampleArgs(language: String, framework: Option[String] = None): List[List[String]] = exampleCases

--- a/project/src/main/scala/RegressionTests.scala
+++ b/project/src/main/scala/RegressionTests.scala
@@ -18,8 +18,8 @@ object RegressionTests {
     )
   )
 
-  val scalaFrameworks = exampleFrameworkSuites("scala").map(_.projectName)
-  val javaFrameworks = exampleFrameworkSuites("java").map(_.projectName)
+  val scalaFrameworks = exampleFrameworkSuites("scala")
+  val javaFrameworks = exampleFrameworkSuites("java")
 
   def sampleResource(name: String): java.io.File = file(s"modules/sample/src/main/resources/${name}")
   val exampleCases: List[ExampleCase] = List(
@@ -92,15 +92,15 @@ object RegressionTests {
     ExampleCase(sampleResource("redaction.yaml"), "redaction"),
     ExampleCase(sampleResource("server1.yaml"), "tracer").args("--tracing"),
     ExampleCase(sampleResource("server2.yaml"), "tracer").args("--tracing"),
-    ExampleCase(sampleResource("pathological-parameters.yaml"), "pathological").frameworks("java" -> javaFrameworks.toSet, "scala" -> (scalaFrameworks.toSet - "endpoints")), // Blocked by https://github.com/endpoints4s/endpoints4s/issues/713
+    ExampleCase(sampleResource("pathological-parameters.yaml"), "pathological").frameworks("java" -> javaFrameworks.map(_.name).toSet, "scala" -> (scalaFrameworks.map(_.name).toSet - "endpoints")), // Blocked by https://github.com/endpoints4s/endpoints4s/issues/713
     ExampleCase(sampleResource("response-headers.yaml"), "responseHeaders"),
     ExampleCase(sampleResource("random-content-types.yaml"), "randomContentTypes").frameworks("java" -> Set("dropwizard", "dropwizard-vavr"), "scala" -> Set("http4s", "dropwizard")),
     ExampleCase(sampleResource("binary.yaml"), "binary").frameworks("java" -> Set("dropwizard", "dropwizard-vavr"), "scala" -> Set("http4s")),
     ExampleCase(sampleResource("binary3.yaml"), "binary3").frameworks("scala" -> Set("http4s")),
     ExampleCase(sampleResource("conflicting-names.yaml"), "conflictingNames"),
-    ExampleCase(sampleResource("base64.yaml"), "base64").frameworks("scala" -> scalaFrameworks.toSet),
+    ExampleCase(sampleResource("base64.yaml"), "base64").frameworks("scala" -> scalaFrameworks.map(_.name).toSet),
     ExampleCase(sampleResource("server1.yaml"), "customExtraction").args("--custom-extraction").frameworks("scala" -> Set("akka-http", "http4s")),
-    ExampleCase(sampleResource("mixed-content-types-3.0.2.yaml"), "mixedContentTypes").frameworks("scala" -> scalaFrameworks.toSet),
+    ExampleCase(sampleResource("mixed-content-types-3.0.2.yaml"), "mixedContentTypes").frameworks("scala" -> scalaFrameworks.map(_.name).toSet),
     ExampleCase(sampleResource("debug-body.yaml"), "debugBody").frameworks("scala" -> Set("http4s")),
   )
 

--- a/project/src/main/scala/modules/scalaHttp4s.scala
+++ b/project/src/main/scala/modules/scalaHttp4s.scala
@@ -6,30 +6,54 @@ import sbt._
 import sbt.Keys._
 
 object scalaHttp4s {
-  val catsEffectVersion      = "2.5.4"
   val catsVersion            = "2.6.1"
   val circeVersion           = "0.14.1"
-  val http4sVersion          = "0.22.7"
   val javaxAnnotationVersion = "1.3.2"
   val jaxbApiVersion         = "2.3.1"
   val scalatestVersion       = "3.2.10"
 
-  val dependencies = Seq(
-    "javax.annotation" %  "javax.annotation-api"  % javaxAnnotationVersion, // for jdk11
-    "javax.xml.bind"   % "jaxb-api"               % jaxbApiVersion, // for jdk11
-  ) ++ Seq(
-    "io.circe"         %% "circe-core"            % circeVersion,
-    "io.circe"         %% "circe-parser"          % circeVersion,
-    "org.http4s"       %% "http4s-blaze-client"   % http4sVersion,
-    "org.http4s"       %% "http4s-blaze-server"   % http4sVersion,
-    "org.http4s"       %% "http4s-circe"          % http4sVersion,
-    "org.http4s"       %% "http4s-dsl"            % http4sVersion,
-    "org.scalatest"    %% "scalatest"             % scalatestVersion % Test,
-    "org.typelevel"    %% "cats-core"             % catsVersion,
-    "org.typelevel"    %% "cats-effect"           % catsEffectVersion
-  ).map(_.cross(CrossVersion.for3Use2_13))
+  val dependenciesV0_22 = {
+    val catsEffectVersion      = "2.5.4"
+    val http4sVersion          = "0.22.7"
+
+    Seq(
+      "javax.annotation" %  "javax.annotation-api"  % javaxAnnotationVersion, // for jdk11
+      "javax.xml.bind"   % "jaxb-api"               % jaxbApiVersion, // for jdk11
+    ) ++ Seq(
+      "io.circe"         %% "circe-core"            % circeVersion,
+      "io.circe"         %% "circe-parser"          % circeVersion,
+      "org.http4s"       %% "http4s-blaze-client"   % http4sVersion,
+      "org.http4s"       %% "http4s-blaze-server"   % http4sVersion,
+      "org.http4s"       %% "http4s-circe"          % http4sVersion,
+      "org.http4s"       %% "http4s-dsl"            % http4sVersion,
+      "org.scalatest"    %% "scalatest"             % scalatestVersion % Test,
+      "org.typelevel"    %% "cats-core"             % catsVersion,
+      "org.typelevel"    %% "cats-effect"           % catsEffectVersion
+    ).map(_.cross(CrossVersion.for3Use2_13))
+  }
+
+  val dependencies = {
+    val catsEffectVersion      = "3.2.9"
+    val http4sVersion          = "0.23.6"
+
+    Seq(
+      "javax.annotation" %  "javax.annotation-api"  % javaxAnnotationVersion, // for jdk11
+      "javax.xml.bind"   % "jaxb-api"               % jaxbApiVersion, // for jdk11
+    ) ++ Seq(
+      "io.circe"         %% "circe-core"            % circeVersion,
+      "io.circe"         %% "circe-parser"          % circeVersion,
+      "org.http4s"       %% "http4s-blaze-client"   % http4sVersion,
+      "org.http4s"       %% "http4s-blaze-server"   % http4sVersion,
+      "org.http4s"       %% "http4s-circe"          % http4sVersion,
+      "org.http4s"       %% "http4s-dsl"            % http4sVersion,
+      "org.scalatest"    %% "scalatest"             % scalatestVersion % Test,
+      "org.typelevel"    %% "cats-core"             % catsVersion,
+      "org.typelevel"    %% "cats-effect"           % catsEffectVersion
+    ).map(_.cross(CrossVersion.for3Use2_13))
+  }
 
   val project = commonModule("scala-http4s")
 
+  val sampleV0_22 = buildSampleProject("http4s-v0_22", dependenciesV0_22)
   val sample = buildSampleProject("http4s", dependencies)
 }


### PR DESCRIPTION
The change fixes regression tests filtering by framework: `scalaFrameworks` and `javaFrameworks` contained `projectName` before but `ExampleCase` required framework name instead. When `scalaFrameworks.toSet` was used, frameworks which have different name and projectName were filtered out. Considering that all `scalaFrameworks.toSet` usages were replaced by list of frameworks to prevent code generation where it's not required.

The http4s update change follows the suggestion from [the comment](https://github.com/guardrail-dev/guardrail/pull/1267#issuecomment-939404470). Also it copies http4s sample and tests for 0.22 to control regressions.