### PR TITLE
Better TypeTag comparison

### DIFF
--- a/modules/core/src/main/scala/dev/guardrail/generators/spi/AbstractLoader.scala
+++ b/modules/core/src/main/scala/dev/guardrail/generators/spi/AbstractLoader.scala
@@ -1,0 +1,31 @@
+package dev.guardrail.generators.spi
+
+import dev.guardrail.languages.LA
+import dev.guardrail.{ MissingDependency, Target }
+import java.util.ServiceLoader
+import scala.jdk.CollectionConverters._
+import scala.reflect.ClassTag
+import scala.reflect.runtime.universe.TypeTag
+
+trait AbstractGeneratorLoader[A[_ <: LA, _[_]]] {
+  type L <: LA
+  def reified: TypeTag[Target[L]]
+  def apply(parameters: Set[String]): Option[A[L, Target]]
+}
+
+abstract class AbstractGeneratorLoaderCompanion[A[_ <: LA, _[_]], B <: AbstractGeneratorLoader[A]](implicit ct: ClassTag[B]) {
+  @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+  def loader: ServiceLoader[B] = ServiceLoader.load(ct.runtimeClass.asInstanceOf[Class[B]])
+  @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+  def load[L <: LA](params: Set[String], error: MissingDependency)(implicit tt: TypeTag[Target[L]]): Target[A[L, Target]] = {
+    val found = loader
+      .iterator()
+      .asScala
+      .filter(_.reified == tt)
+      .flatMap(_.apply(params).asInstanceOf[Option[A[L, Target]]])
+      .toSeq
+      .headOption
+
+    Target.fromOption(found, error)
+  }
+}

--- a/modules/core/src/main/scala/dev/guardrail/generators/spi/AbstractLoader.scala
+++ b/modules/core/src/main/scala/dev/guardrail/generators/spi/AbstractLoader.scala
@@ -21,7 +21,7 @@ abstract class AbstractGeneratorLoaderCompanion[A[_ <: LA, _[_]], B <: AbstractG
     val found = loader
       .iterator()
       .asScala
-      .filter(_.reified == tt)
+      .filter(_.reified.tpe =:= tt.tpe)
       .flatMap(_.apply(params).asInstanceOf[Option[A[L, Target]]])
       .toSeq
       .headOption

--- a/modules/core/src/main/scala/dev/guardrail/generators/spi/ClientGeneratorLoader.scala
+++ b/modules/core/src/main/scala/dev/guardrail/generators/spi/ClientGeneratorLoader.scala
@@ -1,30 +1,11 @@
 package dev.guardrail.generators.spi
 
-import dev.guardrail.{ MissingDependency, Target }
-import dev.guardrail.languages.LA
 import dev.guardrail.terms.client.ClientTerms
 import java.util.ServiceLoader
-import scala.jdk.CollectionConverters._
-import scala.reflect.runtime.universe.TypeTag
 
-trait ClientGeneratorLoader {
-  type L <: LA
-  def reified: TypeTag[Target[L]]
-  def apply(parameters: Set[String]): Option[ClientTerms[L, Target]]
-}
+trait ClientGeneratorLoader extends AbstractGeneratorLoader[ClientTerms]
 
-object ClientGeneratorLoader {
-  def clientLoader: ServiceLoader[ClientGeneratorLoader] = ServiceLoader.load(classOf[ClientGeneratorLoader])
-  @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-  def load[L <: LA](params: Set[String], error: MissingDependency)(implicit tt: TypeTag[Target[L]]): Target[ClientTerms[L, Target]] = {
-    val found = clientLoader
-      .iterator()
-      .asScala
-      .filter(_.reified == tt)
-      .flatMap(_.apply(params).asInstanceOf[Option[ClientTerms[L, Target]]])
-      .toSeq
-      .headOption
-
-    Target.fromOption(found, error)
-  }
+object ClientGeneratorLoader extends AbstractGeneratorLoaderCompanion[ClientTerms, ClientGeneratorLoader] {
+  @deprecated("Deprecated in favor of an abstract 'loader' member", "0.71.2")
+  def clientLoader: ServiceLoader[ClientGeneratorLoader] = loader
 }

--- a/modules/core/src/main/scala/dev/guardrail/generators/spi/CollectionsGeneratorLoader.scala
+++ b/modules/core/src/main/scala/dev/guardrail/generators/spi/CollectionsGeneratorLoader.scala
@@ -1,31 +1,11 @@
 package dev.guardrail.generators.spi
 
-import java.util.ServiceLoader
-import scala.jdk.CollectionConverters._
-import scala.reflect.runtime.universe.TypeTag
-
-import dev.guardrail.{ MissingDependency, Target }
-import dev.guardrail.languages.LA
 import dev.guardrail.terms.CollectionsLibTerms
+import java.util.ServiceLoader
 
-trait CollectionsGeneratorLoader {
-  type L <: LA
-  def reified: TypeTag[Target[L]]
-  def apply(parameters: Set[String]): Option[CollectionsLibTerms[L, Target]]
-}
+trait CollectionsGeneratorLoader extends AbstractGeneratorLoader[CollectionsLibTerms]
 
-object CollectionsGeneratorLoader {
-  def collectionsLoader: ServiceLoader[CollectionsGeneratorLoader] = ServiceLoader.load(classOf[CollectionsGeneratorLoader])
-  @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-  def load[L <: LA](params: Set[String], error: MissingDependency)(implicit tt: TypeTag[Target[L]]): Target[CollectionsLibTerms[L, Target]] = {
-    val found = collectionsLoader
-      .iterator()
-      .asScala
-      .filter(_.reified == tt)
-      .flatMap(_.apply(params).asInstanceOf[Option[CollectionsLibTerms[L, Target]]])
-      .toSeq
-      .headOption
-
-    Target.fromOption(found, error)
-  }
+object CollectionsGeneratorLoader extends AbstractGeneratorLoaderCompanion[CollectionsLibTerms, CollectionsGeneratorLoader] {
+  @deprecated("Deprecated in favor of an abstract 'loader' member", "0.71.2")
+  def collectionsLoader: ServiceLoader[CollectionsGeneratorLoader] = loader
 }

--- a/modules/core/src/main/scala/dev/guardrail/generators/spi/FrameworkGeneratorLoader.scala
+++ b/modules/core/src/main/scala/dev/guardrail/generators/spi/FrameworkGeneratorLoader.scala
@@ -1,30 +1,11 @@
 package dev.guardrail.generators.spi
 
-import dev.guardrail.{ MissingDependency, Target }
-import dev.guardrail.languages.LA
 import dev.guardrail.terms.framework.FrameworkTerms
 import java.util.ServiceLoader
-import scala.jdk.CollectionConverters._
-import scala.reflect.runtime.universe.TypeTag
 
-trait FrameworkGeneratorLoader {
-  type L <: LA
-  def reified: TypeTag[Target[L]]
-  def apply(parameters: Set[String]): Option[FrameworkTerms[L, Target]]
-}
+trait FrameworkGeneratorLoader extends AbstractGeneratorLoader[FrameworkTerms]
 
-object FrameworkGeneratorLoader {
-  def frameworkLoader: ServiceLoader[FrameworkGeneratorLoader] = ServiceLoader.load(classOf[FrameworkGeneratorLoader])
-  @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-  def load[L <: LA](params: Set[String], error: MissingDependency)(implicit tt: TypeTag[Target[L]]): Target[FrameworkTerms[L, Target]] = {
-    val found = frameworkLoader
-      .iterator()
-      .asScala
-      .filter(_.reified == tt)
-      .flatMap(_.apply(params).asInstanceOf[Option[FrameworkTerms[L, Target]]])
-      .toSeq
-      .headOption
-
-    Target.fromOption(found, error)
-  }
+object FrameworkGeneratorLoader extends AbstractGeneratorLoaderCompanion[FrameworkTerms, FrameworkGeneratorLoader] {
+  @deprecated("Deprecated in favor of an abstract 'loader' member", "0.71.2")
+  def frameworkLoader: ServiceLoader[FrameworkGeneratorLoader] = loader
 }

--- a/modules/core/src/main/scala/dev/guardrail/generators/spi/FrameworkLoader.scala
+++ b/modules/core/src/main/scala/dev/guardrail/generators/spi/FrameworkLoader.scala
@@ -2,16 +2,10 @@ package dev.guardrail.generators.spi
 
 import dev.guardrail.generators.Framework
 import dev.guardrail.generators.SwaggerGenerator
-import dev.guardrail.languages.LA
 import dev.guardrail.{ MissingDependency, Target }
 import java.util.ServiceLoader
-import scala.jdk.CollectionConverters._
-import scala.reflect.runtime.universe.TypeTag
 
-trait FrameworkLoader {
-  type L <: LA
-  def reified: TypeTag[Target[L]]
-
+trait FrameworkLoader extends AbstractGeneratorLoader[Framework] {
   def apply(modules: Set[String]): Option[Framework[L, Target]] =
     (for {
       client      <- ClientGeneratorLoader.load[L](modules, MissingDependency(modules.mkString(", ")))(reified)
@@ -34,18 +28,7 @@ trait FrameworkLoader {
       }
 }
 
-object FrameworkLoader {
-  def frameworkLoader: ServiceLoader[FrameworkLoader] = ServiceLoader.load(classOf[FrameworkLoader])
-  @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-  def load[L <: LA](params: Set[String], error: MissingDependency)(implicit tt: TypeTag[Target[L]]): Target[Framework[L, Target]] = {
-    val found = frameworkLoader
-      .iterator()
-      .asScala
-      .filter(_.reified == tt)
-      .flatMap(_.apply(params).asInstanceOf[Option[Framework[L, Target]]])
-      .toSeq
-      .headOption
-
-    Target.fromOption(found, error)
-  }
+object FrameworkLoader extends AbstractGeneratorLoaderCompanion[Framework, FrameworkLoader] {
+  @deprecated("Deprecated in favor of an abstract 'loader' member", "0.71.2")
+  def frameworkLoader: ServiceLoader[FrameworkLoader] = loader
 }

--- a/modules/core/src/main/scala/dev/guardrail/generators/spi/LanguageLoader.scala
+++ b/modules/core/src/main/scala/dev/guardrail/generators/spi/LanguageLoader.scala
@@ -1,31 +1,11 @@
 package dev.guardrail.generators.spi
 
-import dev.guardrail.languages.LA
 import dev.guardrail.terms.LanguageTerms
-import dev.guardrail.{ MissingDependency, Target }
-
 import java.util.ServiceLoader
-import scala.jdk.CollectionConverters._
-import scala.reflect.runtime.universe.TypeTag
 
-trait LanguageLoader {
-  type L <: LA
-  def reified: TypeTag[Target[L]]
-  def apply(parameters: Set[String]): Option[LanguageTerms[L, Target]]
-}
+trait LanguageLoader extends AbstractGeneratorLoader[LanguageTerms]
 
-object LanguageLoader {
-  def frameworkLoader: ServiceLoader[LanguageLoader] = ServiceLoader.load(classOf[LanguageLoader])
-  @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-  def load[L <: LA](params: Set[String], error: MissingDependency)(implicit tt: TypeTag[Target[L]]): Target[LanguageTerms[L, Target]] = {
-    val found = frameworkLoader
-      .iterator()
-      .asScala
-      .filter(_.reified == tt)
-      .flatMap(_.apply(params).asInstanceOf[Option[LanguageTerms[L, Target]]])
-      .toSeq
-      .headOption
-
-    Target.fromOption(found, error)
-  }
+object LanguageLoader extends AbstractGeneratorLoaderCompanion[LanguageTerms, LanguageLoader] {
+  @deprecated("Deprecated in favor of an abstract 'loader' member", "0.71.2")
+  def frameworkLoader: ServiceLoader[LanguageLoader] = loader
 }

--- a/modules/core/src/main/scala/dev/guardrail/generators/spi/ModuleMapperLoader.scala
+++ b/modules/core/src/main/scala/dev/guardrail/generators/spi/ModuleMapperLoader.scala
@@ -19,7 +19,7 @@ object ModuleMapperLoader {
     val found = moduleMapperLoader
       .iterator()
       .asScala
-      .filter(_.reified == tt)
+      .filter(_.reified.tpe =:= tt.tpe)
       .flatMap(_.apply(frameworkName).asInstanceOf[Option[Set[String]]])
       .toSeq
       .headOption

--- a/modules/core/src/main/scala/dev/guardrail/generators/spi/ProtocolGeneratorLoader.scala
+++ b/modules/core/src/main/scala/dev/guardrail/generators/spi/ProtocolGeneratorLoader.scala
@@ -1,30 +1,11 @@
 package dev.guardrail.generators.spi
 
-import dev.guardrail.{ MissingDependency, Target }
-import dev.guardrail.languages.LA
 import dev.guardrail.terms.ProtocolTerms
 import java.util.ServiceLoader
-import scala.jdk.CollectionConverters._
-import scala.reflect.runtime.universe.TypeTag
 
-trait ProtocolGeneratorLoader {
-  type L <: LA
-  def reified: TypeTag[Target[L]]
-  def apply(parameters: Set[String]): Option[ProtocolTerms[L, Target]]
-}
+trait ProtocolGeneratorLoader extends AbstractGeneratorLoader[ProtocolTerms]
 
-object ProtocolGeneratorLoader {
-  def protocolLoader: ServiceLoader[ProtocolGeneratorLoader] = ServiceLoader.load(classOf[ProtocolGeneratorLoader])
-  @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-  def load[L <: LA](params: Set[String], error: MissingDependency)(implicit tt: TypeTag[Target[L]]): Target[ProtocolTerms[L, Target]] = {
-    val found = protocolLoader
-      .iterator()
-      .asScala
-      .filter(_.reified == tt)
-      .flatMap(_.apply(params).asInstanceOf[Option[ProtocolTerms[L, Target]]])
-      .toSeq
-      .headOption
-
-    Target.fromOption(found, error)
-  }
+object ProtocolGeneratorLoader extends AbstractGeneratorLoaderCompanion[ProtocolTerms, ProtocolGeneratorLoader] {
+  @deprecated("Deprecated in favor of an abstract 'loader' member", "0.71.2")
+  def protocolLoader: ServiceLoader[ProtocolGeneratorLoader] = loader
 }

--- a/modules/core/src/main/scala/dev/guardrail/generators/spi/ServerGeneratorLoader.scala
+++ b/modules/core/src/main/scala/dev/guardrail/generators/spi/ServerGeneratorLoader.scala
@@ -1,30 +1,11 @@
 package dev.guardrail.generators.spi
 
-import dev.guardrail.{ MissingDependency, Target }
-import dev.guardrail.languages.LA
 import dev.guardrail.terms.server.ServerTerms
 import java.util.ServiceLoader
-import scala.jdk.CollectionConverters._
-import scala.reflect.runtime.universe.TypeTag
 
-trait ServerGeneratorLoader {
-  type L <: LA
-  def reified: TypeTag[Target[L]]
-  def apply(parameters: Set[String]): Option[ServerTerms[L, Target]]
-}
+trait ServerGeneratorLoader extends AbstractGeneratorLoader[ServerTerms]
 
-object ServerGeneratorLoader {
-  def serverLoader: ServiceLoader[ServerGeneratorLoader] = ServiceLoader.load(classOf[ServerGeneratorLoader])
-  @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-  def load[L <: LA](params: Set[String], error: MissingDependency)(implicit tt: TypeTag[Target[L]]): Target[ServerTerms[L, Target]] = {
-    val found = serverLoader
-      .iterator()
-      .asScala
-      .filter(_.reified == tt)
-      .flatMap(_.apply(params).asInstanceOf[Option[ServerTerms[L, Target]]])
-      .toSeq
-      .headOption
-
-    Target.fromOption(found, error)
-  }
+object ServerGeneratorLoader extends AbstractGeneratorLoaderCompanion[ServerTerms, ServerGeneratorLoader] {
+  @deprecated("Deprecated in favor of an abstract 'loader' member", "0.71.2")
+  def serverLoader: ServiceLoader[ServerGeneratorLoader] = loader
 }


### PR DESCRIPTION
- Abstract out the commonalities in the various SPI loaders
- Change `TypeTag#==` to `TypeTag.tpe#=:=` for more accurate and stable SPI type binding comparisons