### PR TITLE
Resolving some infrastructure issues

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -44,15 +44,15 @@ runExample := Def.inputTaskDyn {
   )
 }.evaluated
 
+// Make "cli" not emit unhandled exceptions on exit
+Test / fork := true
+
 addCommandAlias("runtimeAkkaHttpSuite", "; resetSample ; runExample scala akka-http ; sample-akkaHttp / test")
 
 addCommandAlias("resetSample", "; " ++ (scalaFrameworks ++ javaFrameworks).map(x => s"sample-${x.projectName}/clean").mkString(" ; "))
 
 // Deprecated command
 addCommandAlias("example", "runtimeSuite")
-
-// Make "cli" not emit unhandled exceptions on exit
-run / fork := true
 
 addCommandAlias("cli", "runMain dev.guardrail.cli.CLI")
 addCommandAlias("runtimeScalaSuite", "; resetSample ; runScalaExample ; " + scalaFrameworks.map(x => s"sample-${x.projectName}/test").mkString("; "))

--- a/modules/sample-dropwizardVavr/src/test/java/core/DropwizardVavr/DropwizardJsr310Test.java
+++ b/modules/sample-dropwizardVavr/src/test/java/core/DropwizardVavr/DropwizardJsr310Test.java
@@ -5,6 +5,7 @@ import dateTime.server.dropwizardVavr.dateTime.DateTimeResource;
 import io.dropwizard.testing.junit.ResourceTestRule;
 import io.vavr.concurrent.Future;
 import io.vavr.control.Option;
+import org.glassfish.jersey.test.TestProperties;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -18,6 +19,10 @@ import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 public class DropwizardJsr310Test {
+    static {
+        System.setProperty(TestProperties.CONTAINER_PORT, "0");
+    }
+
     private static final DateTimeHandler handler = mock(DateTimeHandler.class);
 
     @ClassRule


### PR DESCRIPTION
- When switching from sbt alias' to `taskKey`, I didn't know or realize that `run / fork := true` would no longer apply, impacting `runScalaExample`/`runJavaExample`/`runExample`, causing them to `exit(n)` after every run, taking down sbt with it
- Setting the jersey port bind property before running JSR310 tests to avoid port bind conflicts