### PR TITLE
Removing old Circe code

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -63,7 +63,7 @@ addCommandAlias("scalaTestSuite", "; guardrail/test ; runtimeScalaSuite")
 addCommandAlias("javaTestSuite", "; guardrail/test ; runtimeJavaSuite")
 addCommandAlias("format", "; scalafmtAll ; " + scalaFrameworks.map(x => s"sample-${x.projectName}/scalafmtAll").mkString("; "))
 addCommandAlias("checkFormatting", "; scalafmtCheckAll ; " + scalaFrameworks.map(x => s"sample-${x.projectName}/scalafmtCheckAll").mkString("; "))
-addCommandAlias("testSuite", "; scalaTestSuite ; javaTestSuite; microsite/compile")
+addCommandAlias("testSuite", "; guardrail/test ; runtimeScalaSuite ; runtimeJavaSuite ; microsite/compile")
 addCommandAlias("compileSamples", (scalaFrameworks ++ javaFrameworks).map(x => s"sample-${x.projectName}/Test/compile").mkString("; "))
 
 addCommandAlias(


### PR DESCRIPTION
- No need to try to go back to `forProductN`, since the complexity vs additional functionality we get by manually emitting encoders and decoders isn't worth it
- Turns out we were running `test` twice, once outside and then again inside aliases