### PR TITLE
Introducing acceptHeader to http4s client generator

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Run tests
-      run:  sbt ++${{ matrix.scala.version }} clean samples/clean checkFormatting coverage test coverageAggregate versionPolicyCheck microsite/compile
+      run:  sbt ++${{ matrix.scala.version }} 'show stableVersion' clean samples/clean checkFormatting coverage test coverageAggregate versionPolicyCheck microsite/compile
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         GUARDRAIL_CI: true

--- a/modules/sample-http4s/src/test/scala/generators/Http4s/Client/contentType/Http4sTextPlainTest.scala
+++ b/modules/sample-http4s/src/test/scala/generators/Http4s/Client/contentType/Http4sTextPlainTest.scala
@@ -19,7 +19,9 @@ class Http4sTextPlainTest extends AnyFunSuite with Matchers with EitherValues {
   import org.http4s.implicits._
   test("Plain text should be emitted for required parameters (raw)") {
     val route: HttpRoutes[IO] = HttpRoutes.of { case req @ POST -> Root / "foo" =>
-      if (req.contentType.contains(`Content-Type`(MediaType.text.plain, Charset.`UTF-8`))) {
+      val correctContentType = req.contentType.contains(`Content-Type`(MediaType.text.plain, Charset.`UTF-8`))
+      val correctAcceptType  = req.headers.get[org.http4s.headers.Accept].exists(_.values.exists(_.mediaRange.isText)) // guardrail-dev/guardrail#1502
+      if (correctContentType && correctAcceptType) {
         for {
           value <- req.as[String]
           resp  <- if (value == "sample") Created("response") else NotAcceptable()
@@ -33,7 +35,9 @@ class Http4sTextPlainTest extends AnyFunSuite with Matchers with EitherValues {
 
   test("Plain text should be emitted for optional parameters (raw)") {
     val route: HttpRoutes[IO] = HttpRoutes.of { case req @ POST -> Root / "bar" =>
-      if (req.contentType.contains(`Content-Type`(MediaType.text.plain, Charset.`UTF-8`))) {
+      val correctContentType = req.contentType.contains(`Content-Type`(MediaType.text.plain, Charset.`UTF-8`))
+      val correctAcceptType  = req.headers.get[org.http4s.headers.Accept].exists(_.values.exists(_.mediaRange.isText)) // guardrail-dev/guardrail#1502
+      if (correctContentType && correctAcceptType) {
         for {
           value <- req.as[String]
           resp  <- if (value == "sample") Created("response") else NotAcceptable()

--- a/modules/scala-http4s/src/test/scala/tests/core/FullyQualifiedNames.scala
+++ b/modules/scala-http4s/src/test/scala/tests/core/FullyQualifiedNames.scala
@@ -51,23 +51,23 @@ class FullyQualifiedNames extends AnyFunSuite with Matchers with SwaggerSpecRunn
 
       clz.fullType shouldEqual t"_root_.com.test.User"
       client.head.toOption.get shouldEqual q"""
-       class Client[F[_]](host: String)(implicit F: Async[F], httpClient: Http4sClient[F]) {
-         val basePath: String = ""
-         private def parseOptionalHeader(response: Response[F], header: String): F[Option[String]] = F.pure(response.headers.get(CIString(header)).map(_.head.value))
-         private def parseRequiredHeader(response: Response[F], header: String): F[String] = response.headers.get(CIString(header)).map(_.head.value).fold[F[String]](F.raiseError(ParseFailure("Missing required header.", s"HTTP header '$$header' is not present.")))(F.pure)
-         private[this] val getUserOkDecoder = jsonOf[F, _root_.com.test.User]
-         def getUser(id: String, headers: List[Header.ToRaw] = List.empty): F[GetUserResponse] = {
-           val allHeaders = headers ++ List[Option[Header.ToRaw]]().flatten
-           val req = Request[F](method = Method.GET, uri = Uri.unsafeFromString(host + basePath + "/user/" + Formatter.addPath(id)), headers = Headers(allHeaders))
-           httpClient.run(req).use({
-             case _root_.org.http4s.Status.Ok(resp) =>
-               F.map(getUserOkDecoder.decode(resp, strict = false).value.flatMap(F.fromEither))(GetUserResponse.Ok.apply): F[GetUserResponse]
-             case resp =>
-               F.raiseError[GetUserResponse](UnexpectedStatus(resp.status, Method.GET, req.uri))
-           })
-         }
-       }
-    """
+        class Client[F[_]](host: String)(implicit F: Async[F], httpClient: Http4sClient[F]) {
+          val basePath: String = ""
+          private def parseOptionalHeader(response: Response[F], header: String): F[Option[String]] = F.pure(response.headers.get(CIString(header)).map(_.head.value))
+          private def parseRequiredHeader(response: Response[F], header: String): F[String] = response.headers.get(CIString(header)).map(_.head.value).fold[F[String]](F.raiseError(ParseFailure("Missing required header.", s"HTTP header '$$header' is not present.")))(F.pure)
+          private[this] val getUserOkDecoder = jsonOf[F, _root_.com.test.User]
+          def getUser(id: String, headers: List[Header.ToRaw] = List.empty): F[GetUserResponse] = {
+            val allHeaders: List[org.http4s.Header.ToRaw] = List.empty[Header.ToRaw] ++ headers ++ List[Option[Header.ToRaw]]().flatten
+            val req = Request[F](method = Method.GET, uri = Uri.unsafeFromString(host + basePath + "/user/" + Formatter.addPath(id)), headers = Headers(allHeaders))
+            httpClient.run(req).use({
+              case _root_.org.http4s.Status.Ok(resp) =>
+                F.map(getUserOkDecoder.decode(resp, strict = false).value.flatMap(F.fromEither))(GetUserResponse.Ok.apply): F[GetUserResponse]
+              case resp =>
+                F.raiseError[GetUserResponse](UnexpectedStatus(resp.status, Method.GET, req.uri))
+            })
+          }
+        }
+      """
 
       respTrait shouldEqual
         q"""

--- a/modules/scala-http4s/src/test/scala/tests/generators/http4s/BasicTest.scala
+++ b/modules/scala-http4s/src/test/scala/tests/generators/http4s/BasicTest.scala
@@ -124,20 +124,14 @@ class BasicTest extends AnyFunSuite with Matchers with SwaggerSpecRunner {
       def apply[F[_]](host: String = "http://localhost:1234")(implicit F: Async[F], httpClient: Http4sClient[F]): Client[F] = new Client[F](host = host)(F = F, httpClient = httpClient)
       def httpClient[F[_]](httpClient: Http4sClient[F], host: String = "http://localhost:1234")(implicit F: Async[F]): Client[F] = new Client[F](host = host)(F = F, httpClient = httpClient)
     }"""
-      val client = q"""class Client[F[_]](host: String = "http://localhost:1234")(implicit F: Async[F], httpClient: Http4sClient[F]) {
+      val client = q"""
+    class Client[F[_]](host: String = "http://localhost:1234")(implicit F: Async[F], httpClient: Http4sClient[F]) {
       val basePath: String = ""
-
-      private def parseOptionalHeader(response: Response[F], header: String): F[Option[String]] =
-        F.pure(response.headers.get(CIString(header)).map(_.head.value))
-
-      private def parseRequiredHeader(response: Response[F], header: String): F[String] =
-        response.headers
-          .get(CIString(header))
-          .map(_.head.value).fold[F[String]](F.raiseError(ParseFailure("Missing required header.", s"HTTP header '$$header' is not present.")))(F.pure)
-
+      private def parseOptionalHeader(response: Response[F], header: String): F[Option[String]] = F.pure(response.headers.get(CIString(header)).map(_.head.value))
+      private def parseRequiredHeader(response: Response[F], header: String): F[String] = response.headers.get(CIString(header)).map(_.head.value).fold[F[String]](F.raiseError(ParseFailure("Missing required header.", s"HTTP header '$$header' is not present.")))(F.pure)
       private[this] val getBazOkDecoder = jsonOf[F, io.circe.Json]
       def getBar(headers: List[Header.ToRaw] = List.empty): F[GetBarResponse] = {
-        val allHeaders = headers ++ List[Option[Header.ToRaw]]().flatten
+        val allHeaders: List[org.http4s.Header.ToRaw] = List.empty[Header.ToRaw] ++ headers ++ List[Option[Header.ToRaw]]().flatten
         val req = Request[F](method = Method.GET, uri = Uri.unsafeFromString(host + basePath + "/bar"), headers = Headers(allHeaders))
         httpClient.run(req).use({
           case _root_.org.http4s.Status.Ok(_) =>
@@ -147,7 +141,7 @@ class BasicTest extends AnyFunSuite with Matchers with SwaggerSpecRunner {
         })
       }
       def getBaz(headers: List[Header.ToRaw] = List.empty): F[GetBazResponse] = {
-        val allHeaders = headers ++ List[Option[Header.ToRaw]]().flatten
+        val allHeaders: List[org.http4s.Header.ToRaw] = List.empty[Header.ToRaw] ++ headers ++ List[Option[Header.ToRaw]]().flatten
         val req = Request[F](method = Method.GET, uri = Uri.unsafeFromString(host + basePath + "/baz"), headers = Headers(allHeaders))
         httpClient.run(req).use({
           case _root_.org.http4s.Status.Ok(resp) =>
@@ -157,7 +151,7 @@ class BasicTest extends AnyFunSuite with Matchers with SwaggerSpecRunner {
         })
       }
       def postFoo(headers: List[Header.ToRaw] = List.empty): F[PostFooResponse] = {
-        val allHeaders = headers ++ List[Option[Header.ToRaw]]().flatten
+        val allHeaders: List[org.http4s.Header.ToRaw] = List.empty[Header.ToRaw] ++ headers ++ List[Option[Header.ToRaw]]().flatten
         val req = Request[F](method = Method.POST, uri = Uri.unsafeFromString(host + basePath + "/foo"), headers = Headers(allHeaders))
         httpClient.run(req).use({
           case _root_.org.http4s.Status.Ok(_) =>
@@ -167,7 +161,7 @@ class BasicTest extends AnyFunSuite with Matchers with SwaggerSpecRunner {
         })
       }
       def getFoo(headers: List[Header.ToRaw] = List.empty): F[GetFooResponse] = {
-        val allHeaders = headers ++ List[Option[Header.ToRaw]]().flatten
+        val allHeaders: List[org.http4s.Header.ToRaw] = List.empty[Header.ToRaw] ++ headers ++ List[Option[Header.ToRaw]]().flatten
         val req = Request[F](method = Method.GET, uri = Uri.unsafeFromString(host + basePath + "/foo"), headers = Headers(allHeaders))
         httpClient.run(req).use({
           case _root_.org.http4s.Status.Ok(_) =>
@@ -177,7 +171,7 @@ class BasicTest extends AnyFunSuite with Matchers with SwaggerSpecRunner {
         })
       }
       def putFoo(headers: List[Header.ToRaw] = List.empty): F[PutFooResponse] = {
-        val allHeaders = headers ++ List[Option[Header.ToRaw]]().flatten
+        val allHeaders: List[org.http4s.Header.ToRaw] = List.empty[Header.ToRaw] ++ headers ++ List[Option[Header.ToRaw]]().flatten
         val req = Request[F](method = Method.PUT, uri = Uri.unsafeFromString(host + basePath + "/foo"), headers = Headers(allHeaders))
         httpClient.run(req).use({
           case _root_.org.http4s.Status.Ok(_) =>
@@ -187,7 +181,7 @@ class BasicTest extends AnyFunSuite with Matchers with SwaggerSpecRunner {
         })
       }
       def patchFoo(headers: List[Header.ToRaw] = List.empty): F[PatchFooResponse] = {
-        val allHeaders = headers ++ List[Option[Header.ToRaw]]().flatten
+        val allHeaders: List[org.http4s.Header.ToRaw] = List.empty[Header.ToRaw] ++ headers ++ List[Option[Header.ToRaw]]().flatten
         val req = Request[F](method = Method.PATCH, uri = Uri.unsafeFromString(host + basePath + "/foo"), headers = Headers(allHeaders))
         httpClient.run(req).use({
           case _root_.org.http4s.Status.Ok(_) =>
@@ -197,7 +191,7 @@ class BasicTest extends AnyFunSuite with Matchers with SwaggerSpecRunner {
         })
       }
       def deleteFoo(headers: List[Header.ToRaw] = List.empty): F[DeleteFooResponse] = {
-        val allHeaders = headers ++ List[Option[Header.ToRaw]]().flatten
+        val allHeaders: List[org.http4s.Header.ToRaw] = List.empty[Header.ToRaw] ++ headers ++ List[Option[Header.ToRaw]]().flatten
         val req = Request[F](method = Method.DELETE, uri = Uri.unsafeFromString(host + basePath + "/foo"), headers = Headers(allHeaders))
         httpClient.run(req).use({
           case _root_.org.http4s.Status.Ok(_) =>
@@ -206,7 +200,8 @@ class BasicTest extends AnyFunSuite with Matchers with SwaggerSpecRunner {
             F.raiseError[DeleteFooResponse](UnexpectedStatus(resp.status, Method.DELETE, req.uri))
         })
       }
-    }"""
+    }
+    """
       val expected = List(
         q"""
         sealed abstract class GetBarResponse {


### PR DESCRIPTION
Resolve #1424 

- Introduce a `ContentType` mapping and rendering them into a common `org.http4s.headers.Accept` header