### PR TITLE
StringSchema incorrectly treated as a model

### DIFF
--- a/modules/core/src/main/scala/dev/guardrail/generators/ProtocolGenerator.scala
+++ b/modules/core/src/main/scala/dev/guardrail/generators/ProtocolGenerator.scala
@@ -736,7 +736,9 @@ object ProtocolGenerator {
                 defaultPropertyRequirement,
                 components
               )
-              alias <- modelTypeAlias(clsName, x, components)
+              customTypeName <- SwaggerUtil.customTypeName(x)
+              (declType, _)  <- SwaggerUtil.determineTypeName[L, F](x, Tracker.cloneHistory(x, customTypeName), components)
+              alias          <- typeAlias[L, F](formattedClsName, declType)
             } yield enum.orElse(model).getOrElse(alias)
           )
           .orRefine { case x: IntegerSchema => x }(x =>

--- a/modules/core/src/main/scala/dev/guardrail/generators/ProtocolGenerator.scala
+++ b/modules/core/src/main/scala/dev/guardrail/generators/ProtocolGenerator.scala
@@ -679,25 +679,7 @@ object ProtocolGenerator {
       polyADTs <- hierarchies.traverse(fromPoly(_, concreteTypes, definitions.value, dtoPackage, supportPackage.toList, defaultPropertyRequirement, components))
       elems <- definitionsWithoutPoly.traverse { case (clsName, model) =>
         model
-          .refine { case m: StringSchema => m }(m =>
-            for {
-              formattedClsName <- formatTypeName(clsName)
-              enum             <- fromEnum(formattedClsName, m, dtoPackage, components)
-              model <- fromModel(
-                NonEmptyList.of(formattedClsName),
-                m,
-                List.empty,
-                concreteTypes,
-                definitions.value,
-                dtoPackage,
-                supportPackage.toList,
-                defaultPropertyRequirement,
-                components
-              )
-              alias <- modelTypeAlias(clsName, m, components)
-            } yield enum.orElse(model).getOrElse(alias)
-          )
-          .orRefine { case c: ComposedSchema => c }(comp =>
+          .refine { case c: ComposedSchema => c }(comp =>
             for {
               formattedClsName <- formatTypeName(clsName)
               parents <- extractParents(comp, definitions.value, concreteTypes, dtoPackage, supportPackage.toList, defaultPropertyRequirement, components)
@@ -737,6 +719,24 @@ object ProtocolGenerator {
                 components
               )
               alias <- modelTypeAlias(formattedClsName, m, components)
+            } yield enum.orElse(model).getOrElse(alias)
+          )
+          .orRefine { case x: StringSchema => x }(x =>
+            for {
+              formattedClsName <- formatTypeName(clsName)
+              enum             <- fromEnum(formattedClsName, x, dtoPackage, components)
+              model <- fromModel(
+                NonEmptyList.of(formattedClsName),
+                x,
+                List.empty,
+                concreteTypes,
+                definitions.value,
+                dtoPackage,
+                supportPackage.toList,
+                defaultPropertyRequirement,
+                components
+              )
+              alias <- modelTypeAlias(clsName, x, components)
             } yield enum.orElse(model).getOrElse(alias)
           )
           .orRefine { case x: IntegerSchema => x }(x =>

--- a/modules/sample-springMvc/src/test/scala/alias/server/springMvc/foo/AliasSpecs.scala
+++ b/modules/sample-springMvc/src/test/scala/alias/server/springMvc/foo/AliasSpecs.scala
@@ -36,12 +36,12 @@ class AliasSpecs extends AnyFreeSpec with Matchers with BeforeAndAfterAll with M
   "test alias.foo" - {
     "optional body handled with alias param" in {
 
-      when(handlerMock.doFoo(java.util.Optional.of(1L), java.util.Optional.of(42L)))
+      when(handlerMock.doFoo(java.util.Optional.of(1L), java.util.Optional.of("foo"), java.util.Optional.of(42L)))
         .thenReturn(CompletableFuture.completedFuture(FooHandler.DoFooResponse.Created(42L)))
 
       val mvcResult = mvc
         .perform(
-          post("/foo?long=1")
+          post("/foo?long=1&string=foo")
             .contentType(MediaType.APPLICATION_JSON)
             .content("42")
         )

--- a/modules/sample/src/main/resources/alias.yaml
+++ b/modules/sample/src/main/resources/alias.yaml
@@ -1,52 +1,54 @@
-swagger: "2.0"
+openapi: 3.0.0
 info:
   title: Whatever
   version: 1.0.0
-host: localhost:1234
+servers:
+  - url: //localhost:1234
 paths:
   /foo:
     post:
       operationId: doFoo
       x-jvm-package: foo
-      consumes:
-        - application/json
-      produces:
-        - application/json
       parameters:
-      - in: query
-        name: long
-        type: integer
-        format: int64
-      - in: body
-        name: body
-        schema:
-          $ref: '#/definitions/defLong'
-      responses:
-        '201':
-          description: "Created"
+        - in: query
+          name: long
           schema:
-            $ref: '#/definitions/defLong'
-definitions:
-  defLong:
-    type: integer
-    format: int64
-  defArrayLong:
-    type: array
-    items:
+            type: integer
+            format: int64
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/defLong"
+      responses:
+        "201":
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/defLong"
+components:
+  schemas:
+    defLong:
       type: integer
       format: int64
-  defArrayArrayLong:
-    type: array
-    items:
-      $ref: '#/definitions/defArrayLong'
-  propRef:
-    type: object
-    required:
-      - arrayArray
-    properties:
-      param:
-        $ref: "#/definitions/defLong"
-      array:
-        $ref: "#/definitions/defArrayLong"
-      arrayArray:
-        $ref: "#/definitions/defArrayArrayLong"
+    defArrayLong:
+      type: array
+      items:
+        type: integer
+        format: int64
+    defArrayArrayLong:
+      type: array
+      items:
+        $ref: "#/components/schemas/defArrayLong"
+    propRef:
+      type: object
+      required:
+        - arrayArray
+      properties:
+        param:
+          $ref: "#/components/schemas/defLong"
+        array:
+          $ref: "#/components/schemas/defArrayLong"
+        arrayArray:
+          $ref: "#/components/schemas/defArrayArrayLong"

--- a/modules/sample/src/main/resources/alias.yaml
+++ b/modules/sample/src/main/resources/alias.yaml
@@ -15,6 +15,10 @@ paths:
           schema:
             type: integer
             format: int64
+        - in: query
+          name: string
+          schema:
+            $ref: "#/components/schemas/defString"
       requestBody:
         content:
           application/json:
@@ -29,6 +33,8 @@ paths:
                 $ref: "#/components/schemas/defLong"
 components:
   schemas:
+    defString:
+      type: string
     defLong:
       type: integer
       format: int64


### PR DESCRIPTION
Resolves #1502 

Following @djm1329's investigation, `StringSchema` was using `modelTypeAlias`, which wasn't designed to handle primitive type aliases. This may have been a hold-over from before the object model was standardized in `swagger-parser`, or perhaps it's just been a bug forever and #1407 exposed it.

This'll be a `bugfix`, not a `minor`, but due to `early-semver` seeming to be incompatible with `dependsOn`, the only way to get the tests to run successfully currently is to use `minor` to disable the `early-semver` check.