### PR TITLE
Unify model and prop meta

### DIFF
--- a/modules/core/src/main/scala/dev/guardrail/SwaggerUtil.scala
+++ b/modules/core/src/main/scala/dev/guardrail/SwaggerUtil.scala
@@ -285,11 +285,11 @@ object SwaggerUtil {
               } yield core.Resolved[L](customTpe.getOrElse(fallback), None, None, None, None)
           )
           .orRefine({ case a: ArraySchema => a })(
-            p =>
+            arr =>
               for {
-                items     <- getItems(p)
+                items     <- getItems(arr)
                 rec       <- propMetaImpl[L, F](items)(strategy)
-                arrayType <- customArrayTypeName(p).flatMap(_.flatTraverse(x => parseType(Tracker.cloneHistory(p, x))))
+                arrayType <- customArrayTypeName(arr).flatMap(_.flatTraverse(x => parseType(Tracker.cloneHistory(arr, x))))
                 res <- rec match {
                   case core.Resolved(inner, dep, default, _, _) =>
                     (liftVectorType(inner, arrayType), default.traverse(liftVectorTerm))

--- a/modules/core/src/main/scala/dev/guardrail/SwaggerUtil.scala
+++ b/modules/core/src/main/scala/dev/guardrail/SwaggerUtil.scala
@@ -274,7 +274,7 @@ object SwaggerUtil {
         } yield res
       }
 
-      log.debug(s"property:\n${log.schemaToString(property.unwrapTracker)} (${property.unwrapTracker.getExtensions()}, ${property.showHistory})").flatMap { _ =>
+      log.debug(s"property:\n${log.schemaToString(property.unwrapTracker)} (${property.unwrapTracker.getExtensions()}, ${property.showHistory})") >> (
         strategy(property)
           .orRefine({ case o: ObjectSchema => o })(
             o =>
@@ -336,7 +336,7 @@ object SwaggerUtil {
           .orRefine({ case b: BinarySchema => b })(buildResolveNoDefault)
           .orRefine({ case u: UUIDSchema => u })(buildResolveNoDefault)
           .orRefineFallback(x => fallbackPropertyTypeHandler(x).map(core.Resolved[L](_, None, None, None, None))) // This may need to be rawType=string?
-      }
+        )
     }
 
   def extractSecuritySchemes[L <: LA, F[_]](

--- a/modules/core/src/main/scala/dev/guardrail/SwaggerUtil.scala
+++ b/modules/core/src/main/scala/dev/guardrail/SwaggerUtil.scala
@@ -78,7 +78,7 @@ object SwaggerUtil {
                 .refine[F[core.ResolvedType[L]]]({ case b: java.lang.Boolean => b })(
                   _ => objectType(None).map(core.Resolved[L](_, None, None, rawType.unwrapTracker, rawFormat.unwrapTracker))
                 )
-                .orRefine({ case s: Schema[_] => s })(propMeta[L, F](_))
+                .orRefine({ case s: Schema[_] => s })(s => propMetaImpl[L, F](s)(Left(_)).flatMap(resolveScalarTypes[L, F]).flatMap(enrichWithDefault[L, F](s)))
                 .orRefineFallback({ s =>
                   log.debug(s"Unknown structure cannot be reflected: ${s.unwrapTracker} (${s.showHistory})") >> objectType(None)
                     .map(core.Resolved[L](_, None, None, rawType.unwrapTracker, rawFormat.unwrapTracker))
@@ -326,31 +326,32 @@ object SwaggerUtil {
                 }
               } yield res
           )
-          .orRefine({ case m: MapSchema => m })(
-            m =>
-              for {
-                rec <- m
-                  .downField("additionalProperties", _.getAdditionalProperties())
-                  .map(_.getOrElse(false))
-                  .refine[F[core.ResolvedType[L]]]({ case b: java.lang.Boolean => b })(_ => objectType(None).map(core.Resolved[L](_, None, None, None, None)))
-                  .orRefine({ case s: Schema[_] => s })(
-                    s => propMetaImpl[L, F](s)(strategy).flatMap(resolveScalarTypes[L, F]).flatMap(enrichWithDefault[L, F](s))
-                  )
-                  .orRefineFallback({ s =>
-                    log.debug(s"Unknown structure cannot be reflected: ${s.unwrapTracker} (${s.showHistory})") >> objectType(None).map(
-                      core.Resolved[L](_, None, None, None, None)
-                    )
-                  })
-                mapType <- customMapTypeName(m).flatMap(_.flatTraverse(x => parseType(Tracker.cloneHistory(m, x))))
-                res <- rec match {
-                  case core.Resolved(inner, dep, _, _, _) =>
-                    liftMapType(inner, mapType).map(core.Resolved[L](_, dep, None, None, None))
-                  case x: core.DeferredMap[L]   => embedMap(x, mapType)
-                  case x: core.DeferredArray[L] => embedMap(x, mapType)
-                  case x: core.Deferred[L]      => embedMap(x, mapType)
-                }
-              } yield res
-          )
+          .orRefine({ case map: MapSchema => map })({ map =>
+            val rawType   = map.downField("type", _.getType())
+            val rawFormat = map.downField("format", _.getFormat())
+            for {
+              rec <- map
+                .downField("additionalProperties", _.getAdditionalProperties())
+                .map(_.getOrElse(false))
+                .refine[F[core.ResolvedType[L]]]({ case b: java.lang.Boolean => b })(
+                  _ => objectType(None).map(core.Resolved[L](_, None, None, rawType.unwrapTracker, rawFormat.unwrapTracker))
+                )
+                .orRefine({ case s: Schema[_] => s })(
+                  s => propMetaImpl[L, F](s)(strategy).flatMap(resolveScalarTypes[L, F]).flatMap(enrichWithDefault[L, F](s))
+                )
+                .orRefineFallback({ s =>
+                  log.debug(s"Unknown structure cannot be reflected: ${s.unwrapTracker} (${s.showHistory})") >> objectType(None)
+                    .map(core.Resolved[L](_, None, None, rawType.unwrapTracker, rawFormat.unwrapTracker))
+                })
+              mapType <- customMapTypeName(map).flatMap(_.flatTraverse(x => parseType(Tracker.cloneHistory(map, x))))
+              res <- rec match {
+                case core.Resolved(inner, dep, _, tpe, fmt) => liftMapType(inner, mapType).map(core.Resolved[L](_, dep, None, tpe, fmt))
+                case x: core.DeferredMap[L]                 => embedMap(x, mapType)
+                case x: core.DeferredArray[L]               => embedMap(x, mapType)
+                case x: core.Deferred[L]                    => embedMap(x, mapType)
+              }
+            } yield res
+          })
           .orRefine({ case ref: Schema[_] if Option(ref.get$ref).isDefined => ref })(ref => getSimpleRef(ref.map(Option.apply _)).map(core.Deferred[L]))
         )
         .pure[F]

--- a/modules/core/src/main/scala/dev/guardrail/SwaggerUtil.scala
+++ b/modules/core/src/main/scala/dev/guardrail/SwaggerUtil.scala
@@ -92,16 +92,9 @@ object SwaggerUtil {
               }
             } yield res
           })
-          .orRefine({ case ref: Schema[_] if Option(ref.get$ref).isDefined => ref })(ref => getSimpleRef(ref.map(Option.apply _)).map(core.Deferred[L]))
-          .orRefineFallback(
-            impl =>
-              for {
-                tpeName       <- getType(impl)
-                customTpeName <- customTypeName(impl)
-                fmt = impl.downField("format", _.getFormat())
-                tpe <- typeName[L, F](tpeName.map(Option(_)), fmt, Tracker.cloneHistory(impl, customTpeName))
-              } yield core.Resolved[L](tpe, None, None, Some(tpeName.unwrapTracker), fmt.unwrapTracker)
-          ))
+          .orRefine({ case ref: Schema[_] if Option(ref.get$ref).isDefined => ref })(ref => getSimpleRef(ref.map(Option.apply _)).map(core.Deferred[L])))
+          .pure[F]
+          .flatMap(resolveScalarTypes[L, F])
       }
   }
 

--- a/modules/core/src/main/scala/dev/guardrail/SwaggerUtil.scala
+++ b/modules/core/src/main/scala/dev/guardrail/SwaggerUtil.scala
@@ -56,14 +56,17 @@ object SwaggerUtil {
           .orRefine({ case arr: ArraySchema => arr })(
             arr =>
               for {
-                items     <- getItems(arr)
-                _         <- log.debug(s"items:\n${log.schemaToString(items.unwrapTracker)}")
-                meta      <- propMeta[L, F](items)
-                _         <- log.debug(s"meta: ${meta}")
+                items <- getItems(arr)
+                _     <- log.debug(s"items:\n${log.schemaToString(items.unwrapTracker)}")
+                meta  <- propMeta[L, F](items)
+                _     <- log.debug(s"meta: ${meta}")
+                rawType   = arr.downField("type", _.getType())
+                rawFormat = arr.downField("format", _.getFormat())
                 arrayType <- customArrayTypeName(arr).flatMap(_.flatTraverse(x => parseType(Tracker.cloneHistory(arr, x))))
                 res <- meta match {
                   case core.Resolved(inner, dep, default, _, _) =>
-                    (liftVectorType(inner, arrayType), default.traverse(liftVectorTerm(_))).mapN(core.Resolved[L](_, dep, _, None, None))
+                    (liftVectorType(inner, arrayType), default.traverse(liftVectorTerm(_)))
+                      .mapN(core.Resolved[L](_, dep, _, rawType.unwrapTracker, rawFormat.unwrapTracker))
                   case x: core.Deferred[L]      => embedArray(x, arrayType)
                   case x: core.DeferredArray[L] => embedArray(x, arrayType)
                   case x: core.DeferredMap[L]   => embedArray(x, arrayType)
@@ -71,22 +74,26 @@ object SwaggerUtil {
               } yield res
           )
           .orRefine({ case map: MapSchema => map })({ map =>
+            val rawType   = map.downField("type", _.getType())
+            val rawFormat = map.downField("format", _.getFormat())
             for {
               rec <- map
                 .downField("additionalProperties", _.getAdditionalProperties())
                 .map(_.getOrElse(false))
-                .refine[F[core.ResolvedType[L]]]({ case b: java.lang.Boolean => b })(_ => objectType(None).map(core.Resolved[L](_, None, None, None, None)))
+                .refine[F[core.ResolvedType[L]]]({ case b: java.lang.Boolean => b })(
+                  _ => objectType(None).map(core.Resolved[L](_, None, None, rawType.unwrapTracker, rawFormat.unwrapTracker))
+                )
                 .orRefine({ case s: Schema[_] => s })(propMeta[L, F](_))
                 .orRefineFallback({ s =>
                   log.debug(s"Unknown structure cannot be reflected: ${s.unwrapTracker} (${s.showHistory})") >> objectType(None)
-                    .map(core.Resolved[L](_, None, None, None, None))
+                    .map(core.Resolved[L](_, None, None, rawType.unwrapTracker, rawFormat.unwrapTracker))
                 })
               mapType <- customMapTypeName(map).flatMap(_.flatTraverse(x => parseType(Tracker.cloneHistory(map, x))))
               res <- rec match {
-                case core.Resolved(inner, dep, _, _, _) => liftMapType(inner, mapType).map(core.Resolved[L](_, dep, None, None, None))
-                case x: core.DeferredMap[L]             => embedMap(x, mapType)
-                case x: core.DeferredArray[L]           => embedMap(x, mapType)
-                case x: core.Deferred[L]                => embedMap(x, mapType)
+                case core.Resolved(inner, dep, _, tpe, fmt) => liftMapType(inner, mapType).map(core.Resolved[L](_, dep, None, tpe, fmt))
+                case x: core.DeferredMap[L]                 => embedMap(x, mapType)
+                case x: core.DeferredArray[L]               => embedMap(x, mapType)
+                case x: core.Deferred[L]                    => embedMap(x, mapType)
               }
             } yield res
           })

--- a/modules/core/src/main/scala/dev/guardrail/SwaggerUtil.scala
+++ b/modules/core/src/main/scala/dev/guardrail/SwaggerUtil.scala
@@ -37,14 +37,8 @@ object SwaggerUtil {
     } yield CustomMapTypeName(v, prefixes)
   }
 
-  sealed class ModelMetaTypePartiallyApplied[L <: LA, F[_]](val dummy: Boolean = true) {
-    def apply(
-        model: Tracker[Schema[_]]
-    )(implicit Sc: LanguageTerms[L, F], Cl: CollectionsLibTerms[L, F], Sw: SwaggerTerms[L, F], Fw: FrameworkTerms[L, F]): F[core.ResolvedType[L]] =
-      propMetaImpl[L, F](model)(Left(_))
-  }
-
-  def modelMetaType[L <: LA, F[_]]: ModelMetaTypePartiallyApplied[L, F] = new ModelMetaTypePartiallyApplied[L, F]()
+  def modelMetaType[L <: LA, F[_]](model: Tracker[Schema[_]])(implicit Sc: LanguageTerms[L, F], Cl: CollectionsLibTerms[L, F], Sw: SwaggerTerms[L, F], Fw: FrameworkTerms[L, F]): F[core.ResolvedType[L]] =
+    propMetaImpl[L, F](model)(Left(_))
 
   def extractConcreteTypes[L <: LA, F[_]](
       definitions: List[(String, Tracker[Schema[_]])]

--- a/modules/core/src/main/scala/dev/guardrail/SwaggerUtil.scala
+++ b/modules/core/src/main/scala/dev/guardrail/SwaggerUtil.scala
@@ -62,7 +62,12 @@ object SwaggerUtil {
                   formattedClsName <- formatTypeName(clsName)
                   typeName         <- pureTypeName(formattedClsName)
                   widenedTypeName  <- widenTypeName(typeName)
-                  parentSimpleRef = comp.downField("allOf", _.getAllOf).map(_.headOption).flatDownField("$ref", _.get$ref).unwrapTracker.map(_.split("/").last)
+                  parentSimpleRef = comp
+                    .downField("allOf", _.getAllOf)
+                    .indexedDistribute
+                    .headOption
+                    .flatMap(_.downField("$ref", _.get$ref).indexedDistribute)
+                    .map(_.unwrapTracker.split("/").last)
                   parentTerm <- parentSimpleRef.traverse(n => pureTermName(n))
                   resolvedType = core.Resolved[L](widenedTypeName, parentTerm, None, None, None): core.ResolvedType[L]
                 } yield (clsName, resolvedType)

--- a/modules/core/src/main/scala/dev/guardrail/SwaggerUtil.scala
+++ b/modules/core/src/main/scala/dev/guardrail/SwaggerUtil.scala
@@ -95,6 +95,7 @@ object SwaggerUtil {
           .orRefine({ case ref: Schema[_] if Option(ref.get$ref).isDefined => ref })(ref => getSimpleRef(ref.map(Option.apply _)).map(core.Deferred[L])))
           .pure[F]
           .flatMap(resolveScalarTypes[L, F])
+          .flatMap(enrichWithDefault[L, F](model))
       }
   }
 

--- a/modules/core/src/main/scala/dev/guardrail/SwaggerUtil.scala
+++ b/modules/core/src/main/scala/dev/guardrail/SwaggerUtil.scala
@@ -69,7 +69,7 @@ object SwaggerUtil {
             )
             .getOrElse(
               for {
-                resolved <- SwaggerUtil.modelMetaType[L, F](schema)
+                resolved <- modelMetaType[L, F](schema)
               } yield (clsName, resolved)
             )
       }

--- a/modules/core/src/main/scala/dev/guardrail/generators/ProtocolGenerator.scala
+++ b/modules/core/src/main/scala/dev/guardrail/generators/ProtocolGenerator.scala
@@ -203,10 +203,11 @@ object ProtocolGenerator {
           for {
             typeName <- formatTypeName(name).map(formattedName => NonEmptyList.of(hierarchy.name, formattedName))
             propertyRequirement = getPropertyRequirement(prop, requiredFields.contains(name), defaultPropertyRequirement)
-            customType   <- SwaggerUtil.customTypeName(prop)
-            resolvedType <- SwaggerUtil.propMeta[L, F](prop)
-            defValue     <- defaultValue(typeName, prop, propertyRequirement, definitions)
-            fieldName    <- formatFieldName(name)
+            customType <- SwaggerUtil.customTypeName(prop)
+            resolvedType <- SwaggerUtil
+              .propMeta[L, F](prop) // TODO: This should be resolved via an alternate mechanism that maintains references all the way through, instead of re-deriving and assuming that references are valid
+            defValue  <- defaultValue(typeName, prop, propertyRequirement, definitions)
+            fieldName <- formatFieldName(name)
             res <- transformProperty(hierarchy.name, dtoPackage, supportPackage, concreteTypes)(
               name,
               fieldName,

--- a/modules/microsite/src/main/scala/DocsHelpers.scala
+++ b/modules/microsite/src/main/scala/DocsHelpers.scala
@@ -55,7 +55,7 @@ object DocsHelpers {
             val o                                                 = q"object ${Term.Name(className)} { ..${definitions} }"
             val Right(q"""class ${name }(...${args }) {
               ..${defns }
-            }""" )                                                = (g.client.head: @unchecked)
+            }""")                                                 = (g.client.head: @unchecked)
             val basePath = defns.collectFirst {
               case v @ q"val basePath: String = $_" => v
             }

--- a/modules/sample/src/main/resources/response-headers.yaml
+++ b/modules/sample/src/main/resources/response-headers.yaml
@@ -8,10 +8,11 @@ components:
   schemas:
     Foo:
       type: object
+      required:
+        - name
       properties:
         name:
           type: string
-          required: true
 paths:
   /foo:
     get:

--- a/modules/scala-http4s/src/main/scala/dev/guardrail/generators/scala/http4s/Http4sServerGenerator.scala
+++ b/modules/scala-http4s/src/main/scala/dev/guardrail/generators/scala/http4s/Http4sServerGenerator.scala
@@ -905,11 +905,12 @@ class Http4sServerGenerator private (version: Http4sVersion)(implicit Cl: Collec
       for {
         _ <- Target.log.debug("Found that not all parameters could be represented as unescaped terms")
         res <- parameters.traverse[Target, LanguageParameter[ScalaLanguage]] { param =>
-          val newName = Term.Name(s"_${param.paramName.value}")
-          Target.log.debug(s"Escaping param ${param.argName.value}").flatMap { _ =>
-            if (newName.syntax == newName.value) Target.pure(param.withParamName(newName))
+          for {
+            _ <- Target.log.debug(s"Escaping param ${param.argName.value}")
+            newName = Term.Name(s"_${param.paramName.value}")
+            res <- if (newName.syntax == newName.value) Target.pure(param.withParamName(newName))
             else Target.raiseUserError(s"Can't escape parameter with name ${param.argName.value}.")
-          }
+          } yield res
         }
       } yield res
     } else {

--- a/modules/scala-http4s/src/test/scala/core/issues/Issue144.scala
+++ b/modules/scala-http4s/src/test/scala/core/issues/Issue144.scala
@@ -32,7 +32,7 @@ class Issue144 extends AnyFunSuite with Matchers with SwaggerSpecRunner {
        |         description: description
        |""".stripMargin
 
-  def testVersion(version: Http4sVersion): Unit = {
+  def testVersion(version: Http4sVersion): Unit =
     test(s"$version - Ensure mapRoute is generated") {
       val (_, _, Servers(Server(_, _, _, genResource :: _) :: Nil, _)) = runSwaggerSpec(swagger)(Context.empty, new Http4s(version))
 
@@ -63,7 +63,6 @@ class Issue144 extends AnyFunSuite with Matchers with SwaggerSpecRunner {
       // Cause structure is slightly different but source code is the same the value converted to string and then parsed
       genResource.toString().parse[Stat].get.structure shouldEqual resource.structure
     }
-  }
 
   testVersion(Http4sVersion.V0_22)
   testVersion(Http4sVersion.V0_23)

--- a/modules/scala-http4s/src/test/scala/core/issues/Issue165.scala
+++ b/modules/scala-http4s/src/test/scala/core/issues/Issue165.scala
@@ -40,7 +40,7 @@ class Issue165 extends AnyFunSuite with Matchers with SwaggerSpecRunner {
        |         description: description
        |""".stripMargin
 
-  def testVersion(version: Http4sVersion): Unit = {
+  def testVersion(version: Http4sVersion): Unit =
     test(s"$version - Ensure routes are generated") {
       val (_, _, Servers(Server(_, _, genHandler, genResource :: _) :: Nil, Nil)) = runSwaggerSpec(swagger)(Context.empty, new Http4s(version))
 
@@ -88,7 +88,6 @@ class Issue165 extends AnyFunSuite with Matchers with SwaggerSpecRunner {
       // Cause structure is slightly different but source code is the same the value converted to string and then parsed
       genResource.toString().parse[Stat].get.structure shouldEqual resource.structure
     }
-  }
 
   testVersion(Http4sVersion.V0_22)
   testVersion(Http4sVersion.V0_23)

--- a/modules/scala-http4s/src/test/scala/core/issues/Issue166.scala
+++ b/modules/scala-http4s/src/test/scala/core/issues/Issue166.scala
@@ -45,7 +45,7 @@ class Issue166 extends AnyFunSuite with Matchers with SwaggerSpecRunner {
                    |        type: string
                    |""".stripMargin
 
-  def testVersion(version: Http4sVersion): Unit = {
+  def testVersion(version: Http4sVersion): Unit =
     test(s"$version - Handle generation of models") {
       val opts = new ParseOptions()
       opts.setResolve(true)
@@ -73,7 +73,6 @@ class Issue166 extends AnyFunSuite with Matchers with SwaggerSpecRunner {
 
       cls.structure should equal(definition.structure)
     }
-  }
 
   testVersion(Http4sVersion.V0_22)
   testVersion(Http4sVersion.V0_23)

--- a/modules/scala-http4s/src/test/scala/core/issues/Issue223.scala
+++ b/modules/scala-http4s/src/test/scala/core/issues/Issue223.scala
@@ -33,7 +33,7 @@ class Issue223 extends AnyFunSuite with Matchers with SwaggerSpecRunner {
                            |        description: uuid of kernel
                            |""".stripMargin
 
-  def testVersion(version: Http4sVersion): Unit = {
+  def testVersion(version: Http4sVersion): Unit =
     test(s"$version - Test uuid format generation") {
       val (
         ProtocolDefinitions(ClassDefinition(_, _, _, c1, _, _) :: Nil, _, _, _, _),
@@ -43,7 +43,6 @@ class Issue223 extends AnyFunSuite with Matchers with SwaggerSpecRunner {
 
       c1.structure shouldBe q"case class Kernel(id: java.util.UUID)".structure
     }
-  }
 
   testVersion(Http4sVersion.V0_22)
   testVersion(Http4sVersion.V0_23)

--- a/modules/scala-http4s/src/test/scala/core/issues/Issue225.scala
+++ b/modules/scala-http4s/src/test/scala/core/issues/Issue225.scala
@@ -30,7 +30,7 @@ class Issue225 extends AnyFunSuite with Matchers with SwaggerSpecRunner {
        |         description: description
        |""".stripMargin
 
-  def testVersion(version: Http4sVersion): Unit = {
+  def testVersion(version: Http4sVersion): Unit =
     test(s"$version - Ensure mapRoute is generated") {
       val (_, _, Servers(Server(_, _, genHandler, genResource :: _) :: Nil, Nil)) = runSwaggerSpec(swagger)(Context.empty, new Http4s(version))
 
@@ -61,7 +61,6 @@ class Issue225 extends AnyFunSuite with Matchers with SwaggerSpecRunner {
       // Cause structure is slightly different but source code is the same the value converted to string and then parsed
       genResource.toString().parse[Stat].get.structure shouldEqual resource.structure
     }
-  }
 
   testVersion(Http4sVersion.V0_22)
   testVersion(Http4sVersion.V0_23)

--- a/modules/scala-http4s/src/test/scala/core/issues/Issue255.scala
+++ b/modules/scala-http4s/src/test/scala/core/issues/Issue255.scala
@@ -41,7 +41,7 @@ class Issue255 extends AnyFunSuite with Matchers with SwaggerSpecRunner {
                            |        x-scala-type: custom.Bytes
                            |""".stripMargin
 
-  def testVersion(version: Http4sVersion): Unit = {
+  def testVersion(version: Http4sVersion): Unit =
     test(s"$version - Test password format generation") {
       val (
         ProtocolDefinitions(ClassDefinition(_, _, _, c1, _, _) :: Nil, _, _, _, _),
@@ -59,7 +59,6 @@ class Issue255 extends AnyFunSuite with Matchers with SwaggerSpecRunner {
        """
       c1.structure shouldBe expected.structure
     }
-  }
 
   testVersion(Http4sVersion.V0_22)
   testVersion(Http4sVersion.V0_23)

--- a/modules/scala-http4s/src/test/scala/core/issues/Issue260.scala
+++ b/modules/scala-http4s/src/test/scala/core/issues/Issue260.scala
@@ -10,7 +10,7 @@ import org.scalatest.matchers.should.Matchers
 
 class Issue260 extends AnyFunSpec with Matchers with SwaggerSpecRunner {
 
-  def testVersion(version: Http4sVersion): Unit = {
+  def testVersion(version: Http4sVersion): Unit =
     describe(version.toString()) {
       describe("LocalDate path param is generated more than once") {
 
@@ -93,7 +93,6 @@ class Issue260 extends AnyFunSpec with Matchers with SwaggerSpecRunner {
         }
       }
     }
-  }
 
   testVersion(Http4sVersion.V0_22)
   testVersion(Http4sVersion.V0_23)

--- a/modules/scala-http4s/src/test/scala/core/issues/Issue370.scala
+++ b/modules/scala-http4s/src/test/scala/core/issues/Issue370.scala
@@ -53,7 +53,7 @@ class Issue370 extends AnyFunSuite with Matchers with SwaggerSpecRunner {
                            |    default: x
                            |""".stripMargin
 
-  def testVersion(version: Http4sVersion): Unit = {
+  def testVersion(version: Http4sVersion): Unit =
     test(s"$version - Test nested enum definition") {
       val (
         ProtocolDefinitions(ClassDefinition(_, _, _, c1, s, _) :: _, _, _, _, _),
@@ -115,7 +115,6 @@ class Issue370 extends AnyFunSuite with Matchers with SwaggerSpecRunner {
       c1.structure shouldEqual q"case class Foo(value: Option[Foo.Value] = Option(Foo.Value.A), value2: Baz = Baz.X, nested: Option[Foo.Nested] = None)".structure
       companion.structure shouldEqual cmp.structure
     }
-  }
 
   testVersion(Http4sVersion.V0_22)
   testVersion(Http4sVersion.V0_23)

--- a/modules/scala-http4s/src/test/scala/core/issues/Issue416.scala
+++ b/modules/scala-http4s/src/test/scala/core/issues/Issue416.scala
@@ -40,7 +40,7 @@ class Issue416 extends AnyFunSuite with Matchers with SwaggerSpecRunner {
        |        type: string
        |""".stripMargin
 
-  def testVersion(version: Http4sVersion): Unit = {
+  def testVersion(version: Http4sVersion): Unit =
     test(s"$version - Ensure mapRoute is generated") {
       val (_, _, Servers(Server(_, _, genHandler, genResource :: _) :: Nil, _)) = runSwaggerSpec(swagger)(Context.empty, new Http4s(version))
 
@@ -70,7 +70,6 @@ class Issue416 extends AnyFunSuite with Matchers with SwaggerSpecRunner {
       // Cause structure is slightly different but source code is the same the value converted to string and then parsed
       genResource.toString().parse[Stat].get.structure shouldEqual resource.structure
     }
-  }
 
   testVersion(Http4sVersion.V0_22)
   testVersion(Http4sVersion.V0_23)

--- a/modules/scala-http4s/src/test/scala/core/issues/Issue420.scala
+++ b/modules/scala-http4s/src/test/scala/core/issues/Issue420.scala
@@ -32,7 +32,7 @@ class Issue420 extends AnyFunSuite with Matchers with SwaggerSpecRunner {
                           |      - $ref: "#/definitions/Bar"
                        |""".stripMargin
 
-  def testVersion(version: Http4sVersion): Unit = {
+  def testVersion(version: Http4sVersion): Unit =
     test(s"$version - Test ordering") {
       val (
         ProtocolDefinitions(List(bar: ClassDefinition[ScalaLanguage], foo: ClassDefinition[ScalaLanguage]), _, _, _, _),
@@ -43,7 +43,6 @@ class Issue420 extends AnyFunSuite with Matchers with SwaggerSpecRunner {
       cmp(bar.cls, q"case class Bar(id: Option[String] = None)")
       cmp(foo.cls, q"case class Foo(id: Option[String] = None, otherId: Option[String] = None)")
     }
-  }
 
   testVersion(Http4sVersion.V0_22)
   testVersion(Http4sVersion.V0_23)

--- a/modules/scala-http4s/src/test/scala/core/issues/Issue429.scala
+++ b/modules/scala-http4s/src/test/scala/core/issues/Issue429.scala
@@ -25,7 +25,7 @@ class Issue429 extends AnyFunSuite with Matchers with SwaggerSpecRunner {
     |          enum: [0, 1]
     |""".stripMargin
 
-  def testVersion(version: Http4sVersion): Unit = {
+  def testVersion(version: Http4sVersion): Unit =
     test(s"$version - Test correct escaping of numbers used as identifiers") {
       val (
         ProtocolDefinitions(ClassDefinition(_, _, _, _, staticDefns, _) :: Nil, _, _, _, _),
@@ -55,7 +55,6 @@ class Issue429 extends AnyFunSuite with Matchers with SwaggerSpecRunner {
       statusCodeCompanion.structure shouldBe expected.structure
       Term.Name("10").syntax shouldBe "`10`"
     }
-  }
 
   testVersion(Http4sVersion.V0_22)
   testVersion(Http4sVersion.V0_23)

--- a/modules/scala-http4s/src/test/scala/tests/core/FullyQualifiedNames.scala
+++ b/modules/scala-http4s/src/test/scala/tests/core/FullyQualifiedNames.scala
@@ -41,7 +41,7 @@ class FullyQualifiedNames extends AnyFunSuite with Matchers with SwaggerSpecRunn
       |            $ref: '#/definitions/User'
       |""".stripMargin
 
-  def testVersion(version: Http4sVersion): Unit = {
+  def testVersion(version: Http4sVersion): Unit =
     test(s"$version - Test that fully qualified names are used") {
       val (
         ProtocolDefinitions(List(clz @ ClassDefinition(_, _, fullType, _, _, _)), _, _, _, _),
@@ -82,7 +82,6 @@ class FullyQualifiedNames extends AnyFunSuite with Matchers with SwaggerSpecRunn
       respObject shouldEqual q"""object GetUserResponse { case class Ok(value: _root_.com.test.User) extends GetUserResponse }"""
 
     }
-  }
 
   testVersion(Http4sVersion.V0_22)
   testVersion(Http4sVersion.V0_23)

--- a/modules/scala-http4s/src/test/scala/tests/generators/http4s/client/DefaultParametersTest.scala
+++ b/modules/scala-http4s/src/test/scala/tests/generators/http4s/client/DefaultParametersTest.scala
@@ -123,7 +123,7 @@ class DefaultParametersTest extends AnyFunSuite with Matchers with SwaggerSpecRu
     |      name: Order
     |""".stripMargin
 
-  def testVersion(version: Http4sVersion): Unit = {
+  def testVersion(version: Http4sVersion): Unit =
     test(s"$version - Ensure responses are generated") {
       val (
         _,
@@ -212,7 +212,6 @@ class DefaultParametersTest extends AnyFunSuite with Matchers with SwaggerSpecRu
 
       statements.zip(expected).foreach({ case (a, b) => a.structure should equal(b.structure) })
     }
-  }
 
   testVersion(Http4sVersion.V0_22)
   testVersion(Http4sVersion.V0_23)


### PR DESCRIPTION
With a bit of doing, `modelMetaType` and `propMetaImpl` ended up being able to be unified. Both were nearly identical implementations, but stemmed from the fact that in swagger 2.0 days, `model` and `prop` were different type families. After OpenAPI unified them, this became possible.