### PR TITLE
Reverting AbstractGeneratorLoader parameter abstraction

### DIFF
--- a/modules/core/src/main/scala/dev/guardrail/generators/spi/AbstractLoader.scala
+++ b/modules/core/src/main/scala/dev/guardrail/generators/spi/AbstractLoader.scala
@@ -7,17 +7,17 @@ import scala.jdk.CollectionConverters._
 import scala.reflect.ClassTag
 import scala.reflect.runtime.universe.TypeTag
 
-trait AbstractGeneratorLoader[A[_ <: LA, _[_]], P] {
+trait AbstractGeneratorLoader[A[_ <: LA, _[_]]] {
   type L <: LA
   def reified: TypeTag[Target[L]]
-  def apply(parameters: P): Option[A[L, Target]]
+  def apply(parameters: Set[String]): Option[A[L, Target]]
 }
 
-abstract class AbstractGeneratorLoaderCompanion[A[_ <: LA, _[_]], P, B <: AbstractGeneratorLoader[A, P]](implicit ct: ClassTag[B]) {
+abstract class AbstractGeneratorLoaderCompanion[A[_ <: LA, _[_]], B <: AbstractGeneratorLoader[A]](implicit ct: ClassTag[B]) {
   @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
   def loader: ServiceLoader[B] = ServiceLoader.load(ct.runtimeClass.asInstanceOf[Class[B]])
   @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-  def load[L <: LA](params: P, error: MissingDependency)(implicit tt: TypeTag[Target[L]]): Target[A[L, Target]] = {
+  def load[L <: LA](params: Set[String], error: MissingDependency)(implicit tt: TypeTag[Target[L]]): Target[A[L, Target]] = {
     val found = loader
       .iterator()
       .asScala

--- a/modules/core/src/main/scala/dev/guardrail/generators/spi/ClientGeneratorLoader.scala
+++ b/modules/core/src/main/scala/dev/guardrail/generators/spi/ClientGeneratorLoader.scala
@@ -3,9 +3,9 @@ package dev.guardrail.generators.spi
 import dev.guardrail.terms.client.ClientTerms
 import java.util.ServiceLoader
 
-trait ClientGeneratorLoader extends AbstractGeneratorLoader[ClientTerms, Set[String]]
+trait ClientGeneratorLoader extends AbstractGeneratorLoader[ClientTerms]
 
-object ClientGeneratorLoader extends AbstractGeneratorLoaderCompanion[ClientTerms, Set[String], ClientGeneratorLoader] {
+object ClientGeneratorLoader extends AbstractGeneratorLoaderCompanion[ClientTerms, ClientGeneratorLoader] {
   @deprecated("Deprecated in favor of an abstract 'loader' member", "0.71.2")
   def clientLoader: ServiceLoader[ClientGeneratorLoader] = loader
 }

--- a/modules/core/src/main/scala/dev/guardrail/generators/spi/CollectionsGeneratorLoader.scala
+++ b/modules/core/src/main/scala/dev/guardrail/generators/spi/CollectionsGeneratorLoader.scala
@@ -3,9 +3,9 @@ package dev.guardrail.generators.spi
 import dev.guardrail.terms.CollectionsLibTerms
 import java.util.ServiceLoader
 
-trait CollectionsGeneratorLoader extends AbstractGeneratorLoader[CollectionsLibTerms, Set[String]]
+trait CollectionsGeneratorLoader extends AbstractGeneratorLoader[CollectionsLibTerms]
 
-object CollectionsGeneratorLoader extends AbstractGeneratorLoaderCompanion[CollectionsLibTerms, Set[String], CollectionsGeneratorLoader] {
+object CollectionsGeneratorLoader extends AbstractGeneratorLoaderCompanion[CollectionsLibTerms, CollectionsGeneratorLoader] {
   @deprecated("Deprecated in favor of an abstract 'loader' member", "0.71.2")
   def collectionsLoader: ServiceLoader[CollectionsGeneratorLoader] = loader
 }

--- a/modules/core/src/main/scala/dev/guardrail/generators/spi/FrameworkGeneratorLoader.scala
+++ b/modules/core/src/main/scala/dev/guardrail/generators/spi/FrameworkGeneratorLoader.scala
@@ -3,9 +3,9 @@ package dev.guardrail.generators.spi
 import dev.guardrail.terms.framework.FrameworkTerms
 import java.util.ServiceLoader
 
-trait FrameworkGeneratorLoader extends AbstractGeneratorLoader[FrameworkTerms, Set[String]]
+trait FrameworkGeneratorLoader extends AbstractGeneratorLoader[FrameworkTerms]
 
-object FrameworkGeneratorLoader extends AbstractGeneratorLoaderCompanion[FrameworkTerms, Set[String], FrameworkGeneratorLoader] {
+object FrameworkGeneratorLoader extends AbstractGeneratorLoaderCompanion[FrameworkTerms, FrameworkGeneratorLoader] {
   @deprecated("Deprecated in favor of an abstract 'loader' member", "0.71.2")
   def frameworkLoader: ServiceLoader[FrameworkGeneratorLoader] = loader
 }

--- a/modules/core/src/main/scala/dev/guardrail/generators/spi/FrameworkLoader.scala
+++ b/modules/core/src/main/scala/dev/guardrail/generators/spi/FrameworkLoader.scala
@@ -5,7 +5,7 @@ import dev.guardrail.generators.SwaggerGenerator
 import dev.guardrail.{ MissingDependency, Target }
 import java.util.ServiceLoader
 
-trait FrameworkLoader extends AbstractGeneratorLoader[Framework, Set[String]] {
+trait FrameworkLoader extends AbstractGeneratorLoader[Framework] {
   def apply(modules: Set[String]): Option[Framework[L, Target]] =
     (for {
       client      <- ClientGeneratorLoader.load[L](modules, MissingDependency(modules.mkString(", ")))(reified)
@@ -28,7 +28,7 @@ trait FrameworkLoader extends AbstractGeneratorLoader[Framework, Set[String]] {
       }
 }
 
-object FrameworkLoader extends AbstractGeneratorLoaderCompanion[Framework, Set[String], FrameworkLoader] {
+object FrameworkLoader extends AbstractGeneratorLoaderCompanion[Framework, FrameworkLoader] {
   @deprecated("Deprecated in favor of an abstract 'loader' member", "0.71.2")
   def frameworkLoader: ServiceLoader[FrameworkLoader] = loader
 }

--- a/modules/core/src/main/scala/dev/guardrail/generators/spi/LanguageLoader.scala
+++ b/modules/core/src/main/scala/dev/guardrail/generators/spi/LanguageLoader.scala
@@ -3,9 +3,9 @@ package dev.guardrail.generators.spi
 import dev.guardrail.terms.LanguageTerms
 import java.util.ServiceLoader
 
-trait LanguageLoader extends AbstractGeneratorLoader[LanguageTerms, Set[String]]
+trait LanguageLoader extends AbstractGeneratorLoader[LanguageTerms]
 
-object LanguageLoader extends AbstractGeneratorLoaderCompanion[LanguageTerms, Set[String], LanguageLoader] {
+object LanguageLoader extends AbstractGeneratorLoaderCompanion[LanguageTerms, LanguageLoader] {
   @deprecated("Deprecated in favor of an abstract 'loader' member", "0.71.2")
   def frameworkLoader: ServiceLoader[LanguageLoader] = loader
 }

--- a/modules/core/src/main/scala/dev/guardrail/generators/spi/ProtocolGeneratorLoader.scala
+++ b/modules/core/src/main/scala/dev/guardrail/generators/spi/ProtocolGeneratorLoader.scala
@@ -3,9 +3,9 @@ package dev.guardrail.generators.spi
 import dev.guardrail.terms.ProtocolTerms
 import java.util.ServiceLoader
 
-trait ProtocolGeneratorLoader extends AbstractGeneratorLoader[ProtocolTerms, Set[String]]
+trait ProtocolGeneratorLoader extends AbstractGeneratorLoader[ProtocolTerms]
 
-object ProtocolGeneratorLoader extends AbstractGeneratorLoaderCompanion[ProtocolTerms, Set[String], ProtocolGeneratorLoader] {
+object ProtocolGeneratorLoader extends AbstractGeneratorLoaderCompanion[ProtocolTerms, ProtocolGeneratorLoader] {
   @deprecated("Deprecated in favor of an abstract 'loader' member", "0.71.2")
   def protocolLoader: ServiceLoader[ProtocolGeneratorLoader] = loader
 }

--- a/modules/core/src/main/scala/dev/guardrail/generators/spi/ServerGeneratorLoader.scala
+++ b/modules/core/src/main/scala/dev/guardrail/generators/spi/ServerGeneratorLoader.scala
@@ -3,9 +3,9 @@ package dev.guardrail.generators.spi
 import dev.guardrail.terms.server.ServerTerms
 import java.util.ServiceLoader
 
-trait ServerGeneratorLoader extends AbstractGeneratorLoader[ServerTerms, Set[String]]
+trait ServerGeneratorLoader extends AbstractGeneratorLoader[ServerTerms]
 
-object ServerGeneratorLoader extends AbstractGeneratorLoaderCompanion[ServerTerms, Set[String], ServerGeneratorLoader] {
+object ServerGeneratorLoader extends AbstractGeneratorLoaderCompanion[ServerTerms, ServerGeneratorLoader] {
   @deprecated("Deprecated in favor of an abstract 'loader' member", "0.71.2")
   def serverLoader: ServiceLoader[ServerGeneratorLoader] = loader
 }


### PR DESCRIPTION
Deferring this to at some point in the future to avoid breaking bincompat.

Turns out it wasn't actually used anyway.