### PR TITLE
use extends to avoid duplicate config

### DIFF
--- a/.github/release-drafter-cli.yml
+++ b/.github/release-drafter-cli.yml
@@ -1,37 +1,7 @@
+_extends: guardrail:.github/release-drafter.yml
 name-template: 'cli-v$RESOLVED_VERSION'
 tag-template: 'cli-v$RESOLVED_VERSION'
 tag-prefix: cli-v
 include-paths:
   - "modules/cli/src/main/"
   - "project/src/main/scala/modules/cli.scala"
-# NB: Managed by support/regenerate-release-drafter.sh
-categories:
-  - title: '🚀 Features'
-    labels:
-      - 'enhancement'
-  - title: '🐛 Bug Fixes'
-    labels:
-      - 'bug'
-  - title: '🧰 Maintenance'
-    label: 'chore'
-change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
-change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
-version-resolver:
-  major:
-    labels:
-      - 'major'
-  minor:
-    labels:
-      - 'minor'
-  patch:
-    labels:
-      - 'patch'
-  default: patch
-template: |
-  ## Changes
-
-  $CHANGES
-
-  ## Contributors
-
-  Thanks to $CONTRIBUTORS for your contributions to this release!

--- a/.github/release-drafter-core.yml
+++ b/.github/release-drafter-core.yml
@@ -1,37 +1,7 @@
+_extends: guardrail:.github/release-drafter.yml
 name-template: 'core-v$RESOLVED_VERSION'
 tag-template: 'core-v$RESOLVED_VERSION'
 tag-prefix: core-v
 include-paths:
   - "modules/core/src/main/"
   - "project/src/main/scala/modules/core.scala"
-# NB: Managed by support/regenerate-release-drafter.sh
-categories:
-  - title: '🚀 Features'
-    labels:
-      - 'enhancement'
-  - title: '🐛 Bug Fixes'
-    labels:
-      - 'bug'
-  - title: '🧰 Maintenance'
-    label: 'chore'
-change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
-change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
-version-resolver:
-  major:
-    labels:
-      - 'major'
-  minor:
-    labels:
-      - 'minor'
-  patch:
-    labels:
-      - 'patch'
-  default: patch
-template: |
-  ## Changes
-
-  $CHANGES
-
-  ## Contributors
-
-  Thanks to $CONTRIBUTORS for your contributions to this release!

--- a/.github/release-drafter-java-async-http.yml
+++ b/.github/release-drafter-java-async-http.yml
@@ -1,37 +1,7 @@
+_extends: guardrail:.github/release-drafter.yml
 name-template: 'java-async-http-v$RESOLVED_VERSION'
 tag-template: 'java-async-http-v$RESOLVED_VERSION'
 tag-prefix: java-async-http-v
 include-paths:
   - "modules/java-async-http/src/main/"
   - "project/src/main/scala/modules/javaAsyncHttp.scala"
-# NB: Managed by support/regenerate-release-drafter.sh
-categories:
-  - title: '🚀 Features'
-    labels:
-      - 'enhancement'
-  - title: '🐛 Bug Fixes'
-    labels:
-      - 'bug'
-  - title: '🧰 Maintenance'
-    label: 'chore'
-change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
-change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
-version-resolver:
-  major:
-    labels:
-      - 'major'
-  minor:
-    labels:
-      - 'minor'
-  patch:
-    labels:
-      - 'patch'
-  default: patch
-template: |
-  ## Changes
-
-  $CHANGES
-
-  ## Contributors
-
-  Thanks to $CONTRIBUTORS for your contributions to this release!

--- a/.github/release-drafter-java-dropwizard.yml
+++ b/.github/release-drafter-java-dropwizard.yml
@@ -1,37 +1,7 @@
+_extends: guardrail:.github/release-drafter.yml
 name-template: 'java-dropwizard-v$RESOLVED_VERSION'
 tag-template: 'java-dropwizard-v$RESOLVED_VERSION'
 tag-prefix: java-dropwizard-v
 include-paths:
   - "modules/java-dropwizard/src/main/"
   - "project/src/main/scala/modules/javaDropwizard.scala"
-# NB: Managed by support/regenerate-release-drafter.sh
-categories:
-  - title: '🚀 Features'
-    labels:
-      - 'enhancement'
-  - title: '🐛 Bug Fixes'
-    labels:
-      - 'bug'
-  - title: '🧰 Maintenance'
-    label: 'chore'
-change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
-change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
-version-resolver:
-  major:
-    labels:
-      - 'major'
-  minor:
-    labels:
-      - 'minor'
-  patch:
-    labels:
-      - 'patch'
-  default: patch
-template: |
-  ## Changes
-
-  $CHANGES
-
-  ## Contributors
-
-  Thanks to $CONTRIBUTORS for your contributions to this release!

--- a/.github/release-drafter-java-spring-mvc.yml
+++ b/.github/release-drafter-java-spring-mvc.yml
@@ -1,37 +1,7 @@
+_extends: guardrail:.github/release-drafter.yml
 name-template: 'java-spring-mvc-v$RESOLVED_VERSION'
 tag-template: 'java-spring-mvc-v$RESOLVED_VERSION'
 tag-prefix: java-spring-mvc-v
 include-paths:
   - "modules/java-spring-mvc/src/main/"
   - "project/src/main/scala/modules/javaSpringMvc.scala"
-# NB: Managed by support/regenerate-release-drafter.sh
-categories:
-  - title: '🚀 Features'
-    labels:
-      - 'enhancement'
-  - title: '🐛 Bug Fixes'
-    labels:
-      - 'bug'
-  - title: '🧰 Maintenance'
-    label: 'chore'
-change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
-change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
-version-resolver:
-  major:
-    labels:
-      - 'major'
-  minor:
-    labels:
-      - 'minor'
-  patch:
-    labels:
-      - 'patch'
-  default: patch
-template: |
-  ## Changes
-
-  $CHANGES
-
-  ## Contributors
-
-  Thanks to $CONTRIBUTORS for your contributions to this release!

--- a/.github/release-drafter-java-support.yml
+++ b/.github/release-drafter-java-support.yml
@@ -1,37 +1,7 @@
+_extends: guardrail:.github/release-drafter.yml
 name-template: 'java-support-v$RESOLVED_VERSION'
 tag-template: 'java-support-v$RESOLVED_VERSION'
 tag-prefix: java-support-v
 include-paths:
   - "modules/java-support/src/main/"
   - "project/src/main/scala/modules/javaSupport.scala"
-# NB: Managed by support/regenerate-release-drafter.sh
-categories:
-  - title: '🚀 Features'
-    labels:
-      - 'enhancement'
-  - title: '🐛 Bug Fixes'
-    labels:
-      - 'bug'
-  - title: '🧰 Maintenance'
-    label: 'chore'
-change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
-change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
-version-resolver:
-  major:
-    labels:
-      - 'major'
-  minor:
-    labels:
-      - 'minor'
-  patch:
-    labels:
-      - 'patch'
-  default: patch
-template: |
-  ## Changes
-
-  $CHANGES
-
-  ## Contributors
-
-  Thanks to $CONTRIBUTORS for your contributions to this release!

--- a/.github/release-drafter-scala-akka-http.yml
+++ b/.github/release-drafter-scala-akka-http.yml
@@ -1,37 +1,7 @@
+_extends: guardrail:.github/release-drafter.yml
 name-template: 'scala-akka-http-v$RESOLVED_VERSION'
 tag-template: 'scala-akka-http-v$RESOLVED_VERSION'
 tag-prefix: scala-akka-http-v
 include-paths:
   - "modules/scala-akka-http/src/main/"
   - "project/src/main/scala/modules/scalaAkkaHttp.scala"
-# NB: Managed by support/regenerate-release-drafter.sh
-categories:
-  - title: '🚀 Features'
-    labels:
-      - 'enhancement'
-  - title: '🐛 Bug Fixes'
-    labels:
-      - 'bug'
-  - title: '🧰 Maintenance'
-    label: 'chore'
-change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
-change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
-version-resolver:
-  major:
-    labels:
-      - 'major'
-  minor:
-    labels:
-      - 'minor'
-  patch:
-    labels:
-      - 'patch'
-  default: patch
-template: |
-  ## Changes
-
-  $CHANGES
-
-  ## Contributors
-
-  Thanks to $CONTRIBUTORS for your contributions to this release!

--- a/.github/release-drafter-scala-dropwizard.yml
+++ b/.github/release-drafter-scala-dropwizard.yml
@@ -1,37 +1,7 @@
+_extends: guardrail:.github/release-drafter.yml
 name-template: 'scala-dropwizard-v$RESOLVED_VERSION'
 tag-template: 'scala-dropwizard-v$RESOLVED_VERSION'
 tag-prefix: scala-dropwizard-v
 include-paths:
   - "modules/scala-dropwizard/src/main/"
   - "project/src/main/scala/modules/scalaDropwizard.scala"
-# NB: Managed by support/regenerate-release-drafter.sh
-categories:
-  - title: '🚀 Features'
-    labels:
-      - 'enhancement'
-  - title: '🐛 Bug Fixes'
-    labels:
-      - 'bug'
-  - title: '🧰 Maintenance'
-    label: 'chore'
-change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
-change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
-version-resolver:
-  major:
-    labels:
-      - 'major'
-  minor:
-    labels:
-      - 'minor'
-  patch:
-    labels:
-      - 'patch'
-  default: patch
-template: |
-  ## Changes
-
-  $CHANGES
-
-  ## Contributors
-
-  Thanks to $CONTRIBUTORS for your contributions to this release!

--- a/.github/release-drafter-scala-http4s.yml
+++ b/.github/release-drafter-scala-http4s.yml
@@ -1,37 +1,7 @@
+_extends: guardrail:.github/release-drafter.yml
 name-template: 'scala-http4s-v$RESOLVED_VERSION'
 tag-template: 'scala-http4s-v$RESOLVED_VERSION'
 tag-prefix: scala-http4s-v
 include-paths:
   - "modules/scala-http4s/src/main/"
   - "project/src/main/scala/modules/scalaHttp4s.scala"
-# NB: Managed by support/regenerate-release-drafter.sh
-categories:
-  - title: '🚀 Features'
-    labels:
-      - 'enhancement'
-  - title: '🐛 Bug Fixes'
-    labels:
-      - 'bug'
-  - title: '🧰 Maintenance'
-    label: 'chore'
-change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
-change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
-version-resolver:
-  major:
-    labels:
-      - 'major'
-  minor:
-    labels:
-      - 'minor'
-  patch:
-    labels:
-      - 'patch'
-  default: patch
-template: |
-  ## Changes
-
-  $CHANGES
-
-  ## Contributors
-
-  Thanks to $CONTRIBUTORS for your contributions to this release!

--- a/.github/release-drafter-scala-support.yml
+++ b/.github/release-drafter-scala-support.yml
@@ -1,37 +1,7 @@
+_extends: guardrail:.github/release-drafter.yml
 name-template: 'scala-support-v$RESOLVED_VERSION'
 tag-template: 'scala-support-v$RESOLVED_VERSION'
 tag-prefix: scala-support-v
 include-paths:
   - "modules/scala-support/src/main/"
   - "project/src/main/scala/modules/scalaSupport.scala"
-# NB: Managed by support/regenerate-release-drafter.sh
-categories:
-  - title: '🚀 Features'
-    labels:
-      - 'enhancement'
-  - title: '🐛 Bug Fixes'
-    labels:
-      - 'bug'
-  - title: '🧰 Maintenance'
-    label: 'chore'
-change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
-change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
-version-resolver:
-  major:
-    labels:
-      - 'major'
-  minor:
-    labels:
-      - 'minor'
-  patch:
-    labels:
-      - 'patch'
-  default: patch
-template: |
-  ## Changes
-
-  $CHANGES
-
-  ## Contributors
-
-  Thanks to $CONTRIBUTORS for your contributions to this release!

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,30 @@
+categories:
+  - title: '🚀 Features'
+    labels:
+      - 'enhancement'
+  - title: '🐛 Bug Fixes'
+    labels:
+      - 'bug'
+  - title: '🧰 Maintenance'
+    label: 'chore'
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
+version-resolver:
+  major:
+    labels:
+      - 'major'
+  minor:
+    labels:
+      - 'minor'
+  patch:
+    labels:
+      - 'patch'
+  default: patch
+template: |
+  ## Changes
+
+  $CHANGES
+
+  ## Contributors
+
+  Thanks to $CONTRIBUTORS for your contributions to this release!

--- a/support/regenerate-release-drafter.sh
+++ b/support/regenerate-release-drafter.sh
@@ -11,6 +11,7 @@ render() {
   module="$1"; shift || die "Missing module for render"
 
   cat <<!
+_extends: guardrail:.github/release-drafter.yml
 name-template: '$module-v\$RESOLVED_VERSION'
 tag-template: '$module-v\$RESOLVED_VERSION'
 tag-prefix: $module-v
@@ -22,39 +23,6 @@ include-paths:
   - "$path"
 !
   done
-  cat <<!
-# NB: Managed by support/regenerate-release-drafter.sh
-categories:
-  - title: '🚀 Features'
-    labels:
-      - 'enhancement'
-  - title: '🐛 Bug Fixes'
-    labels:
-      - 'bug'
-  - title: '🧰 Maintenance'
-    label: 'chore'
-change-template: '- \$TITLE @\$AUTHOR (#\$NUMBER)'
-change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add \` to disable code blocks.
-version-resolver:
-  major:
-    labels:
-      - 'major'
-  minor:
-    labels:
-      - 'minor'
-  patch:
-    labels:
-      - 'patch'
-  default: patch
-template: |
-  ## Changes
-
-  \$CHANGES
-
-  ## Contributors
-
-  Thanks to \$CONTRIBUTORS for your contributions to this release!
-!
 }
 
 reinitialize_release() {


### PR DESCRIPTION
Now the main release-drafter.yml does not need to managed by the script and you can simply modify it once.