### PR TITLE
Start to break up frameworks

### DIFF
--- a/modules/codegen/src/main/scala/dev/guardrail/generators/scala/ScalaModule.scala
+++ b/modules/codegen/src/main/scala/dev/guardrail/generators/scala/ScalaModule.scala
@@ -59,23 +59,13 @@ object ScalaModule extends AbstractModule[ScalaLanguage] {
     AkkaHttpGenerator(AkkaHttpVersion.V10_1, modelGeneratorType)
   )
 
-  def http4sV0_22(implicit Cl: CollectionsLibTerms[ScalaLanguage, Target]): (
+  def http4s(http4sVersion: Http4sVersion)(implicit Cl: CollectionsLibTerms[ScalaLanguage, Target]): (
       ClientTerms[ScalaLanguage, Target],
       ServerTerms[ScalaLanguage, Target],
       FrameworkTerms[ScalaLanguage, Target]
   ) = (
     Http4sClientGenerator(),
-    Http4sServerGenerator(Http4sVersion.V0_22),
-    Http4sGenerator()
-  )
-
-  def http4s(implicit Cl: CollectionsLibTerms[ScalaLanguage, Target]): (
-      ClientTerms[ScalaLanguage, Target],
-      ServerTerms[ScalaLanguage, Target],
-      FrameworkTerms[ScalaLanguage, Target]
-  ) = (
-    Http4sClientGenerator(),
-    Http4sServerGenerator(Http4sVersion.V0_23),
+    Http4sServerGenerator(http4sVersion),
     Http4sGenerator()
   )
 
@@ -103,9 +93,9 @@ object ScalaModule extends AbstractModule[ScalaLanguage] {
         "framework",
         ("akka-http", catchClassNotFound(akkaHttp(modelGeneratorType), MissingDependency("guardrail-scala-akka-http"))),
         ("akka-http-v10.1", catchClassNotFound(akkaHttpV10_1(modelGeneratorType), MissingDependency("guardrail-scala-akka-http"))),
-        ("http4s", catchClassNotFound(http4s, MissingDependency("guardrail-scala-http4s"))),
-        ("http4s-v0.23", catchClassNotFound(http4s, MissingDependency("guardrail-scala-http4s"))),
-        ("http4s-v0.22", catchClassNotFound(http4sV0_22, MissingDependency("guardrail-scala-http4s"))),
+        ("http4s", catchClassNotFound(http4s(Http4sVersion.V0_23), MissingDependency("guardrail-scala-http4s"))),
+        ("http4s-v0.23", catchClassNotFound(http4s(Http4sVersion.V0_23), MissingDependency("guardrail-scala-http4s"))),
+        ("http4s-v0.22", catchClassNotFound(http4s(Http4sVersion.V0_22), MissingDependency("guardrail-scala-http4s"))),
         ("dropwizard", catchClassNotFound(dropwizard, MissingDependency("guardrail-scala-dropwizard")))
       )
       // parser             =  or interpFramework

--- a/modules/codegen/src/main/scala/dev/guardrail/generators/scala/ScalaModule.scala
+++ b/modules/codegen/src/main/scala/dev/guardrail/generators/scala/ScalaModule.scala
@@ -85,7 +85,8 @@ object ScalaModule extends AbstractModule[ScalaLanguage] {
       (modelGeneratorType, protocol) <- popModule(
         "json",
         ("circe-java8", catchClassNotFound((CirceModelGenerator.V011, circeJava8(CirceModelGenerator.V011)), MissingDependency("guardrail-scala-support"))),
-        ("circe-0.11", catchClassNotFound((CirceModelGenerator.V011, circe(CirceModelGenerator.V011)), MissingDependency("guardrail-scala-support"))),
+        ("circe-v0.11", catchClassNotFound((CirceModelGenerator.V011, circe(CirceModelGenerator.V011)), MissingDependency("guardrail-scala-support"))),
+        ("circe-v0.12", catchClassNotFound((CirceModelGenerator.V012, circe(CirceModelGenerator.V012)), MissingDependency("guardrail-scala-support"))),
         ("circe", catchClassNotFound((CirceModelGenerator.V012, circe(CirceModelGenerator.V012)), MissingDependency("guardrail-scala-support"))),
         ("jackson", catchClassNotFound((JacksonModelGenerator, jackson), MissingDependency("guardrail-scala-support")))
       )
@@ -108,6 +109,17 @@ object ScalaModule extends AbstractModule[ScalaLanguage] {
       def SwaggerInterp: SwaggerTerms[ScalaLanguage, Target]               = SwaggerGenerator[ScalaLanguage]()
       def LanguageInterp: LanguageTerms[ScalaLanguage, Target]             = ScalaGenerator()
       def CollectionsLibInterp: CollectionsLibTerms[ScalaLanguage, Target] = collections
-    }).runA(modules.toList.toSet)
+    }).runA(
+      modules
+        .map {
+          case oldv @ "circe-0.11" =>
+            val newv = "circe-v0.11"
+            println(s"Deprecation: ${oldv} has been renamed to ${newv} for consistency")
+            newv
+          case other => other
+        }
+        .toList
+        .toSet
+    )
   }
 }

--- a/modules/codegen/src/test/scala/codegen/WritePackageSpec.scala
+++ b/modules/codegen/src/test/scala/codegen/WritePackageSpec.scala
@@ -79,7 +79,6 @@ class WritePackageSpec extends AnyFunSuite with SwaggerSpecRunner with Matchers 
     )
 
     import dev.guardrail.generators.scala.ScalaModule
-    import dev.guardrail.generators.scala.akkaHttp.AkkaHttp
     val result: List[WriteTree] = Target
       .unsafeExtract(
         Common
@@ -88,7 +87,7 @@ class WritePackageSpec extends AnyFunSuite with SwaggerSpecRunner with Matchers 
               "akka-http",
               ScalaModule.extract,
               { case "akka-http" =>
-                Target.pure(AkkaHttp)
+                NonEmptyList.of("akka-http", "circe")
               },
               _.parse[Importer].toEither.bimap(err => UnparseableArgument("import", err.toString), importer => Import(List(importer)))
             )
@@ -144,7 +143,6 @@ class WritePackageSpec extends AnyFunSuite with SwaggerSpecRunner with Matchers 
     )
 
     import dev.guardrail.generators.scala.ScalaModule
-    import dev.guardrail.generators.scala.akkaHttp.AkkaHttp
     val result: List[WriteTree] = Target
       .unsafeExtract(
         Common
@@ -153,7 +151,7 @@ class WritePackageSpec extends AnyFunSuite with SwaggerSpecRunner with Matchers 
               "akka-http",
               ScalaModule.extract,
               { case "akka-http" =>
-                Target.pure(AkkaHttp)
+                NonEmptyList.of("akka-http", "circe")
               },
               _.parse[Importer].toEither.bimap(err => UnparseableArgument("import", err.toString), importer => Import(List(importer)))
             )

--- a/modules/core/src/main/scala/dev/guardrail/Target.scala
+++ b/modules/core/src/main/scala/dev/guardrail/Target.scala
@@ -15,6 +15,8 @@ object Target {
   def raiseError[T](x: Error): Target[T]      = new TargetError(x, StructuredLogger.Empty)
   def raiseUserError[T](x: String): Target[T] = raiseError(UserError(x))
   def raiseException[T](x: String): Target[T] = raiseError(RuntimeFailure(x))
+  def fromEither[T](x: Either[Error, T]): Target[T] =
+    x.fold[Target[T]](err => new TargetError(err, StructuredLogger.Empty), value => new TargetValue(value, StructuredLogger.Empty))
   def fromOption[T](x: Option[T], default: => Error): Target[T] =
     x.fold[Target[T]](new TargetError(default, StructuredLogger.Empty))(new TargetValue(_, StructuredLogger.Empty))
 

--- a/modules/core/src/main/scala/dev/guardrail/core/CoreTermInterp.scala
+++ b/modules/core/src/main/scala/dev/guardrail/core/CoreTermInterp.scala
@@ -109,9 +109,8 @@ class CoreTermInterp[L <: LA](
         customImports <- args.imports
           .traverse(x =>
             for {
-              _ <- Target.log.debug(s"Attempting to parse $x as an import directive")
-              customImport <- handleImport(x)
-                .fold[Target[L#Import]](err => Target.raiseError(UnparseableArgument("import", err.toString)), Target.pure _)
+              _            <- Target.log.debug(s"Attempting to parse $x as an import directive")
+              customImport <- Target.fromEither(handleImport(x).left.map(err => UnparseableArgument("import", err.toString)))
             } yield customImport
           )
         _ <- Target.log.debug("Finished processing arguments")

--- a/modules/core/src/main/scala/dev/guardrail/core/CoreTermInterp.scala
+++ b/modules/core/src/main/scala/dev/guardrail/core/CoreTermInterp.scala
@@ -29,7 +29,7 @@ import dev.guardrail.{
 class CoreTermInterp[L <: LA](
     val defaultFramework: String,
     val handleModules: NonEmptyList[String] => Target[Framework[L, Target]],
-    val frameworkMapping: PartialFunction[String, Target[Framework[L, Target]]],
+    val frameworkMapping: PartialFunction[String, NonEmptyList[String]],
     val handleImport: String => Either[Error, L#Import]
 ) extends CoreTerms[L, Target] { self =>
   implicit def MonadF: Monad[Target] = Target.targetInstances
@@ -37,10 +37,10 @@ class CoreTermInterp[L <: LA](
   def extendWith(
       defaultFramework: String = self.defaultFramework,
       handleModules: NonEmptyList[String] => Target[Framework[L, Target]] = self.handleModules,
-      additionalFrameworkMappings: PartialFunction[String, Framework[L, Target]] = PartialFunction.empty,
+      additionalFrameworkMappings: PartialFunction[String, NonEmptyList[String]] = PartialFunction.empty,
       handleImport: String => Either[Error, L#Import] = self.handleImport
   ): CoreTermInterp[L] =
-    new CoreTermInterp[L](defaultFramework, handleModules, additionalFrameworkMappings.andThen(Target.pure _).orElse(self.frameworkMapping), handleImport)
+    new CoreTermInterp[L](defaultFramework, handleModules, additionalFrameworkMappings.orElse(self.frameworkMapping), handleImport)
 
   def getDefaultFramework =
     Target.log.function("getDefaultFramework") {
@@ -58,7 +58,8 @@ class CoreTermInterp[L <: LA](
             ctxFramework =>
               for {
                 frameworkName <- Target.fromOption(ctxFramework.orElse(vendorDefaultFramework), NoFramework)
-                framework     <- Target.fromOption(PartialFunction.condOpt(frameworkName)(frameworkMapping), UnknownFramework(frameworkName)).flatten
+                modules       <- Target.fromOption(PartialFunction.condOpt(frameworkName)(frameworkMapping), UnknownFramework(frameworkName))
+                framework     <- handleModules(modules)
                 _             <- Target.log.debug(s"Found: $framework")
               } yield framework,
             handleModules


### PR DESCRIPTION
- Frameworks are now just `NEL[String]`, where the strings are the constituent modules
- Unifying module version specification as `${module}-v{version}`, `circe-0.11` -> `circe-v0.11`