### PR TITLE
Added support for HTTP HEAD method for akka-http and http4s

### DIFF
--- a/modules/scala-akka-http/src/main/scala/dev/guardrail/generators/scala/akkaHttp/AkkaHttpServerGenerator.scala
+++ b/modules/scala-akka-http/src/main/scala/dev/guardrail/generators/scala/akkaHttp/AkkaHttpServerGenerator.scala
@@ -351,6 +351,7 @@ class AkkaHttpServerGenerator private (akkaHttpVersion: AkkaHttpVersion, modelGe
     case HttpMethod.POST    => Target.pure(q"post")
     case HttpMethod.PUT     => Target.pure(q"put")
     case HttpMethod.OPTIONS => Target.pure(q"options")
+    case HttpMethod.HEAD    => Target.pure(q"head")
     case other              => Target.raiseUserError(s"Unknown method: ${other}")
   }
 

--- a/modules/scala-akka-http/src/test/scala/core/issues/Issue1682.scala
+++ b/modules/scala-akka-http/src/test/scala/core/issues/Issue1682.scala
@@ -1,0 +1,36 @@
+package core.issues
+
+import dev.guardrail.generators.scala.ScalaGeneratorMappings.scalaInterpreter
+import dev.guardrail.Context
+import support.SwaggerSpecRunner
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+class Issue1682 extends AnyFunSuite with Matchers with SwaggerSpecRunner {
+
+  val swagger: String = s"""
+                           |swagger: '2.0'
+                           |host: petstore.swagger.io
+                           |paths:
+                           |  "/pet/{petId}":
+                           |    head:
+                           |      operationId: test1682
+                           |      tags:
+                           |      - pet
+                           |      parameters:
+                           |      - name: petId
+                           |        in: path
+                           |        description: ID of pet that needs to be fetched
+                           |        required: true
+                           |        type: string
+                           |      responses:
+                           |        '400':
+                           |          description: Invalid ID supplied
+                           |        '404':
+                           |          description: Pet not found
+                           |""".stripMargin
+
+  test("Support for HTTP HEAD method") {
+    runSwaggerSpec(scalaInterpreter)(swagger)(Context.empty, "akka-http")
+  }
+}

--- a/modules/scala-http4s/src/main/scala/dev/guardrail/generators/scala/http4s/Http4sServerGenerator.scala
+++ b/modules/scala-http4s/src/main/scala/dev/guardrail/generators/scala/http4s/Http4sServerGenerator.scala
@@ -388,6 +388,7 @@ class Http4sServerGenerator private (version: Http4sVersion) extends ServerTerms
     case HttpMethod.PATCH  => Target.pure(Term.Name("PATCH"))
     case HttpMethod.POST   => Target.pure(Term.Name("POST"))
     case HttpMethod.PUT    => Target.pure(Term.Name("PUT"))
+    case HttpMethod.HEAD   => Target.pure(Term.Name("HEAD"))
     case other             => Target.raiseUserError(s"Unknown method: ${other}")
   }
 

--- a/modules/scala-http4s/src/test/scala/core/issues/Issue1682.scala
+++ b/modules/scala-http4s/src/test/scala/core/issues/Issue1682.scala
@@ -1,0 +1,43 @@
+package core.issues
+
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+import support.SwaggerSpecRunner
+
+import dev.guardrail._
+import dev.guardrail.generators.scala.ScalaGeneratorMappings.scalaInterpreter
+import dev.guardrail.generators.scala.http4s.Http4sVersion
+
+class Issue1682 extends AnyFunSuite with Matchers with SwaggerSpecRunner {
+
+  val swagger: String = s"""
+                           |swagger: '2.0'
+                           |host: petstore.swagger.io
+                           |paths:
+                           |  "/pet/{petId}":
+                           |    head:
+                           |      operationId: test1682
+                           |      tags:
+                           |      - pet
+                           |      parameters:
+                           |      - name: petId
+                           |        in: path
+                           |        description: ID of pet that needs to be fetched
+                           |        required: true
+                           |        type: string
+                           |      responses:
+                           |        '400':
+                           |          description: Invalid ID supplied
+                           |        '404':
+                           |          description: Pet not found
+                           |""".stripMargin
+
+  def testVersion(version: Http4sVersion): Unit =
+    test(s"$version - Test HTTP HEAD support") {
+      runSwaggerSpec(scalaInterpreter)(swagger)(Context.empty, version.value)
+    }
+
+  testVersion(Http4sVersion.V0_22)
+  testVersion(Http4sVersion.V0_23)
+}


### PR DESCRIPTION
Also added minimal test cases to show that the "Unknown method" error no longer occurs.
