### PR TITLE
Adding proper support for empty path segments

### DIFF
--- a/modules/core/src/main/scala/dev/guardrail/core/PathExtractor.scala
+++ b/modules/core/src/main/scala/dev/guardrail/core/PathExtractor.scala
@@ -49,6 +49,14 @@ object PathExtractor {
   }
 }
 
+// PathExtractor is a parameterized parser that takes a raw string and extracts
+// a set of bindings and extractors, as well as any static querystring
+//
+// Type arguments:
+//   L <: LA            : Which language our types refer to
+//   T                  : L#Term, but we can't type project in class arguments
+//   TN                 : L#TermName, but we can't type project in class arguments
+//   ModelGeneratorType : Smuggling in some extra data useful in parse, but that we don't have access to in the core module
 class PathExtractor[L <: LA, T, TN <: T, ModelGeneratorType](
     pathSegmentConverter: (LanguageParameter[L], Option[T], ModelGeneratorType) => Either[String, T],
     buildParamConstraint: ((String, String)) => T,

--- a/modules/sample/src/main/resources/issues/issue1594.yaml
+++ b/modules/sample/src/main/resources/issues/issue1594.yaml
@@ -1,0 +1,14 @@
+openapi: 3.0.0
+info:
+  title: Whatever
+  version: 1.0.0
+servers:
+  - url: //localhost:1234/foo/
+paths:
+  /foo//bar:
+    post:
+      operationId: doFoo
+      x-jvm-package: foo
+      responses:
+        "201":
+          description: Created

--- a/project/src/main/scala/RegressionTests.scala
+++ b/project/src/main/scala/RegressionTests.scala
@@ -112,13 +112,14 @@ object RegressionTests {
     ExampleCase(sampleResource("authentication-override.yaml"), "authentication-override-simple").args("--auth-implementation", "simple").frameworks("scala" -> Set("http4s", "http4s-v0.22")),
   )
 
-  def exampleArgs(language: String, framework: Option[String] = None): List[List[String]] = exampleCases
+  def exampleArgs(language: String, framework: Option[String] = None, file: Option[String] = None): List[List[String]] = exampleCases
     .foldLeft(List[List[String]](List(language)))({
       case (acc, ExampleCase(path, prefix, extra, onlyFrameworks)) =>
         acc ++ (for {
           frameworkSuite <- exampleFrameworkSuites(language).filter(efs => framework.forall(_ == efs.name))
           ExampleFramework(frameworkName, frameworkPackage, kinds, modules) = frameworkSuite
           if onlyFrameworks.forall(_.exists({ case (onlyLanguage, onlyFrameworks) => onlyLanguage == language && onlyFrameworks.contains(frameworkName) }))
+          if file.forall(path.toPath.endsWith)
           kind <- kinds
           filteredExtra = extra.filterNot(if (language == "java" || (language == "scala" && frameworkName == "dropwizard")) _ == "--tracing" else Function.const(false) _)
         } yield

--- a/project/src/main/scala/RegressionTests.scala
+++ b/project/src/main/scala/RegressionTests.scala
@@ -84,6 +84,7 @@ object RegressionTests {
     ExampleCase(sampleResource("issues/issue1138.yaml"), "issues.issue1138"),
     ExampleCase(sampleResource("issues/issue1260.yaml"), "issues.issue1260"),
     ExampleCase(sampleResource("issues/issue1218.yaml"), "issues.issue1218").frameworks("scala" -> Set("http4s", "http4s-v0.22")),
+    ExampleCase(sampleResource("issues/issue1594.yaml"), "issues.issue1594"),
     ExampleCase(sampleResource("multipart-form-data.yaml"), "multipartFormData"),
     ExampleCase(sampleResource("petstore.json"), "examples").args("--import", "examples.support.PositiveLong"),
     // ExampleCase(sampleResource("petstore-openapi-3.0.2.yaml"), "examples.petstore.openapi302").args("--import", "examples.support.PositiveLong"),

--- a/src/test/scala/tests/core/PathParserSpec.scala
+++ b/src/test/scala/tests/core/PathParserSpec.scala
@@ -44,6 +44,8 @@ class PathParserSpec extends AnyFunSuite with Matchers with EitherValues with Op
   List[(String, Term)](
     ("", q""" pathEnd """),
     ("foo", q""" path("foo") """),
+    ("foo/bar", q""" path("foo" / "bar") """),
+    ("foo//bar", q""" path("foo" / "bar") """),
     ("foo/", q""" pathPrefix("foo") & pathEndOrSingleSlash """),
     ("{foo}", q""" path(IntNumber) """),
     (


### PR DESCRIPTION
Fixes #1594 

From the [whatwg spec](https://url.spec.whatwg.org/#urls), `https://example.org//` should be permitted.