### PR TITLE
isRelease should be considered for bincompat

### DIFF
--- a/project/src/main/scala/Build.scala
+++ b/project/src/main/scala/Build.scala
@@ -25,7 +25,7 @@ object Build {
     val isMasterBranch = sys.env.get("GITHUB_REF").contains("refs/heads/master")
     val isRelease = sys.env.contains("GUARDRAIL_RELEASE_MODULE")
     val isCi = sys.env.contains("GUARDRAIL_CI")
-    if (isCi) {
+    if (isCi || isRelease) {
       val ignoreBincompat = {
         import scala.sys.process._
         "support/current-pr-labels.sh"


### PR DESCRIPTION
I mistakenly assumed that release.yml also had `GUARDRAIL_CI`. Better to just re-establish the previous flow here instead of messing with the workflow definitions.