### PR TITLE
Promoting determining packages from tags to a feature instead of deprecated

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -46,6 +46,7 @@ runExample := Def.inputTaskDyn {
 
 // Make "cli" not emit unhandled exceptions on exit
 Test / fork := true
+run / fork := true
 
 addCommandAlias("runtimeAkkaHttpSuite", "; resetSample ; runExample scala akka-http ; sample-akkaHttp / test")
 
@@ -147,6 +148,7 @@ lazy val core = modules.core.project
 
 lazy val cli = modules.cli.project
   .customDependsOn(guardrail)
+  .settings(run / fork := true)
 
 lazy val javaSupport = modules.javaSupport.project
   .customDependsOn(core)

--- a/modules/cli/src/main/scala/dev/guardrail/cli/CLICommon.scala
+++ b/modules/cli/src/main/scala/dev/guardrail/cli/CLICommon.scala
@@ -31,7 +31,7 @@ object CLICommon {
     |   --framework <framework name>                           : Use one of the pre-composed frameworks
     |   --module <module name>                                 : Explicitly select libraries to satisfy composition requirements
     |   --custom-extraction                                    : Permit supplying an akka-http Directive into the generated guardrail routing layer (server only)
-    |   --tags-are-packages                                    : Use the tags, defined in the OpenAPI specification, to guide the generated package structures
+    |   --package-from-tags                                    : Use the tags, defined in the OpenAPI specification, to guide the generated package structures
     |
     |Examples:
     |  Generate two clients, put both in src/main/scala, under different packages, one with tracing, one without:
@@ -128,8 +128,8 @@ trait CLICommon extends GuardrailRunner {
                 Continue((sofar.copyContext(modules = sofar.context.modules :+ value) :: already, xs))
               case (sofar :: already, "--custom-extraction" :: xs) =>
                 Continue((sofar.copyContext(customExtraction = true) :: already, xs))
-              case (sofar :: already, "--tags-are-packages" :: xs) =>
-                Continue((sofar.copyContext(tagsBehaviour = Context.TagsArePackages) :: already, xs))
+              case (sofar :: already, "--package-from-tags" :: xs) =>
+                Continue((sofar.copyContext(tagsBehaviour = Context.PackageFromTags) :: already, xs))
               case (sofar :: already, (arg @ "--optional-encode-as") :: value :: xs) =>
                 for {
                   propertyRequirement <- parseOptionalProperty(arg, value)

--- a/modules/cli/src/main/scala/dev/guardrail/cli/CLICommon.scala
+++ b/modules/cli/src/main/scala/dev/guardrail/cli/CLICommon.scala
@@ -31,6 +31,7 @@ object CLICommon {
     |   --framework <framework name>                           : Use one of the pre-composed frameworks
     |   --module <module name>                                 : Explicitly select libraries to satisfy composition requirements
     |   --custom-extraction                                    : Permit supplying an akka-http Directive into the generated guardrail routing layer (server only)
+    |   --tags-are-packages                                    : Use the tags, defined in the OpenAPI specification, to guide the generated package structures
     |
     |Examples:
     |  Generate two clients, put both in src/main/scala, under different packages, one with tracing, one without:
@@ -127,6 +128,8 @@ trait CLICommon extends GuardrailRunner {
                 Continue((sofar.copyContext(modules = sofar.context.modules :+ value) :: already, xs))
               case (sofar :: already, "--custom-extraction" :: xs) =>
                 Continue((sofar.copyContext(customExtraction = true) :: already, xs))
+              case (sofar :: already, "--tags-are-packages" :: xs) =>
+                Continue((sofar.copyContext(tagsBehaviour = Context.TagsArePackages) :: already, xs))
               case (sofar :: already, (arg @ "--optional-encode-as") :: value :: xs) =>
                 for {
                   propertyRequirement <- parseOptionalProperty(arg, value)

--- a/modules/core/src/main/scala/dev/guardrail/Args.scala
+++ b/modules/core/src/main/scala/dev/guardrail/Args.scala
@@ -18,7 +18,8 @@ case class Args(
       customExtraction: Boolean = self.context.customExtraction,
       tracing: Boolean = self.context.tracing,
       modules: List[String] = self.context.modules,
-      propertyRequirement: PropertyRequirement.Configured = self.context.propertyRequirement
+      propertyRequirement: PropertyRequirement.Configured = self.context.propertyRequirement,
+      tagsBehaviour: Context.TagsBehaviour = self.context.tagsBehaviour
   ): Args =
     self.copy(
       context = self.context.copy(
@@ -26,7 +27,8 @@ case class Args(
         customExtraction = customExtraction,
         tracing = tracing,
         modules = modules,
-        propertyRequirement = propertyRequirement
+        propertyRequirement = propertyRequirement,
+        tagsBehaviour = tagsBehaviour
       )
     )
 

--- a/modules/core/src/main/scala/dev/guardrail/Common.scala
+++ b/modules/core/src/main/scala/dev/guardrail/Common.scala
@@ -79,7 +79,7 @@ object Common {
       routes           <- extractOperations(paths, requestBodies, globalSecurityRequirements)
       prefixes         <- vendorPrefixes()
       securitySchemes  <- SwaggerUtil.extractSecuritySchemes(swagger.unwrapTracker, prefixes)
-      classNamedRoutes <- routes.traverse(route => getClassName(route.operation, prefixes).map(_ -> route))
+      classNamedRoutes <- routes.traverse(route => getClassName(route.operation, prefixes, context.tagsBehaviour).map(_ -> route))
       groupedRoutes = classNamedRoutes
         .groupMap(_._1)(_._2)
         .toList

--- a/modules/core/src/main/scala/dev/guardrail/Context.scala
+++ b/modules/core/src/main/scala/dev/guardrail/Context.scala
@@ -7,15 +7,21 @@ case class Context(
     customExtraction: Boolean,
     tracing: Boolean,
     modules: List[String],
-    propertyRequirement: PropertyRequirement.Configured
+    propertyRequirement: PropertyRequirement.Configured,
+    tagsBehaviour: Context.TagsBehaviour
 )
 
 object Context {
+  sealed trait TagsBehaviour
+  case object TagsArePackages extends TagsBehaviour
+  case object TagsAreIgnored  extends TagsBehaviour
+
   val empty: Context = Context(
     None,
     customExtraction = false,
     tracing = false,
     modules = List.empty,
-    propertyRequirement = PropertyRequirement.Configured(PropertyRequirement.OptionalLegacy, PropertyRequirement.OptionalLegacy)
+    propertyRequirement = PropertyRequirement.Configured(PropertyRequirement.OptionalLegacy, PropertyRequirement.OptionalLegacy),
+    tagsBehaviour = TagsAreIgnored
   )
 }

--- a/modules/core/src/main/scala/dev/guardrail/Context.scala
+++ b/modules/core/src/main/scala/dev/guardrail/Context.scala
@@ -13,7 +13,7 @@ case class Context(
 
 object Context {
   sealed trait TagsBehaviour
-  case object TagsArePackages extends TagsBehaviour
+  case object PackageFromTags extends TagsBehaviour
   case object TagsAreIgnored  extends TagsBehaviour
 
   val empty: Context = Context(

--- a/modules/core/src/main/scala/dev/guardrail/generators/ProtocolGenerator.scala
+++ b/modules/core/src/main/scala/dev/guardrail/generators/ProtocolGenerator.scala
@@ -773,8 +773,8 @@ object ProtocolGenerator {
                   tpeName        <- getType(x)
                   customTypeName <- SwaggerUtil.customTypeName(x)
                   tpe            <- SwaggerUtil.typeName[L, F](tpeName.map(Option(_)), x.downField("format", _.getFormat()), Tracker.cloneHistory(x, customTypeName))
-                  res            <- typeAlias[L, F](formattedClsName, tpe)
-                } yield enum.orElse(model).getOrElse(res)
+                  alias          <- typeAlias[L, F](formattedClsName, tpe)
+                } yield enum.orElse(model).getOrElse(alias)
             )
             .valueOr(
               x =>

--- a/modules/core/src/main/scala/dev/guardrail/generators/SwaggerGenerator.scala
+++ b/modules/core/src/main/scala/dev/guardrail/generators/SwaggerGenerator.scala
@@ -178,7 +178,7 @@ class SwaggerGenerator[L <: LA] extends SwaggerTerms[L, Target] {
             .map(_.split('.').toVector)
             .orElse(
               tagBehaviour match {
-                case Context.TagsArePackages =>
+                case Context.PackageFromTags =>
                   operation
                     .downField("tags", _.getTags)
                     .toNel

--- a/modules/core/src/main/scala/dev/guardrail/terms/SwaggerTerms.scala
+++ b/modules/core/src/main/scala/dev/guardrail/terms/SwaggerTerms.scala
@@ -38,7 +38,7 @@ abstract class SwaggerTerms[L <: LA, F[_]] {
   def extractHttpSecurityScheme(schemeName: String, securityScheme: SwSecurityScheme, tpe: Option[L#Type]): F[HttpSecurityScheme[L]]
   def extractOpenIdConnectSecurityScheme(schemeName: String, securityScheme: SwSecurityScheme, tpe: Option[L#Type]): F[OpenIdConnectSecurityScheme[L]]
   def extractOAuth2SecurityScheme(schemeName: String, securityScheme: SwSecurityScheme, tpe: Option[L#Type]): F[OAuth2SecurityScheme[L]]
-  def getClassName(operation: Tracker[Operation], vendorPrefixes: List[String]): F[List[String]]
+  def getClassName(operation: Tracker[Operation], vendorPrefixes: List[String], tagBehaviour: Context.TagsBehaviour): F[List[String]]
   def getParameterName(parameter: Tracker[Parameter]): F[String]
   def getBodyParameterSchema(parameter: Tracker[Parameter]): F[Tracker[Schema[_]]]
   def getHeaderParameterType(parameter: Tracker[Parameter]): F[Tracker[String]]

--- a/modules/scala-support/src/main/scala/dev/guardrail/generators/scala/jackson/JacksonProtocolGenerator.scala
+++ b/modules/scala-support/src/main/scala/dev/guardrail/generators/scala/jackson/JacksonProtocolGenerator.scala
@@ -224,7 +224,7 @@ object JacksonProtocolGenerator {
             case t"Int"    => Target.pure(q"writeNumber")
             case t"Long"   => Target.pure(q"writeNumber")
             case t"String" => Target.pure(q"writeString")
-            case other     => Target.raiseException(s"Unexpected type during enumeration encoder: ${other}")
+            case other     => Target.raiseException(s"Unexpected type during enumeration encoder: ${className} was ${other}")
           }
         } yield Some(
           q"""
@@ -241,7 +241,7 @@ object JacksonProtocolGenerator {
             case t"String" => Target.pure(q"getText")
             case t"Int"    => Target.pure(q"getIntValue")
             case t"Long"   => Target.pure(q"getLongValue")
-            case other     => Target.raiseException(s"Unexpected type during enumeration decoder: ${other}")
+            case other     => Target.raiseException(s"Unexpected type during enumeration decoder: ${className} was ${other}")
           }
         } yield Some(
           q"""

--- a/project/src/main/scala/RegressionTests.scala
+++ b/project/src/main/scala/RegressionTests.scala
@@ -24,7 +24,7 @@ object RegressionTests {
 
   def sampleResource(name: String): java.io.File = file(s"modules/sample/src/main/resources/${name}")
   val exampleCases: List[ExampleCase] = List(
-    ExampleCase(sampleResource("department.yaml"), "department").args("--tags-are-packages"),
+    ExampleCase(sampleResource("department.yaml"), "department").args("--package-from-tags"),
     ExampleCase(sampleResource("additional-properties.yaml"), "additionalProperties"),
     ExampleCase(sampleResource("alias.yaml"), "alias"),
     ExampleCase(sampleResource("char-encoding/char-encoding-request-stream.yaml"), "charEncoding.requestStream").frameworks("java" -> Set("dropwizard", "dropwizard-vavr"), "scala" -> Set("dropwizard")),

--- a/project/src/main/scala/RegressionTests.scala
+++ b/project/src/main/scala/RegressionTests.scala
@@ -24,7 +24,7 @@ object RegressionTests {
 
   def sampleResource(name: String): java.io.File = file(s"modules/sample/src/main/resources/${name}")
   val exampleCases: List[ExampleCase] = List(
-    ExampleCase(sampleResource("department.yaml"), "department"),
+    ExampleCase(sampleResource("department.yaml"), "department").args("--tags-are-packages"),
     ExampleCase(sampleResource("additional-properties.yaml"), "additionalProperties"),
     ExampleCase(sampleResource("alias.yaml"), "alias"),
     ExampleCase(sampleResource("char-encoding/char-encoding-request-stream.yaml"), "charEncoding.requestStream").frameworks("java" -> Set("dropwizard", "dropwizard-vavr"), "scala" -> Set("dropwizard")),


### PR DESCRIPTION
In response to some objections to removing the conversion of `tags: [a,b,c]` into package components (eg: `com.example.foo.a.b.c....`), adding a CLI flag, ~`--tags-are-packages`~ `--package-from-tags`, to retain that behaviour but to get rid of that warning.