### PR TITLE
Resolve overly broad circe imports

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,49 +1,49 @@
 core:
-- modules/core/*
-- modules/core/**/*
+- modules/core/src/main/*
+- modules/core/src/main/**/*
 - project/src/main/scala/modules/core.scala
 
 java-async-http:
-- modules/java-async-http/*
-- modules/java-async-http/**/*
+- modules/java-async-http/src/main/*
+- modules/java-async-http/src/main/**/*
 - project/src/main/scala/modules/javaAsyncHttp.scala
 
 java-dropwizard:
-- modules/java-dropwizard/*
-- modules/java-dropwizard/**/*
+- modules/java-dropwizard/src/main/*
+- modules/java-dropwizard/src/main/**/*
 - project/src/main/scala/modules/javaDropwizard.scala
 
 java-spring-mvc:
-- modules/java-spring-mvc/*
-- modules/java-spring-mvc/**/*
+- modules/java-spring-mvc/src/main/*
+- modules/java-spring-mvc/src/main/**/*
 - project/src/main/scala/modules/javaSpringMvc.scala
 
 java-support:
-- modules/java-support/*
-- modules/java-support/**/*
+- modules/java-support/src/main/*
+- modules/java-support/src/main/**/*
 - project/src/main/scala/modules/javaSupport.scala
 
 scala-akka-http:
-- modules/scala-akka-http/*
-- modules/scala-akka-http/**/*
+- modules/scala-akka-http/src/main/*
+- modules/scala-akka-http/src/main/**/*
 - project/src/main/scala/modules/scalaAkkaHttp.scala
 
 scala-dropwizard:
-- modules/scala-dropwizard/*
-- modules/scala-dropwizard/**/*
+- modules/scala-dropwizard/src/main/*
+- modules/scala-dropwizard/src/main/**/*
 - project/src/main/scala/modules/scalaDropwizard.scala
 
 scala-http4s:
-- modules/scala-http4s/*
-- modules/scala-http4s/**/*
+- modules/scala-http4s/src/main/*
+- modules/scala-http4s/src/main/**/*
 - project/src/main/scala/modules/scalaHttp4s.scala
 
 scala-support:
-- modules/scala-support/*
-- modules/scala-support/**/*
+- modules/scala-support/src/main/*
+- modules/scala-support/src/main/**/*
 - project/src/main/scala/modules/scalaSupport.scala
 
 cli:
-- modules/cli/*
-- modules/cli/**/*
+- modules/cli/src/main/*
+- modules/cli/src/main/**/*
 - project/src/main/scala/modules/cli.scala

--- a/modules/java-async-http/src/main/scala/dev/guardrail/generators/java/asyncHttpClient/AsyncHttpClientClientGenerator.scala
+++ b/modules/java-async-http/src/main/scala/dev/guardrail/generators/java/asyncHttpClient/AsyncHttpClientClientGenerator.scala
@@ -541,7 +541,7 @@ class AsyncHttpClientClientGenerator private (implicit Cl: CollectionsLibTerms[J
       val allProduces = operation.unwrapTracker.produces.flatMap(ContentType.unapply).toList
       val produces =
         responses.value
-          .map(resp => (resp.statusCode, ResponseHelpers.getBestProduces[JavaLanguage](operation.unwrapTracker.getOperationId, allProduces, resp, _.isPlain)))
+          .map(resp => (resp.statusCode, ResponseHelpers.getBestProduces[JavaLanguage](operation, allProduces, resp, _.isPlain)))
           .toMap
 
       val builderMethodCalls: List[(LanguageParameter[JavaLanguage], Statement)] = builderParamsMethodNames

--- a/modules/java-dropwizard/src/main/scala/dev/guardrail/generators/java/dropwizard/DropwizardServerGenerator.scala
+++ b/modules/java-dropwizard/src/main/scala/dev/guardrail/generators/java/dropwizard/DropwizardServerGenerator.scala
@@ -297,7 +297,7 @@ class DropwizardServerGenerator private (implicit Cl: CollectionsLibTerms[JavaLa
       routeMethodsAndHandlerMethodSigs <- routes
         .traverse {
           case GenerateRouteMeta(
-                operationId,
+                _,
                 methodName,
                 responseClsName,
                 customExtractionFields,
@@ -326,7 +326,7 @@ class DropwizardServerGenerator private (implicit Cl: CollectionsLibTerms[JavaLa
             NonEmptyList
               .fromList(
                 responses.value
-                  .flatMap(ResponseHelpers.getBestProduces[JavaLanguage](operationId, allProduces, _, _.isPlain))
+                  .flatMap(ResponseHelpers.getBestProduces[JavaLanguage](operation, allProduces, _, _.isPlain))
                   .distinct
                   .map(toJaxRsAnnotationName)
               )

--- a/modules/java-support/src/main/scala/dev/guardrail/java/helpers/ResponseHelpers.scala
+++ b/modules/java-support/src/main/scala/dev/guardrail/java/helpers/ResponseHelpers.scala
@@ -38,7 +38,7 @@ object ResponseHelpers {
     }
 
   def getBestProduces[L <: LA](
-      operationId: String,
+      operation: Tracker[Operation],
       contentTypes: List[ContentType],
       response: Response[L],
       fallbackIsString: L#Type => Boolean
@@ -51,9 +51,10 @@ object ResponseHelpers {
           .orElse(contentTypes.collectFirst { case tc: TextContent => tc })
           .orElse(contentTypes.collectFirst { case bc: BinaryContent => bc })
           .orElse {
-            val fallback = if (fallbackIsString(valueType)) TextPlain.empty else ApplicationJson.empty
+            val fallback    = if (fallbackIsString(valueType)) TextPlain.empty else ApplicationJson.empty
+            val operationId = operation.downField("operationId", _.getOperationId).unwrapTracker.getOrElse("<no operationId>")
             println(
-              s"WARNING: no supported body param type for operation '$operationId', response code ${response.statusCode}; falling back to ${fallback.value}"
+              s"WARNING: no supported body param type for operation '$operationId', response code ${response.statusCode}; falling back to ${fallback.value} (${operation.showHistory})"
             )
             Option(fallback)
           }

--- a/modules/scala-akka-http/src/main/scala/dev/guardrail/generators/scala/akkaHttp/AkkaHttpGenerator.scala
+++ b/modules/scala-akka-http/src/main/scala/dev/guardrail/generators/scala/akkaHttp/AkkaHttpGenerator.scala
@@ -160,7 +160,7 @@ class AkkaHttpGenerator private (akkaHttpVersion: AkkaHttpVersion, modelGenerato
       q"""
           // Translate Json => HttpEntity
           implicit final def jsonMarshaller(
-              implicit printer: Printer = Printer.noSpaces
+              implicit printer: _root_.io.circe.Printer = _root_.io.circe.Printer.noSpaces
           ): ToEntityMarshaller[${jsonType}] =
             Marshaller.withFixedContentType(MediaTypes.`application/json`) { json =>
               HttpEntity(MediaTypes.`application/json`, ${Term.Select(q"printer", circeVersion.print)}(json))
@@ -170,7 +170,7 @@ class AkkaHttpGenerator private (akkaHttpVersion: AkkaHttpVersion, modelGenerato
           // Translate [A: Encoder] => HttpEntity
           implicit final def jsonEntityMarshaller[A](
               implicit J: ${jsonEncoderTypeclass}[A],
-                       printer: Printer = Printer.noSpaces
+                       printer: _root_.io.circe.Printer = _root_.io.circe.Printer.noSpaces
           ): ToEntityMarshaller[A] =
             jsonMarshaller(printer).compose(J.apply)
        """,
@@ -183,7 +183,7 @@ class AkkaHttpGenerator private (akkaHttpVersion: AkkaHttpVersion, modelGenerato
                 case ByteString.empty =>
                   throw Unmarshaller.NoContentException
                 case data =>
-                  Json.fromString(data.decodeString("utf-8"))
+                  _root_.io.circe.Json.fromString(data.decodeString("utf-8"))
               })
        """,
       q"""
@@ -198,8 +198,8 @@ class AkkaHttpGenerator private (akkaHttpVersion: AkkaHttpVersion, modelGenerato
                   FastFuture.failed(Unmarshaller.NoContentException)
                 } else {
                   val parseResult = Unmarshaller.bestUnmarshallingCharsetFor(httpEntity) match {
-                    case HttpCharsets.`UTF-8` => jawn.parse(byteString.utf8String)
-                    case otherCharset => jawn.parse(byteString.decodeString(otherCharset.nioCharset.name))
+                    case HttpCharsets.`UTF-8` => _root_.io.circe.jawn.parse(byteString.utf8String)
+                    case otherCharset => _root_.io.circe.jawn.parse(byteString.decodeString(otherCharset.nioCharset.name))
                   }
                   parseResult.fold(FastFuture.failed, FastFuture.successful)
                 }
@@ -207,7 +207,7 @@ class AkkaHttpGenerator private (akkaHttpVersion: AkkaHttpVersion, modelGenerato
        """,
       q"""
           final val stringyJsonUnmarshaller: FromStringUnmarshaller[${jsonType}] =
-            Unmarshaller.strict(value => Json.fromString(value))
+            Unmarshaller.strict(value => _root_.io.circe.Json.fromString(value))
        """,
       q"""
           // Translate HttpEntity => Json (for `application/json`)
@@ -219,8 +219,8 @@ class AkkaHttpGenerator private (akkaHttpVersion: AkkaHttpVersion, modelGenerato
                   FastFuture.failed(Unmarshaller.NoContentException)
                 } else {
                   val parseResult = Unmarshaller.bestUnmarshallingCharsetFor(httpEntity) match {
-                    case HttpCharsets.`UTF-8` => jawn.parse(byteString.utf8String)
-                    case otherCharset => jawn.parse(byteString.decodeString(otherCharset.nioCharset.name))
+                    case HttpCharsets.`UTF-8` => _root_.io.circe.jawn.parse(byteString.utf8String)
+                    case otherCharset => _root_.io.circe.jawn.parse(byteString.decodeString(otherCharset.nioCharset.name))
                   }
                   parseResult.fold(FastFuture.failed, FastFuture.successful)
                 }
@@ -243,14 +243,14 @@ class AkkaHttpGenerator private (akkaHttpVersion: AkkaHttpVersion, modelGenerato
       q"""
           // Translate String => Json by parsing
           final val jsonParsingUnmarshaller: FromStringUnmarshaller[${jsonType}] = Unmarshaller {
-            _ => data => jawn.parse(data).fold(FastFuture.failed, FastFuture.successful)
+            _ => data => _root_.io.circe.jawn.parse(data).fold(FastFuture.failed, FastFuture.successful)
           }
        """,
       q"""
           // Translate String => Json by treaing as a JSON literal
           final val jsonStringyUnmarshaller: FromStringUnmarshaller[${jsonType}] = Unmarshaller.strict {
             case data =>
-              Json.fromString(data)
+              _root_.io.circe.Json.fromString(data)
           }
        """,
       q"""

--- a/modules/scala-akka-http/src/main/scala/dev/guardrail/generators/scala/akkaHttp/AkkaHttpHelper.scala
+++ b/modules/scala-akka-http/src/main/scala/dev/guardrail/generators/scala/akkaHttp/AkkaHttpHelper.scala
@@ -42,7 +42,7 @@ object AkkaHttpHelper {
   }
 
   def fromStringConverter(tpe: Type, modelGeneratorType: ModelGeneratorType): Either[String, Term] = modelGeneratorType match {
-    case _: CirceModelGenerator   => Right(q"io.circe.Json.fromString(str).as[$tpe].toOption")
+    case _: CirceModelGenerator   => Right(q"_root_.io.circe.Json.fromString(str).as[$tpe].toOption")
     case _: JacksonModelGenerator => Right(q"scala.util.Try(mapper.convertValue(str, new com.fasterxml.jackson.core.`type`.TypeReference[$tpe] {})).toOption")
     case _                        => Left(s"Unknown modelGeneratorType: ${modelGeneratorType}")
   }

--- a/modules/scala-akka-http/src/test/scala/core/issues/Issue43.scala
+++ b/modules/scala-akka-http/src/test/scala/core/issues/Issue43.scala
@@ -129,7 +129,7 @@ class Issue43 extends AnyFunSpec with Matchers with SwaggerSpecRunner {
         object Cat {
           implicit val encodeCat: _root_.io.circe.Encoder.AsObject[Cat] = {
             val readOnlyKeys = _root_.scala.Predef.Set[_root_.scala.Predef.String]()
-            _root_.io.circe.Encoder.AsObject.instance[Cat](a => _root_.io.circe.JsonObject.fromIterable(_root_.scala.Vector(("name", a.name.asJson), ("huntingSkill", a.huntingSkill.asJson), ("petType", Json.fromString("Cat"))))).mapJsonObject(_.filterKeys(key => !(readOnlyKeys contains key)))
+            _root_.io.circe.Encoder.AsObject.instance[Cat](a => _root_.io.circe.JsonObject.fromIterable(_root_.scala.Vector(("name", a.name.asJson), ("huntingSkill", a.huntingSkill.asJson), ("petType", _root_.io.circe.Json.fromString("Cat"))))).mapJsonObject(_.filterKeys(key => !(readOnlyKeys contains key)))
           }
           implicit val decodeCat: _root_.io.circe.Decoder[Cat] = new _root_.io.circe.Decoder[Cat] { final def apply(c: _root_.io.circe.HCursor): _root_.io.circe.Decoder.Result[Cat] = for (v0 <- c.downField("name").as[String]; v1 <- c.downField("huntingSkill").as[Cat.HuntingSkill]) yield Cat(v0, v1) }
           sealed abstract class HuntingSkill(val value: String) extends _root_.scala.Product with _root_.scala.Serializable { override def toString: String = value.toString }
@@ -167,9 +167,9 @@ class Issue43 extends AnyFunSpec with Matchers with SwaggerSpecRunner {
         val discriminator: String = "petType"
         implicit val encoder: _root_.io.circe.Encoder[Pet] = _root_.io.circe.Encoder.instance({
           case e: Cat =>
-            e.asJsonObject.add(discriminator, "Cat".asJson).asJson
+            e.asJsonObject.add(discriminator, _root_.io.circe.Json.fromString("Cat")).asJson
           case e: Dog =>
-            e.asJsonObject.add(discriminator, "Dog".asJson).asJson
+            e.asJsonObject.add(discriminator, _root_.io.circe.Json.fromString("Dog")).asJson
         })
         implicit val decoder: _root_.io.circe.Decoder[Pet] = _root_.io.circe.Decoder.instance({ c =>
           val discriminatorCursor = c.downField(discriminator)
@@ -179,7 +179,7 @@ class Issue43 extends AnyFunSpec with Matchers with SwaggerSpecRunner {
             case "Dog" =>
               c.as[Dog]
             case tpe =>
-              _root_.scala.Left(DecodingFailure("Unknown value " ++ tpe ++ " (valid: Cat, Dog)", discriminatorCursor.history))
+              _root_.scala.Left(_root_.io.circe.DecodingFailure("Unknown value " ++ tpe ++ " (valid: Cat, Dog)", discriminatorCursor.history))
           })
         })
       }
@@ -319,7 +319,7 @@ class Issue43 extends AnyFunSpec with Matchers with SwaggerSpecRunner {
         object Dog {
           implicit val encodeDog: _root_.io.circe.Encoder.AsObject[Dog] = {
             val readOnlyKeys = _root_.scala.Predef.Set[_root_.scala.Predef.String]()
-            _root_.io.circe.Encoder.AsObject.instance[Dog](a => _root_.io.circe.JsonObject.fromIterable(_root_.scala.Vector(("name", a.name.asJson), ("packSize", a.packSize.asJson), ("petType", Json.fromString("Dog"))))).mapJsonObject(_.filterKeys(key => !(readOnlyKeys contains key)))
+            _root_.io.circe.Encoder.AsObject.instance[Dog](a => _root_.io.circe.JsonObject.fromIterable(_root_.scala.Vector(("name", a.name.asJson), ("packSize", a.packSize.asJson), ("petType", _root_.io.circe.Json.fromString("Dog"))))).mapJsonObject(_.filterKeys(key => !(readOnlyKeys contains key)))
           }
           implicit val decodeDog: _root_.io.circe.Decoder[Dog] = new _root_.io.circe.Decoder[Dog] { final def apply(c: _root_.io.circe.HCursor): _root_.io.circe.Decoder.Result[Dog] = for (v0 <- c.downField("name").as[String]; v1 <- c.downField("packSize").as[Int]) yield Dog(v0, v1) }
         }
@@ -332,7 +332,7 @@ class Issue43 extends AnyFunSpec with Matchers with SwaggerSpecRunner {
         object PersianCat {
           implicit val encodePersianCat: _root_.io.circe.Encoder.AsObject[PersianCat] = {
             val readOnlyKeys = _root_.scala.Predef.Set[_root_.scala.Predef.String]()
-            _root_.io.circe.Encoder.AsObject.instance[PersianCat](a => _root_.io.circe.JsonObject.fromIterable(_root_.scala.Vector(("name", a.name.asJson), ("huntingSkill", a.huntingSkill.asJson), ("wool", a.wool.asJson), ("petType", Json.fromString("PersianCat"))))).mapJsonObject(_.filterKeys(key => !(readOnlyKeys contains key)))
+            _root_.io.circe.Encoder.AsObject.instance[PersianCat](a => _root_.io.circe.JsonObject.fromIterable(_root_.scala.Vector(("name", a.name.asJson), ("huntingSkill", a.huntingSkill.asJson), ("wool", a.wool.asJson), ("petType", _root_.io.circe.Json.fromString("PersianCat"))))).mapJsonObject(_.filterKeys(key => !(readOnlyKeys contains key)))
           }
           implicit val decodePersianCat: _root_.io.circe.Decoder[PersianCat] = new _root_.io.circe.Decoder[PersianCat] { final def apply(c: _root_.io.circe.HCursor): _root_.io.circe.Decoder.Result[PersianCat] = for (v0 <- c.downField("name").as[String]; v1 <- c.downField("huntingSkill").as[Cat.HuntingSkill]; v2 <- c.downField("wool").as[Int]) yield PersianCat(v0, v1, v2) }
         }
@@ -351,9 +351,9 @@ class Issue43 extends AnyFunSpec with Matchers with SwaggerSpecRunner {
         val discriminator: String = "petType"
         implicit val encoder: _root_.io.circe.Encoder[Pet] = _root_.io.circe.Encoder.instance({
           case e: Dog =>
-            e.asJsonObject.add(discriminator, "Dog".asJson).asJson
+            e.asJsonObject.add(discriminator, _root_.io.circe.Json.fromString("Dog")).asJson
           case e: PersianCat =>
-            e.asJsonObject.add(discriminator, "PersianCat".asJson).asJson
+            e.asJsonObject.add(discriminator, _root_.io.circe.Json.fromString("PersianCat")).asJson
         })
         implicit val decoder: _root_.io.circe.Decoder[Pet] = _root_.io.circe.Decoder.instance { c =>
           val discriminatorCursor = c.downField(discriminator)
@@ -363,7 +363,7 @@ class Issue43 extends AnyFunSpec with Matchers with SwaggerSpecRunner {
             case "PersianCat" =>
               c.as[PersianCat]
             case tpe =>
-              _root_.scala.Left(DecodingFailure("Unknown value " ++ tpe ++ " (valid: Dog, PersianCat)", discriminatorCursor.history))
+              _root_.scala.Left(_root_.io.circe.DecodingFailure("Unknown value " ++ tpe ++ " (valid: Dog, PersianCat)", discriminatorCursor.history))
           })
         }
       }
@@ -373,7 +373,7 @@ class Issue43 extends AnyFunSpec with Matchers with SwaggerSpecRunner {
         val discriminator: String = "petType"
         implicit val encoder: _root_.io.circe.Encoder[Cat] = _root_.io.circe.Encoder.instance({
           case e: PersianCat =>
-            e.asJsonObject.add(discriminator, "PersianCat".asJson).asJson
+            e.asJsonObject.add(discriminator, _root_.io.circe.Json.fromString("PersianCat")).asJson
         })
         implicit val decoder: _root_.io.circe.Decoder[Cat] = _root_.io.circe.Decoder.instance { c =>
           val discriminatorCursor = c.downField(discriminator)
@@ -381,7 +381,7 @@ class Issue43 extends AnyFunSpec with Matchers with SwaggerSpecRunner {
             case "PersianCat" =>
               c.as[PersianCat]
             case tpe =>
-              _root_.scala.Left(DecodingFailure("Unknown value " ++ tpe ++ " (valid: PersianCat)", discriminatorCursor.history))
+              _root_.scala.Left(_root_.io.circe.DecodingFailure("Unknown value " ++ tpe ++ " (valid: PersianCat)", discriminatorCursor.history))
           })
         }
       }
@@ -491,7 +491,7 @@ class Issue43 extends AnyFunSpec with Matchers with SwaggerSpecRunner {
         object PersianCat {
           implicit val encodePersianCat: _root_.io.circe.Encoder.AsObject[PersianCat] = {
             val readOnlyKeys = _root_.scala.Predef.Set[_root_.scala.Predef.String]()
-            _root_.io.circe.Encoder.AsObject.instance[PersianCat](a => _root_.io.circe.JsonObject.fromIterable(_root_.scala.Vector(("catBreed", a.catBreed.asJson), ("petType", Json.fromString("PersianCat"))))).mapJsonObject(_.filterKeys(key => !(readOnlyKeys contains key)))
+            _root_.io.circe.Encoder.AsObject.instance[PersianCat](a => _root_.io.circe.JsonObject.fromIterable(_root_.scala.Vector(("catBreed", a.catBreed.asJson), ("petType", _root_.io.circe.Json.fromString("PersianCat"))))).mapJsonObject(_.filterKeys(key => !(readOnlyKeys contains key)))
           }
           implicit val decodePersianCat: _root_.io.circe.Decoder[PersianCat] = new _root_.io.circe.Decoder[PersianCat] { final def apply(c: _root_.io.circe.HCursor): _root_.io.circe.Decoder.Result[PersianCat] = for (v0 <- c.downField("catBreed").as[String]) yield PersianCat(v0) }
         }
@@ -509,7 +509,7 @@ class Issue43 extends AnyFunSpec with Matchers with SwaggerSpecRunner {
         val discriminator: String = "petType"
         implicit val encoder: _root_.io.circe.Encoder[Cat] = _root_.io.circe.Encoder.instance({
           case e: PersianCat =>
-            e.asJsonObject.add(discriminator, "PersianCat".asJson).asJson
+            e.asJsonObject.add(discriminator, _root_.io.circe.Json.fromString("PersianCat")).asJson
         })
         implicit val decoder: _root_.io.circe.Decoder[Cat] = _root_.io.circe.Decoder.instance { c =>
           val discriminatorCursor = c.downField(discriminator)
@@ -517,7 +517,7 @@ class Issue43 extends AnyFunSpec with Matchers with SwaggerSpecRunner {
             case "PersianCat" =>
               c.as[PersianCat]
             case tpe =>
-              _root_.scala.Left(DecodingFailure("Unknown value " ++ tpe ++ " (valid: PersianCat)", discriminatorCursor.history))
+              _root_.scala.Left(_root_.io.circe.DecodingFailure("Unknown value " ++ tpe ++ " (valid: PersianCat)", discriminatorCursor.history))
           })
         }
       }
@@ -592,7 +592,7 @@ class Issue43 extends AnyFunSpec with Matchers with SwaggerSpecRunner {
         object Cat {
           implicit val encodeCat: _root_.io.circe.Encoder.AsObject[Cat] = {
             val readOnlyKeys = _root_.scala.Predef.Set[_root_.scala.Predef.String]()
-            _root_.io.circe.Encoder.AsObject.instance[Cat](a => _root_.io.circe.JsonObject.fromIterable(_root_.scala.Vector(("wool", a.wool.asJson), ("catBreed", a.catBreed.asJson), ("petType", Json.fromString("Cat")), ("mammalType", Json.fromString("Cat"))))).mapJsonObject(_.filterKeys(key => !(readOnlyKeys contains key)))
+            _root_.io.circe.Encoder.AsObject.instance[Cat](a => _root_.io.circe.JsonObject.fromIterable(_root_.scala.Vector(("wool", a.wool.asJson), ("catBreed", a.catBreed.asJson), ("petType", _root_.io.circe.Json.fromString("Cat")), ("mammalType", _root_.io.circe.Json.fromString("Cat"))))).mapJsonObject(_.filterKeys(key => !(readOnlyKeys contains key)))
           }
           implicit val decodeCat: _root_.io.circe.Decoder[Cat] = new _root_.io.circe.Decoder[Cat] { final def apply(c: _root_.io.circe.HCursor): _root_.io.circe.Decoder.Result[Cat] = for (v0 <- c.downField("wool").as[Boolean]; v1 <- c.downField("catBreed").as[String]) yield Cat(v0, v1) }
         }
@@ -610,7 +610,7 @@ class Issue43 extends AnyFunSpec with Matchers with SwaggerSpecRunner {
         val discriminator: String = "petType"
         implicit val encoder: _root_.io.circe.Encoder[Pet] = _root_.io.circe.Encoder.instance({
           case e: Cat =>
-            e.asJsonObject.add(discriminator, "Cat".asJson).asJson
+            e.asJsonObject.add(discriminator, _root_.io.circe.Json.fromString("Cat")).asJson
         })
         implicit val decoder: _root_.io.circe.Decoder[Pet] = _root_.io.circe.Decoder.instance({ c => {
           val discriminatorCursor = c.downField(discriminator)
@@ -618,7 +618,7 @@ class Issue43 extends AnyFunSpec with Matchers with SwaggerSpecRunner {
             case "Cat" =>
               c.as[Cat]
             case tpe =>
-              _root_.scala.Left(DecodingFailure("Unknown value " ++ tpe ++ " (valid: Cat)", discriminatorCursor.history))
+              _root_.scala.Left(_root_.io.circe.DecodingFailure("Unknown value " ++ tpe ++ " (valid: Cat)", discriminatorCursor.history))
           })
         } })
       }
@@ -628,7 +628,7 @@ class Issue43 extends AnyFunSpec with Matchers with SwaggerSpecRunner {
         val discriminator: String = "mammalType"
         implicit val encoder: _root_.io.circe.Encoder[Mammal] = _root_.io.circe.Encoder.instance({
           case e: Cat =>
-            e.asJsonObject.add(discriminator, "Cat".asJson).asJson
+            e.asJsonObject.add(discriminator, _root_.io.circe.Json.fromString("Cat")).asJson
         })
         implicit val decoder: _root_.io.circe.Decoder[Mammal] = _root_.io.circe.Decoder.instance { c =>
           val discriminatorCursor = c.downField(discriminator)
@@ -636,7 +636,7 @@ class Issue43 extends AnyFunSpec with Matchers with SwaggerSpecRunner {
             case "Cat" =>
               c.as[Cat]
             case tpe =>
-              _root_.scala.Left(DecodingFailure("Unknown value " ++ tpe ++ " (valid: Cat)", discriminatorCursor.history))
+              _root_.scala.Left(_root_.io.circe.DecodingFailure("Unknown value " ++ tpe ++ " (valid: Cat)", discriminatorCursor.history))
           })
         }
       }

--- a/modules/scala-dropwizard/src/main/scala/dev/guardrail/generators/scala/dropwizard/DropwizardServerGenerator.scala
+++ b/modules/scala-dropwizard/src/main/scala/dev/guardrail/generators/scala/dropwizard/DropwizardServerGenerator.scala
@@ -319,7 +319,7 @@ class DropwizardServerGenerator private extends ServerTerms[ScalaLanguage, Targe
 
     val (routeMethods, handlerMethodSigs) = routes.map {
       case GenerateRouteMeta(
-            operationId,
+            _,
             methodName,
             responseClsName,
             customExtractionFields,
@@ -348,7 +348,7 @@ class DropwizardServerGenerator private extends ServerTerms[ScalaLanguage, Targe
         val producesAnnotation = NonEmptyList
           .fromList(
             responses.value
-              .flatMap(ResponseHelpers.getBestProduces[ScalaLanguage](operationId, allProduces, _, isTypePlain))
+              .flatMap(ResponseHelpers.getBestProduces[ScalaLanguage](operation, allProduces, _, isTypePlain))
               .distinct
               .map(toJaxRsAnnotationName)
           )

--- a/modules/scala-http4s/src/main/scala/dev/guardrail/generators/scala/http4s/Http4sServerGenerator.scala
+++ b/modules/scala-http4s/src/main/scala/dev/guardrail/generators/scala/http4s/Http4sServerGenerator.scala
@@ -470,7 +470,7 @@ class Http4sServerGenerator private (version: Http4sVersion) extends ServerTerms
               None,
               Some(
                 (
-                  q"req.headers.get(CIString(${arg.argName.toLit})).map(_.head.value).map(Json.fromString(_).as[$tpe])",
+                  q"req.headers.get(CIString(${arg.argName.toLit})).map(_.head.value).map(_root_.io.circe.Json.fromString(_).as[$tpe])",
                   p"Some(Right(${Pat.Var(arg.paramName)}))"
                 )
               ),
@@ -488,7 +488,7 @@ class Http4sServerGenerator private (version: Http4sVersion) extends ServerTerms
               None,
               Some(
                 (
-                  q"req.headers.get(CIString(${arg.argName.toLit})).map(_.head.value).map(Json.fromString(_).as[$tpe]).sequence",
+                  q"req.headers.get(CIString(${arg.argName.toLit})).map(_.head.value).map(_root_.io.circe.Json.fromString(_).as[$tpe]).sequence",
                   p"Right(${Pat.Var(arg.paramName)})"
                 )
               ),
@@ -524,7 +524,7 @@ class Http4sServerGenerator private (version: Http4sVersion) extends ServerTerms
               None,
               Some(
                 (
-                  q"urlForm.values.get(${arg.argName.toLit}).flatMap(_.headOption).map(Json.fromString(_).as[$tpe])",
+                  q"urlForm.values.get(${arg.argName.toLit}).flatMap(_.headOption).map(_root_.io.circe.Json.fromString(_).as[$tpe])",
                   p"Some(Right(${Pat.Var(arg.paramName)}))"
                 )
               ),
@@ -542,7 +542,7 @@ class Http4sServerGenerator private (version: Http4sVersion) extends ServerTerms
                 None,
                 Some(
                   (
-                    q"urlForm.values.get(${arg.argName.toLit}).flatMap(_.toList).traverse(Json.fromString(_).as[$tpe])",
+                    q"urlForm.values.get(${arg.argName.toLit}).flatMap(_.toList).traverse(_root_.io.circe.Json.fromString(_).as[$tpe])",
                     p"Some(Right(${Pat.Var(arg.paramName)}))"
                   )
                 ),
@@ -559,7 +559,7 @@ class Http4sServerGenerator private (version: Http4sVersion) extends ServerTerms
                 None,
                 Some(
                   (
-                    q"${lift(q"urlForm.values.get(${arg.argName.toLit})")}.flatMap(${lift(q"_")}).map(Json.fromString(_).as[$tpe]).sequence.sequence",
+                    q"${lift(q"urlForm.values.get(${arg.argName.toLit})")}.flatMap(${lift(q"_")}).map(_root_.io.circe.Json.fromString(_).as[$tpe]).sequence.sequence",
                     p"Right(${Pat.Var(arg.paramName)})"
                   )
                 ),
@@ -576,7 +576,7 @@ class Http4sServerGenerator private (version: Http4sVersion) extends ServerTerms
               None,
               Some(
                 (
-                  q"urlForm.values.get(${arg.argName.toLit}).traverse(_.toList).map(_.traverse(Json.fromString(_).as[$tpe]))",
+                  q"urlForm.values.get(${arg.argName.toLit}).traverse(_.toList).map(_.traverse(_root_.io.circe.Json.fromString(_).as[$tpe]))",
                   p"List(Right(${Pat.Var(arg.paramName)}))"
                 )
               ),
@@ -619,7 +619,7 @@ class Http4sServerGenerator private (version: Http4sVersion) extends ServerTerms
                 Target.pure(
                   Param(
                     Some(
-                      enumerator"${Pat.Var(Term.Name(s"${arg.argName.value}Option"))} <- multipart.parts.find(_.name.contains(${arg.argName.toLit})).map(_.body.through($bodyUtf8Decode).compile.foldMonoid.flatMap(str => F.fromEither(Json.fromString(str).as[$tpe]))).sequence"
+                      enumerator"${Pat.Var(Term.Name(s"${arg.argName.value}Option"))} <- multipart.parts.find(_.name.contains(${arg.argName.toLit})).map(_.body.through($bodyUtf8Decode).compile.foldMonoid.flatMap(str => F.fromEither(_root_.io.circe.Json.fromString(str).as[$tpe]))).sequence"
                     ),
                     Some(
                       (
@@ -652,7 +652,7 @@ class Http4sServerGenerator private (version: Http4sVersion) extends ServerTerms
                   Target.pure(
                     Param(
                       Some(
-                        enumerator"${Pat.Var(arg.paramName)} <- multipart.parts.filter(_.name.contains(${arg.argName.toLit})).map(_.body.through($bodyUtf8Decode).compile.foldMonoid.flatMap(str => F.fromEither(Json.fromString(str).as[$tpe]))).sequence"
+                        enumerator"${Pat.Var(arg.paramName)} <- multipart.parts.filter(_.name.contains(${arg.argName.toLit})).map(_.body.through($bodyUtf8Decode).compile.foldMonoid.flatMap(str => F.fromEither(_root_.io.circe.Json.fromString(str).as[$tpe]))).sequence"
                       ),
                       None,
                       arg.paramName
@@ -680,7 +680,7 @@ class Http4sServerGenerator private (version: Http4sVersion) extends ServerTerms
                   Target.pure(
                     Param(
                       Some(
-                        enumerator"${Pat.Var(arg.paramName)} <- multipart.parts.filter(_.name.contains(${arg.argName.toLit})).map(_.body.through($bodyUtf8Decode).compile.foldMonoid.flatMap(str => F.fromEither(Json.fromString(str).as[$tpe]))).sequence.map(Option(_).filter(_.nonEmpty))"
+                        enumerator"${Pat.Var(arg.paramName)} <- multipart.parts.filter(_.name.contains(${arg.argName.toLit})).map(_.body.through($bodyUtf8Decode).compile.foldMonoid.flatMap(str => F.fromEither(_root_.io.circe.Json.fromString(str).as[$tpe]))).sequence.map(Option(_).filter(_.nonEmpty))"
                       ),
                       None,
                       arg.paramName
@@ -707,7 +707,7 @@ class Http4sServerGenerator private (version: Http4sVersion) extends ServerTerms
                 Target.pure(
                   Param(
                     Some(
-                      enumerator"${Pat.Var(arg.paramName)} <- multipart.parts.find(_.name.contains(${arg.argName.toLit})).map(_.body.through($bodyUtf8Decode).compile.foldMonoid.flatMap(str => F.fromEither(Json.fromString(str).as[$tpe]))).sequence"
+                      enumerator"${Pat.Var(arg.paramName)} <- multipart.parts.find(_.name.contains(${arg.argName.toLit})).map(_.body.through($bodyUtf8Decode).compile.foldMonoid.flatMap(str => F.fromEither(_root_.io.circe.Json.fromString(str).as[$tpe]))).sequence"
                     ),
                     None,
                     arg.paramName
@@ -1046,7 +1046,7 @@ class Http4sServerGenerator private (version: Http4sVersion) extends ServerTerms
           object ${Term.Name(s"${name}Var")} {
             def unapply(str: String): Option[${tpe}] = {
               if (!str.isEmpty)
-                Json.fromString(str).as[${tpe}].toOption
+                _root_.io.circe.Json.fromString(str).as[${tpe}].toOption
               else
                 None
             }
@@ -1124,7 +1124,7 @@ class Http4sServerGenerator private (version: Http4sVersion) extends ServerTerms
         if (!List("Unit", "Boolean", "Double", "Float", "Short", "Int", "Long", "Char", "String").contains(elemType.toString())) {
           val queryParamDecoder = q"""
               implicit val ${Pat.Var(Term.Name(s"${elemType.toString()}QueryParamDecoder"))}: QueryParamDecoder[$elemType] = (value: QueryParameterValue) =>
-                  Json.fromString(value.value).as[$elemType]
+                  _root_.io.circe.Json.fromString(value.value).as[$elemType]
                     .leftMap(t => ParseFailure("Query decoding failed", t.getMessage))
                     .toValidatedNel
             """

--- a/modules/scala-http4s/src/test/scala/tests/generators/http4s/Http4sServerTest.scala
+++ b/modules/scala-http4s/src/test/scala/tests/generators/http4s/Http4sServerTest.scala
@@ -150,7 +150,7 @@ class Http4sServerTest extends AnyFunSuite with Matchers with SwaggerSpecRunner 
         q"""
       class StoreResource[F[_]](mapRoute: (String, Request[F], F[Response[F]]) => F[Response[F]] = (_: String, _: Request[F], r: F[Response[F]]) => r)(implicit F: Async[F]) extends Http4sDsl[F] with CirceInstances {
         import StoreResource._
-        implicit val OrderStatusQueryParamDecoder: QueryParamDecoder[OrderStatus] = (value: QueryParameterValue) => Json.fromString(value.value).as[OrderStatus].leftMap(t => ParseFailure("Query decoding failed", t.getMessage)).toValidatedNel
+        implicit val OrderStatusQueryParamDecoder: QueryParamDecoder[OrderStatus] = (value: QueryParameterValue) => _root_.io.circe.Json.fromString(value.value).as[OrderStatus].leftMap(t => ParseFailure("Query decoding failed", t.getMessage)).toValidatedNel
         object GetOrderByIdStatusMatcher extends QueryParamDecoderMatcher[OrderStatus]("status")
         object PutBarBarMatcher extends QueryParamDecoderMatcher[Long]("bar")
         private[this] val getFooBarOkEncoder = jsonEncoderOf[F, Boolean]
@@ -236,7 +236,7 @@ class Http4sServerTest extends AnyFunSuite with Matchers with SwaggerSpecRunner 
         q"""
       class StoreResource[F[_]](trace: String => Request[F] => TraceBuilder[F], mapRoute: (String, Request[F], F[Response[F]]) => F[Response[F]] = (_: String, _: Request[F], r: F[Response[F]]) => r)(implicit F: Async[F]) extends Http4sDsl[F] with CirceInstances {
         import StoreResource._
-        implicit val OrderStatusQueryParamDecoder: QueryParamDecoder[OrderStatus] = (value: QueryParameterValue) => Json.fromString(value.value).as[OrderStatus].leftMap(t => ParseFailure("Query decoding failed", t.getMessage)).toValidatedNel
+        implicit val OrderStatusQueryParamDecoder: QueryParamDecoder[OrderStatus] = (value: QueryParameterValue) => _root_.io.circe.Json.fromString(value.value).as[OrderStatus].leftMap(t => ParseFailure("Query decoding failed", t.getMessage)).toValidatedNel
         object GetOrderByIdStatusMatcher extends QueryParamDecoderMatcher[OrderStatus]("status")
         object PutBarBarMatcher extends QueryParamDecoderMatcher[Long]("bar")
         object usingForGetFoo { def unapply(r: Request[F]): Some[(Request[F], TraceBuilder[F])] = Some(r -> trace("store:getFoo")(r)) }
@@ -326,7 +326,7 @@ class Http4sServerTest extends AnyFunSuite with Matchers with SwaggerSpecRunner 
         q"""
       class StoreResource[F[_], E](customExtract: String => Request[F] => E, mapRoute: (String, Request[F], F[Response[F]]) => F[Response[F]] = (_: String, _: Request[F], r: F[Response[F]]) => r)(implicit F: Async[F]) extends Http4sDsl[F] with CirceInstances {
         import StoreResource._
-        implicit val OrderStatusQueryParamDecoder: QueryParamDecoder[OrderStatus] = (value: QueryParameterValue) => Json.fromString(value.value).as[OrderStatus].leftMap(t => ParseFailure("Query decoding failed", t.getMessage)).toValidatedNel
+        implicit val OrderStatusQueryParamDecoder: QueryParamDecoder[OrderStatus] = (value: QueryParameterValue) => _root_.io.circe.Json.fromString(value.value).as[OrderStatus].leftMap(t => ParseFailure("Query decoding failed", t.getMessage)).toValidatedNel
         object GetOrderByIdStatusMatcher extends QueryParamDecoderMatcher[OrderStatus]("status")
         object PutBarBarMatcher extends QueryParamDecoderMatcher[Long]("bar")
         object extractorForGetFoo { def unapply(r: Request[F]): Some[(Request[F], E)] = Some(r -> customExtract("getFoo")(r)) }

--- a/modules/scala-support/src/main/scala/dev/guardrail/generators/scala/ResponseADTHelper.scala
+++ b/modules/scala-support/src/main/scala/dev/guardrail/generators/scala/ResponseADTHelper.scala
@@ -67,7 +67,7 @@ object ResponseADTHelper {
                   decodeBy(MediaType.text.plain) { msg =>
                     msg.contentLength.filter(_ > 0).fold[DecodeResult[F, $tpe]](DecodeResult.successT(None)){ _ =>
                       DecodeResult.success(decodeText(msg)).flatMap { str =>
-                        Json.fromString(str).as[$tpe]
+                        _root_.io.circe.Json.fromString(str).as[$tpe]
                           .fold(failure =>
                             DecodeResult.failureT(InvalidMessageBodyFailure(s"Could not decode response: $$str", Some(failure))),
                             DecodeResult.successT(_)

--- a/modules/scala-support/src/main/scala/dev/guardrail/generators/scala/circe/CirceProtocolGenerator.scala
+++ b/modules/scala-support/src/main/scala/dev/guardrail/generators/scala/circe/CirceProtocolGenerator.scala
@@ -290,7 +290,7 @@ class CirceProtocolGenerator private (circeVersion: CirceModelGenerator, applyVa
     val typeName                      = Type.Name(clsName)
     val encVal = {
       def encodeStatic(param: ProtocolParameter[ScalaLanguage], clsName: String) =
-        q"""(${Lit.String(param.name.value)}, Json.fromString(${Lit.String(clsName)}))"""
+        q"""(${Lit.String(param.name.value)}, _root_.io.circe.Json.fromString(${Lit.String(clsName)}))"""
 
       def encodeRequired(param: ProtocolParameter[ScalaLanguage]) =
         q"""(${Lit.String(param.name.value)}, a.${Term.Name(param.term.name.value)}.asJson)"""
@@ -494,10 +494,7 @@ class CirceProtocolGenerator private (circeVersion: CirceModelGenerator, applyVa
   override def protocolImports() =
     Target.pure(
       List(
-        q"import cats.syntax.either._",
-        q"import io.circe._",
-        q"import io.circe.syntax._",
-        q"import cats.implicits._"
+        q"import io.circe.syntax._"
       )
     )
 
@@ -629,7 +626,7 @@ class CirceProtocolGenerator private (circeVersion: CirceModelGenerator, applyVa
                discriminatorCursor.as[String].flatMap {
                  ..case $childrenCases;
                  case tpe =>
-                   _root_.scala.Left(DecodingFailure("Unknown value " ++ tpe ++ ${Lit
+                   _root_.scala.Left(_root_.io.circe.DecodingFailure("Unknown value " ++ tpe ++ ${Lit
           .String(s" (valid: ${childrenDiscriminators.mkString(", ")})")}, discriminatorCursor.history))
                }
           })"""
@@ -641,7 +638,7 @@ class CirceProtocolGenerator private (circeVersion: CirceModelGenerator, applyVa
       val discriminatorValue = discriminator.mapping
         .collectFirst { case (value, elem) if elem.name == child => value }
         .getOrElse(child)
-      p"case e:${Type.Name(child)} => e.asJsonObject.add(discriminator, ${Lit.String(discriminatorValue)}.asJson).asJson"
+      p"case e:${Type.Name(child)} => e.asJsonObject.add(discriminator, _root_.io.circe.Json.fromString(${Lit.String(discriminatorValue)})).asJson"
     }
     val code =
       q"""implicit val encoder: _root_.io.circe.Encoder[${Type.Name(clsName)}] = _root_.io.circe.Encoder.instance {

--- a/modules/scala-support/src/main/scala/dev/guardrail/scala/helpers/ResponseHelpers.scala
+++ b/modules/scala-support/src/main/scala/dev/guardrail/scala/helpers/ResponseHelpers.scala
@@ -38,7 +38,7 @@ object ResponseHelpers {
     }
 
   def getBestProduces[L <: LA](
-      operationId: String,
+      operation: Tracker[Operation],
       contentTypes: List[ContentType],
       response: Response[L],
       fallbackIsString: L#Type => Boolean
@@ -51,9 +51,10 @@ object ResponseHelpers {
           .orElse(contentTypes.collectFirst { case tc: TextContent => tc })
           .orElse(contentTypes.collectFirst { case bc: BinaryContent => bc })
           .orElse {
-            val fallback = if (fallbackIsString(valueType)) TextPlain.empty else ApplicationJson.empty
+            val fallback    = if (fallbackIsString(valueType)) TextPlain.empty else ApplicationJson.empty
+            val operationId = operation.downField("operationId", _.getOperationId).unwrapTracker.getOrElse("<no operationId>")
             println(
-              s"WARNING: no supported body param type for operation '$operationId', response code ${response.statusCode}; falling back to ${fallback.value}"
+              s"WARNING: no supported body param type for operation '$operationId', response code ${response.statusCode}; falling back to ${fallback.value} (${operation.showHistory})"
             )
             Option(fallback)
           }

--- a/project/src/main/scala/modules/core.scala
+++ b/project/src/main/scala/modules/core.scala
@@ -18,7 +18,6 @@ object core {
           "org.tpolecat"                %% "atto-core"                    % "0.9.5",
           "org.typelevel"               %% "cats-core"                    % catsVersion,
           "org.typelevel"               %% "cats-kernel"                  % catsVersion,
-          "org.typelevel"               %% "cats-free"                    % catsVersion,
           "org.scala-lang.modules"      %% "scala-java8-compat"           % "1.0.2",
         ).map(_.cross(CrossVersion.for3Use2_13)),
       )

--- a/src/test/scala/tests/core/PathParserSpec.scala
+++ b/src/test/scala/tests/core/PathParserSpec.scala
@@ -49,23 +49,23 @@ class PathParserSpec extends AnyFunSuite with Matchers with EitherValues with Op
     (
       "{foo}.json",
       q""" path(new scala.util.matching.Regex("^" + "" + "(.*)" + ".json" + ${Lit
-          .String("$")}).flatMap(str => io.circe.Json.fromString(str).as[Int].toOption)) """
+          .String("$")}).flatMap(str => _root_.io.circe.Json.fromString(str).as[Int].toOption)) """
     ),
     (
       "{foo}/{bar}.json",
       q""" path(IntNumber / new scala.util.matching.Regex("^" + "" + "(.*)" + ".json" + ${Lit
-          .String("$")}).flatMap(str => io.circe.Json.fromString(str).as[Int].toOption)) """
+          .String("$")}).flatMap(str => _root_.io.circe.Json.fromString(str).as[Int].toOption)) """
     ),
     (
       "{foo_bar}/{bar_baz}.json",
       q""" path(IntNumber / new scala.util.matching.Regex("^" + "" + "(.*)" + ".json" + ${Lit
-          .String("$")}).flatMap(str => io.circe.Json.fromString(str).as[Int].toOption)) """
+          .String("$")}).flatMap(str => _root_.io.circe.Json.fromString(str).as[Int].toOption)) """
     ),
     ("foo?abort=1", q""" path("foo") & parameter("abort").require(_ == "1") """),
     (
       "{foo}.json?abort=1",
       q""" path(new scala.util.matching.Regex("^" + "" + "(.*)" + ".json" + ${Lit
-          .String("$")}).flatMap(str => io.circe.Json.fromString(str).as[Int].toOption)) & parameter("abort").require(_ == "1") """
+          .String("$")}).flatMap(str => _root_.io.circe.Json.fromString(str).as[Int].toOption)) & parameter("abort").require(_ == "1") """
     ),
     ("?", q""" pathEnd """),
     ("?a", q""" pathEnd & parameter("a").require(_ == "") """),


### PR DESCRIPTION
As raised in #1530, `io.circe.Error` is a particularly common term to show up in a specification file, so use fully qualified class names and remove unnecessary imports.