### PR TITLE
Actually disable versionScheme, somehow early-semver was still being picked up

### DIFF
--- a/project/src/main/scala/Build.scala
+++ b/project/src/main/scala/Build.scala
@@ -87,9 +87,9 @@ object Build {
     crossScalaVersions := Seq("2.12.15", "2.13.8"),
     scalaVersion := "2.12.15",
 
-    // This was a mistake. We already have early-semver guaratees during CI, but including this in the publishing POM
+    // early-semver was a mistake. We already have early-semver guaratees during CI, but including this in the publishing POM
     // ensures that independent 0.x versions are incompatible, even though we know they are.
-    // versionScheme := Some("early-semver"), // This should help once the build plugins start depending directly on modules
+    versionScheme := None,
 
     scalacOptions ++= Seq(
       "-Xfatal-warnings",


### PR DESCRIPTION
Follow-up to #1504, which actually disables it.