### PR TITLE
Adding missing Schema mappings

### DIFF
--- a/modules/core/src/main/scala/dev/guardrail/SwaggerUtil.scala
+++ b/modules/core/src/main/scala/dev/guardrail/SwaggerUtil.scala
@@ -150,6 +150,7 @@ object SwaggerUtil {
             .orRefine { case SchemaLiteral(x: StringSchema) if x.getFormat() == "byte" => x }(const(bytesType()))
             .orRefine { case SchemaLiteral(x: StringSchema) if x.getFormat() == "binary" => x }(extractFormat(fmt => fileType(None).map(log(fmt, _))))
             .orRefine { case SchemaLiteral(x: StringSchema) => x }(extractFormat(fmt => stringType(None).map(log(fmt, _))))
+            .orRefine { case SchemaLiteral(x: ByteArraySchema) => x }(const(bytesType()))
             .orRefine { case SchemaLiteral(x: NumberSchema) if x.getFormat() == "float" => x }(const(floatType()))
             .orRefine { case SchemaLiteral(x: NumberSchema) if x.getFormat() == "double" => x }(const(doubleType()))
             .orRefine { case SchemaLiteral(x: NumberSchema) => x }(extractFormat(fmt => numberType(fmt).map(log(fmt, _))))
@@ -175,6 +176,7 @@ object SwaggerUtil {
             .orRefine { case SchemaLiteral(x: BinarySchema) => x }(extractFormat(fmt => fileType(None).map(log(fmt, _))))
             .orRefine { case SchemaLiteral(x: ObjectSchema) => x }(extractFormat(fmt => objectType(fmt).map(log(fmt, _))))
             .orRefine { case SchemaLiteral(x: MapSchema) => x }(extractFormat(fmt => objectType(fmt).map(log(fmt, _))))
+            .orRefine { case SchemaLiteral(x: JsonSchema) => x }(extractFormat(fmt => objectType(fmt).map(log(fmt, _))))
             .orRefineFallback { schemaProjection =>
               schemaProjection.unwrapTracker match {
                 case SchemaLiteral(x) =>

--- a/modules/core/src/main/scala/dev/guardrail/SwaggerUtil.scala
+++ b/modules/core/src/main/scala/dev/guardrail/SwaggerUtil.scala
@@ -140,6 +140,8 @@ object SwaggerUtil {
               extractFormat(fmt => stringType(None).map(log(fmt, _)))
             )
             .orRefine { case SchemaLiteral(x: UUIDSchema) => x }(const(uuidType()))
+            .orRefine { case SchemaLiteral(x: EmailSchema) => x }(const(stringType(None)))
+            .orRefine { case SchemaLiteral(x: PasswordSchema) => x }(const(stringType(None)))
             .orRefine { case SchemaLiteral(x: StringSchema) if x.getType() == "file" => x }(extractFormat(fmt => fileType(None).map(log(fmt, _))))
             .orRefine { case SchemaLiteral(x: StringSchema) if x.getFormat() == "password" => x }(const(stringType(None)))
             .orRefine { case SchemaLiteral(x: StringSchema) if x.getFormat() == "email" => x }(const(stringType(None)))
@@ -174,6 +176,11 @@ object SwaggerUtil {
             .orRefine { case SchemaLiteral(x: ObjectSchema) => x }(extractFormat(fmt => objectType(fmt).map(log(fmt, _))))
             .orRefine { case SchemaLiteral(x: MapSchema) => x }(extractFormat(fmt => objectType(fmt).map(log(fmt, _))))
             .orRefineFallback { schemaProjection =>
+              schemaProjection.unwrapTracker match {
+                case SchemaLiteral(x) =>
+                  println(s"WARNING: Missing type mapping for ${x.getClass}, please report this at https://github.com/guardrail-dev/guardrail/issues")
+                case SchemaRef(schema, ref) => println(s"WARNING: Unexpected type mapping missing, $ref")
+              }
               val schema = schemaProjection.map {
                 case SchemaLiteral(x)               => x
                 case SchemaRef(SchemaLiteral(x), _) => x


### PR DESCRIPTION
An unintended consequence of #1407 was missing `*Schema` mappings causing the underlying raw types to be interpolated directly into generated sources.

Add more mappings, as well as a `println` to help track down further issues.