### PR TITLE
Test bincompat CI extensions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,8 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Run tests
       run:  sbt ++${{ matrix.scala.version }} clean guardrail/clean checkFormatting coverage guardrail/test coverageAggregate versionPolicyCheck microsite/compile
+      env:
+        GUARDRAIL_CI: true
     - uses: codecov/codecov-action@v1
       with:
         file: ./target/scala-${{ matrix.scala.bincompat }}/scoverage-report/scoverage.xml

--- a/project/src/main/scala/Build.scala
+++ b/project/src/main/scala/Build.scala
@@ -188,7 +188,14 @@ object Build {
 
     def customDependsOn(other: Project, useProvided: Boolean = false): Project = {
       val isRelease = sys.env.contains("GUARDRAIL_RELEASE_MODULE")
-      if (isRelease) {
+      val isCi = sys.env.contains("GUARDRAIL_CI")
+      val isBincompatCi = if (isCi) {
+        import scala.sys.process._
+        "support/current-pr-labels.sh"
+          .lineStream_!
+          .exists(Set("major", "minor").contains)
+      } else false
+      if (isRelease || isBincompatCi) {
         project
           .settings(libraryDependencySchemes += "dev.guardrail" % other.id % "early-semver")
           .settings(libraryDependencies += {

--- a/support/current-pr-labels.sh
+++ b/support/current-pr-labels.sh
@@ -1,10 +1,19 @@
+#!/bin/bash
 if [ -n "$GITHUB_EVENT_PATH" ]; then
   pr_number="$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")"
-  curl \
-    -H "Accept: application/vnd.github.v3+json" \
-    -H "Authorization: Bearer ${GITHUB_TOKEN}" \
-    "https://api.github.com/repos/guardrail-dev/guardrail/pulls/${pr_number}" | \
-    jq -r '.labels | map(.name)[]'
+  cache="${TMPDIR}/guardrail-ci-${pr_number}-labels-cache.json"
+  (
+    if [ -f "$cache" ]; then
+      cat "$cache"
+    else
+      echo "Fetching labels for current PR"
+      curl \
+        -H "Accept: application/vnd.github.v3+json" \
+        -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+        "https://api.github.com/repos/guardrail-dev/guardrail/pulls/${pr_number}" | \
+        tee "$cache"
+    fi
+  ) | jq -r '.labels | map(.name)[]'
 else
   echo 'Skipping finding labels because GITHUB_EVENT_PATH is not defined' >&2
 fi

--- a/support/current-pr-labels.sh
+++ b/support/current-pr-labels.sh
@@ -1,0 +1,10 @@
+if [ -n "$GITHUB_EVENT_PATH" ]; then
+  pr_number="$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")"
+  curl \
+    -H "Accept: application/vnd.github.v3+json" \
+    -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+    "https://api.github.com/repos/guardrail-dev/guardrail/pulls/${pr_number}" | \
+    jq -r '.labels | map(.name)[]'
+else
+  echo 'Skipping finding labels because GITHUB_EVENT_PATH is not defined' >&2
+fi


### PR DESCRIPTION
During CI, unless `major` or `minor` are explicitly specified, we should restrict to the current ABI for all modules