### PR TITLE
Break up `ModelGeneratorTypes` sealed trait

### DIFF
--- a/modules/codegen/src/main/scala/dev/guardrail/generators/scala/ScalaModule.scala
+++ b/modules/codegen/src/main/scala/dev/guardrail/generators/scala/ScalaModule.scala
@@ -4,7 +4,7 @@ import cats.data.NonEmptyList
 
 import dev.guardrail._
 import dev.guardrail.generators._
-import dev.guardrail.generators.scala.akkaHttp.{ AkkaHttpClientGenerator, AkkaHttpGenerator, AkkaHttpServerGenerator }
+import dev.guardrail.generators.scala.akkaHttp.{ AkkaHttpClientGenerator, AkkaHttpGenerator, AkkaHttpServerGenerator, AkkaHttpVersion }
 import dev.guardrail.generators.scala.circe.CirceProtocolGenerator
 import dev.guardrail.generators.scala.dropwizard.{ DropwizardClientGenerator, DropwizardGenerator, DropwizardServerGenerator }
 import dev.guardrail.generators.scala.http4s.{ Http4sClientGenerator, Http4sGenerator, Http4sServerGenerator, Http4sVersion }

--- a/modules/scala-akka-http/src/main/scala/dev/guardrail/generators/scala/akkaHttp/AkkaHttp.scala
+++ b/modules/scala-akka-http/src/main/scala/dev/guardrail/generators/scala/akkaHttp/AkkaHttp.scala
@@ -1,7 +1,7 @@
 package dev.guardrail.generators.scala.akkaHttp
 
 import dev.guardrail.Target
-import dev.guardrail.generators.scala.{ AkkaHttpVersion, CirceModelGenerator, ScalaCollectionsGenerator, ScalaGenerator, ScalaLanguage }
+import dev.guardrail.generators.scala.{ CirceModelGenerator, ScalaCollectionsGenerator, ScalaGenerator, ScalaLanguage }
 import dev.guardrail.generators.scala.circe.CirceProtocolGenerator
 import dev.guardrail.generators.{ Framework, SwaggerGenerator }
 

--- a/modules/scala-akka-http/src/main/scala/dev/guardrail/generators/scala/akkaHttp/AkkaHttpClientGenerator.scala
+++ b/modules/scala-akka-http/src/main/scala/dev/guardrail/generators/scala/akkaHttp/AkkaHttpClientGenerator.scala
@@ -9,12 +9,12 @@ import scala.meta._
 
 import dev.guardrail.Target
 import dev.guardrail.core.{ SupportDefinition, Tracker }
+import dev.guardrail.generators.{ LanguageParameter, LanguageParameters, RawParameterName, RenderedClientOperation }
 import dev.guardrail.generators.scala.ModelGeneratorType
 import dev.guardrail.generators.scala.ResponseADTHelper
 import dev.guardrail.generators.scala.ScalaLanguage
 import dev.guardrail.generators.scala.syntax._
 import dev.guardrail.generators.syntax._
-import dev.guardrail.generators.{ LanguageParameter, LanguageParameters, RawParameterName, RenderedClientOperation }
 import dev.guardrail.shims._
 import dev.guardrail.terms.client.ClientTerms
 import dev.guardrail.terms.protocol.{ StaticDefns, StrictProtocolElems }

--- a/modules/scala-akka-http/src/main/scala/dev/guardrail/generators/scala/akkaHttp/AkkaHttpGenerator.scala
+++ b/modules/scala-akka-http/src/main/scala/dev/guardrail/generators/scala/akkaHttp/AkkaHttpGenerator.scala
@@ -1,7 +1,7 @@
 package dev.guardrail.generators.scala.akkaHttp
 
 import dev.guardrail.{ RuntimeFailure, Target }
-import dev.guardrail.generators.scala.{ AkkaHttpVersion, CirceModelGenerator, JacksonModelGenerator, ModelGeneratorType, ScalaLanguage }
+import dev.guardrail.generators.scala.{ CirceModelGenerator, JacksonModelGenerator, ModelGeneratorType, ScalaLanguage }
 import dev.guardrail.terms.CollectionsLibTerms
 import dev.guardrail.terms.framework._
 import scala.meta._

--- a/modules/scala-akka-http/src/main/scala/dev/guardrail/generators/scala/akkaHttp/AkkaHttpJackson.scala
+++ b/modules/scala-akka-http/src/main/scala/dev/guardrail/generators/scala/akkaHttp/AkkaHttpJackson.scala
@@ -3,7 +3,7 @@ package dev.guardrail.generators.scala.akkaHttp
 import dev.guardrail.Target
 import dev.guardrail.generators.scala.{ JacksonModelGenerator, ScalaCollectionsGenerator, ScalaLanguage }
 import dev.guardrail.generators.scala.jackson.JacksonProtocolGenerator
-import dev.guardrail.generators.scala.{ AkkaHttpVersion, ScalaGenerator }
+import dev.guardrail.generators.scala.ScalaGenerator
 import dev.guardrail.generators.{ Framework, SwaggerGenerator }
 
 object AkkaHttpJackson extends Framework[ScalaLanguage, Target] {

--- a/modules/scala-akka-http/src/main/scala/dev/guardrail/generators/scala/akkaHttp/AkkaHttpPathExtractor.scala
+++ b/modules/scala-akka-http/src/main/scala/dev/guardrail/generators/scala/akkaHttp/AkkaHttpPathExtractor.scala
@@ -19,7 +19,9 @@ object AkkaHttpPathExtractor
             case t"Long"   => Right(q"LongNumber")
             case t"BigInt" => Right(q"Segment.map(BigInt.apply _)")
             case tpe =>
-              Right(q"Segment.flatMap(str => ${AkkaHttpHelper.fromStringConverter(tpe, modelGeneratorType)})")
+              AkkaHttpHelper
+                .fromStringConverter(tpe, modelGeneratorType)
+                .map(tpe => q"Segment.flatMap(str => ${tpe})")
           }
         } { segment =>
           argType match {
@@ -28,7 +30,9 @@ object AkkaHttpPathExtractor
               Right(q"${segment}.map(BigDecimal.apply _)")
             case t"BigInt" => Right(q"${segment}.map(BigInt.apply _)")
             case tpe =>
-              Right(q"${segment}.flatMap(str => ${AkkaHttpHelper.fromStringConverter(tpe, modelGeneratorType)})")
+              AkkaHttpHelper
+                .fromStringConverter(tpe, modelGeneratorType)
+                .map(tpe => q"${segment}.flatMap(str => ${tpe})")
           }
         }
       },

--- a/modules/scala-akka-http/src/main/scala/dev/guardrail/generators/scala/akkaHttp/AkkaHttpServerGenerator.scala
+++ b/modules/scala-akka-http/src/main/scala/dev/guardrail/generators/scala/akkaHttp/AkkaHttpServerGenerator.scala
@@ -11,7 +11,7 @@ import dev.guardrail.AuthImplementation
 import dev.guardrail.core.extract.{ ServerRawResponse, TracingLabel }
 import dev.guardrail.core.{ LiteralRawType, MapRawType, ReifiedRawType, Tracker, VectorRawType }
 import dev.guardrail.generators.operations.TracingLabelFormatter
-import dev.guardrail.generators.scala.{ AkkaHttpVersion, ModelGeneratorType }
+import dev.guardrail.generators.scala.ModelGeneratorType
 import dev.guardrail.generators.scala.ScalaLanguage
 import dev.guardrail.generators.scala.syntax._
 import dev.guardrail.generators.syntax._

--- a/modules/scala-akka-http/src/main/scala/dev/guardrail/generators/scala/akkaHttp/AkkaHttpVersion.scala
+++ b/modules/scala-akka-http/src/main/scala/dev/guardrail/generators/scala/akkaHttp/AkkaHttpVersion.scala
@@ -1,0 +1,12 @@
+package dev.guardrail.generators.scala.akkaHttp
+
+sealed abstract class AkkaHttpVersion(val value: String)
+object AkkaHttpVersion {
+  case object V10_1 extends AkkaHttpVersion("akka-http-v10.1")
+  case object V10_2 extends AkkaHttpVersion("akka-http-v10.2")
+  def unapply(version: String): Option[AkkaHttpVersion] = version match {
+    case V10_1.value => Some(V10_1)
+    case V10_2.value => Some(V10_2)
+    case _           => None
+  }
+}

--- a/modules/scala-dropwizard/src/main/scala/dev/guardrail/generators/scala/dropwizard/DropwizardClientGenerator.scala
+++ b/modules/scala-dropwizard/src/main/scala/dev/guardrail/generators/scala/dropwizard/DropwizardClientGenerator.scala
@@ -6,8 +6,8 @@ import java.net.URI
 import scala.meta.{ Defn, Import, Term }
 
 import dev.guardrail.core.SupportDefinition
-import dev.guardrail.generators.scala.ScalaLanguage
 import dev.guardrail.generators.{ LanguageParameters, RenderedClientOperation }
+import dev.guardrail.generators.scala.ScalaLanguage
 import dev.guardrail.terms.Responses
 import dev.guardrail.terms.client.ClientTerms
 import dev.guardrail.terms.protocol.{ StaticDefns, StrictProtocolElems }

--- a/modules/scala-dropwizard/src/main/scala/dev/guardrail/generators/scala/dropwizard/DropwizardServerGenerator.scala
+++ b/modules/scala-dropwizard/src/main/scala/dev/guardrail/generators/scala/dropwizard/DropwizardServerGenerator.scala
@@ -9,8 +9,8 @@ import scala.meta._
 import dev.guardrail.AuthImplementation
 import dev.guardrail.Target
 import dev.guardrail.core.{ SupportDefinition, Tracker }
-import dev.guardrail.generators.scala.ScalaLanguage
 import dev.guardrail.generators.{ CustomExtractionField, LanguageParameter, RawParameterName, RenderedRoutes, TracingField }
+import dev.guardrail.generators.scala.ScalaLanguage
 import dev.guardrail.scalaext.helpers.ResponseHelpers
 import dev.guardrail.shims.OperationExt
 import dev.guardrail.terms.protocol.StrictProtocolElems

--- a/modules/scala-dropwizard/src/main/scala/dev/guardrail/generators/scala/dropwizard/DropwizardVersion.scala
+++ b/modules/scala-dropwizard/src/main/scala/dev/guardrail/generators/scala/dropwizard/DropwizardVersion.scala
@@ -1,0 +1,9 @@
+package dev.guardrail.generators.scala.dropwizard
+
+sealed abstract class DropwizardVersion(val value: String)
+object DropwizardVersion extends DropwizardVersion("dropwizard") {
+  def unapply(version: String): Option[DropwizardVersion] = version match {
+    case "dropwizard" => Some(DropwizardVersion)
+    case _            => None
+  }
+}

--- a/modules/scala-support/src/main/scala/dev/guardrail/generators/scala/CirceModelGenerator.scala
+++ b/modules/scala-support/src/main/scala/dev/guardrail/generators/scala/CirceModelGenerator.scala
@@ -1,0 +1,28 @@
+package dev.guardrail.generators.scala
+
+import scala.meta._
+
+sealed abstract class CirceModelGenerator(val value: String) extends ModelGeneratorType {
+  def encoderObject: Type
+  def encoderObjectCompanion: Term
+  def print: Term.Name
+}
+
+object CirceModelGenerator {
+  case object V011 extends CirceModelGenerator("circe-v0.11") {
+    def encoderObject: Type.Name          = t"ObjectEncoder"
+    def encoderObjectCompanion: Term.Name = q"ObjectEncoder"
+    def print: Term.Name                  = q"pretty"
+  }
+  case object V012 extends CirceModelGenerator("circe-v0.12") {
+    def encoderObject: Type.Select          = t"_root_.io.circe.Encoder.AsObject"
+    def encoderObjectCompanion: Term.Select = q"_root_.io.circe.Encoder.AsObject"
+    def print: Term.Name                    = q"print"
+  }
+
+  def unapply(version: String): Option[CirceModelGenerator] = version match {
+    case V011.value => Some(V011)
+    case V012.value => Some(V012)
+    case _          => None
+  }
+}

--- a/modules/scala-support/src/main/scala/dev/guardrail/generators/scala/JacksonModelGenerator.scala
+++ b/modules/scala-support/src/main/scala/dev/guardrail/generators/scala/JacksonModelGenerator.scala
@@ -1,0 +1,9 @@
+package dev.guardrail.generators.scala
+
+sealed abstract class JacksonModelGenerator(val value: String) extends ModelGeneratorType
+case object JacksonModelGenerator extends JacksonModelGenerator("jackson") {
+  def unapply(version: String): Option[JacksonModelGenerator] = version match {
+    case JacksonModelGenerator.value => Some(JacksonModelGenerator)
+    case _                           => None
+  }
+}

--- a/modules/scala-support/src/main/scala/dev/guardrail/generators/scala/ModelGeneratorType.scala
+++ b/modules/scala-support/src/main/scala/dev/guardrail/generators/scala/ModelGeneratorType.scala
@@ -23,7 +23,8 @@ object CirceModelGenerator {
   }
 }
 
-case object JacksonModelGenerator extends ModelGeneratorType
+sealed abstract class JacksonModelGenerator extends ModelGeneratorType
+case object JacksonModelGenerator           extends JacksonModelGenerator
 
 sealed trait AkkaHttpVersion
 object AkkaHttpVersion {

--- a/modules/scala-support/src/main/scala/dev/guardrail/generators/scala/ModelGeneratorType.scala
+++ b/modules/scala-support/src/main/scala/dev/guardrail/generators/scala/ModelGeneratorType.scala
@@ -2,32 +2,50 @@ package dev.guardrail.generators.scala
 
 import scala.meta._
 
-sealed trait ModelGeneratorType
+sealed trait ModelGeneratorType {
+  def value: String
+}
 
-sealed trait CirceModelGenerator extends ModelGeneratorType {
+sealed abstract class CirceModelGenerator(val value: String) extends ModelGeneratorType {
   def encoderObject: Type
   def encoderObjectCompanion: Term
   def print: Term.Name
 }
 
 object CirceModelGenerator {
-  case object V011 extends CirceModelGenerator {
+  case object V011 extends CirceModelGenerator("circe-v0.11") {
     def encoderObject: Type.Name          = t"ObjectEncoder"
     def encoderObjectCompanion: Term.Name = q"ObjectEncoder"
     def print: Term.Name                  = q"pretty"
   }
-  case object V012 extends CirceModelGenerator {
+  case object V012 extends CirceModelGenerator("circe-v0.12") {
     def encoderObject: Type.Select          = t"_root_.io.circe.Encoder.AsObject"
     def encoderObjectCompanion: Term.Select = q"_root_.io.circe.Encoder.AsObject"
     def print: Term.Name                    = q"print"
   }
+
+  def unapply(version: String): Option[CirceModelGenerator] = version match {
+    case V011.value => Some(V011)
+    case V012.value => Some(V012)
+    case _          => None
+  }
 }
 
-sealed abstract class JacksonModelGenerator extends ModelGeneratorType
-case object JacksonModelGenerator           extends JacksonModelGenerator
+sealed abstract class JacksonModelGenerator(val value: String) extends ModelGeneratorType
+case object JacksonModelGenerator extends JacksonModelGenerator("jackson") {
+  def unapply(version: String): Option[JacksonModelGenerator] = version match {
+    case JacksonModelGenerator.value => Some(JacksonModelGenerator)
+    case _                           => None
+  }
+}
 
-sealed trait AkkaHttpVersion
+sealed abstract class AkkaHttpVersion(val value: String)
 object AkkaHttpVersion {
-  case object V10_1 extends AkkaHttpVersion
-  case object V10_2 extends AkkaHttpVersion
+  case object V10_1 extends AkkaHttpVersion("akka-http-v10.1")
+  case object V10_2 extends AkkaHttpVersion("akka-http-v10.2")
+  def unapply(version: String): Option[AkkaHttpVersion] = version match {
+    case V10_1.value => Some(V10_1)
+    case V10_2.value => Some(V10_2)
+    case _           => None
+  }
 }

--- a/modules/scala-support/src/main/scala/dev/guardrail/generators/scala/ModelGeneratorType.scala
+++ b/modules/scala-support/src/main/scala/dev/guardrail/generators/scala/ModelGeneratorType.scala
@@ -1,51 +1,5 @@
 package dev.guardrail.generators.scala
 
-import scala.meta._
-
-sealed trait ModelGeneratorType {
+trait ModelGeneratorType {
   def value: String
-}
-
-sealed abstract class CirceModelGenerator(val value: String) extends ModelGeneratorType {
-  def encoderObject: Type
-  def encoderObjectCompanion: Term
-  def print: Term.Name
-}
-
-object CirceModelGenerator {
-  case object V011 extends CirceModelGenerator("circe-v0.11") {
-    def encoderObject: Type.Name          = t"ObjectEncoder"
-    def encoderObjectCompanion: Term.Name = q"ObjectEncoder"
-    def print: Term.Name                  = q"pretty"
-  }
-  case object V012 extends CirceModelGenerator("circe-v0.12") {
-    def encoderObject: Type.Select          = t"_root_.io.circe.Encoder.AsObject"
-    def encoderObjectCompanion: Term.Select = q"_root_.io.circe.Encoder.AsObject"
-    def print: Term.Name                    = q"print"
-  }
-
-  def unapply(version: String): Option[CirceModelGenerator] = version match {
-    case V011.value => Some(V011)
-    case V012.value => Some(V012)
-    case _          => None
-  }
-}
-
-sealed abstract class JacksonModelGenerator(val value: String) extends ModelGeneratorType
-case object JacksonModelGenerator extends JacksonModelGenerator("jackson") {
-  def unapply(version: String): Option[JacksonModelGenerator] = version match {
-    case JacksonModelGenerator.value => Some(JacksonModelGenerator)
-    case _                           => None
-  }
-}
-
-sealed abstract class AkkaHttpVersion(val value: String)
-object AkkaHttpVersion {
-  case object V10_1 extends AkkaHttpVersion("akka-http-v10.1")
-  case object V10_2 extends AkkaHttpVersion("akka-http-v10.2")
-  def unapply(version: String): Option[AkkaHttpVersion] = version match {
-    case V10_1.value => Some(V10_1)
-    case V10_2.value => Some(V10_2)
-    case _           => None
-  }
 }


### PR DESCRIPTION
Moving towards SPI, there's no value in the `sealed` aspect of these version trackers.

Additionally, by moving these version trackers out further down into modules, it avoids the need to unnecessarily bump the core libs