### PR TITLE
Make resource vals protected

### DIFF
--- a/modules/scala-http4s/src/main/scala/dev/guardrail/generators/scala/http4s/Http4sServerGenerator.scala
+++ b/modules/scala-http4s/src/main/scala/dev/guardrail/generators/scala/http4s/Http4sServerGenerator.scala
@@ -1175,7 +1175,7 @@ class Http4sServerGenerator private (version: Http4sVersion) extends ServerTerms
   def generateDecoders(methodName: String, bodyArgs: Option[LanguageParameter[ScalaLanguage]], consumes: Seq[ContentType]): List[Defn.Val] =
     bodyArgs.toList.flatMap { case LanguageParameter(_, _, _, _, argType) =>
       List(
-        q"private[this] val ${Pat.Typed(Pat.Var(Term.Name(s"${methodName.uncapitalized}Decoder")), t"EntityDecoder[F, $argType]")} = ${ResponseADTHelper
+        q"protected[this] val ${Pat.Typed(Pat.Var(Term.Name(s"${methodName.uncapitalized}Decoder")), t"EntityDecoder[F, $argType]")} = ${ResponseADTHelper
             .generateDecoder(argType, consumes)}"
       )
     }
@@ -1186,14 +1186,14 @@ class Http4sServerGenerator private (version: Http4sVersion) extends ServerTerms
       (_, tpe, _) <- response.value
     } yield {
       val contentTypes = response.value.map(_._1).map(List(_)).getOrElse(produces) // for OpenAPI 3.x we should take ContentType from the response
-      q"private[this] val ${Pat.Var(Term.Name(s"$methodName${response.statusCodeName}Encoder"))} = ${ResponseADTHelper.generateEncoder(tpe, contentTypes)}"
+      q"protected[this] val ${Pat.Var(Term.Name(s"$methodName${response.statusCodeName}Encoder"))} = ${ResponseADTHelper.generateEncoder(tpe, contentTypes)}"
     }
 
   def generateResponseGenerators(methodName: String, responses: Responses[ScalaLanguage]): List[Defn.Val] =
     for {
       response <- responses.value
       if response.value.nonEmpty
-    } yield q"private[this] val ${Pat.Var(Term.Name(s"$methodName${response.statusCodeName}EntityResponseGenerator"))} = ${ResponseADTHelper
+    } yield q"protected[this] val ${Pat.Var(Term.Name(s"$methodName${response.statusCodeName}EntityResponseGenerator"))} = ${ResponseADTHelper
         .generateEntityResponseGenerator(q"org.http4s.Status.${response.statusCodeName}")}"
 
   def generateTracingExtractor(methodName: String, tracingField: Term): Defn.Object =

--- a/modules/scala-http4s/src/test/scala/core/issues/Issue144.scala
+++ b/modules/scala-http4s/src/test/scala/core/issues/Issue144.scala
@@ -40,7 +40,7 @@ class Issue144 extends AnyFunSuite with Matchers with SwaggerSpecRunner {
         q"""
       class Resource[F[_]](mapRoute: (String, Request[F], F[Response[F]]) => F[Response[F]] = (_: String, _: Request[F], r: F[Response[F]]) => r)(implicit F: Async[F]) extends Http4sDsl[F] with CirceInstances {
         import Resource._
-        private[this] val getEpochSecondsDecoder: EntityDecoder[F, Long] = jsonOf[F, Long]
+        protected[this] val getEpochSecondsDecoder: EntityDecoder[F, Long] = jsonOf[F, Long]
         def routes(handler: Handler[F]): HttpRoutes[F] = HttpRoutes.of {
           {
             case req @ GET -> Root =>

--- a/modules/scala-http4s/src/test/scala/core/issues/Issue416.scala
+++ b/modules/scala-http4s/src/test/scala/core/issues/Issue416.scala
@@ -47,7 +47,7 @@ class Issue416 extends AnyFunSuite with Matchers with SwaggerSpecRunner {
       val resource = q"""
       class Resource[F[_]](mapRoute: (String, Request[F], F[Response[F]]) => F[Response[F]] = (_: String, _: Request[F], r: F[Response[F]]) => r)(implicit F: Async[F]) extends Http4sDsl[F] with CirceInstances {
         import Resource._
-        private[this] val getRootDecoder: EntityDecoder[F, Option[SinkConfiguration]] = jsonOf[F, Option[SinkConfiguration]]
+        protected[this] val getRootDecoder: EntityDecoder[F, Option[SinkConfiguration]] = jsonOf[F, Option[SinkConfiguration]]
         def routes(handler: Handler[F]): HttpRoutes[F] = HttpRoutes.of {
           {
             case req @ GET -> Root =>

--- a/modules/scala-http4s/src/test/scala/tests/generators/http4s/Http4sServerTest.scala
+++ b/modules/scala-http4s/src/test/scala/tests/generators/http4s/Http4sServerTest.scala
@@ -153,18 +153,18 @@ class Http4sServerTest extends AnyFunSuite with Matchers with SwaggerSpecRunner 
         implicit val OrderStatusQueryParamDecoder: QueryParamDecoder[OrderStatus] = (value: QueryParameterValue) => _root_.io.circe.Json.fromString(value.value).as[OrderStatus].leftMap(t => ParseFailure("Query decoding failed", t.getMessage)).toValidatedNel
         object GetOrderByIdStatusMatcher extends QueryParamDecoderMatcher[OrderStatus]("status")
         object PutBarBarMatcher extends QueryParamDecoderMatcher[Long]("bar")
-        private[this] val getFooBarOkEncoder = jsonEncoderOf[F, Boolean]
-        private[this] val getFooBarOkEntityResponseGenerator = new org.http4s.dsl.impl.EntityResponseGenerator[F, F] {
+        protected[this] val getFooBarOkEncoder = jsonEncoderOf[F, Boolean]
+        protected[this] val getFooBarOkEntityResponseGenerator = new org.http4s.dsl.impl.EntityResponseGenerator[F, F] {
           def status = org.http4s.Status.Ok
           val liftG = cats.arrow.FunctionK.id
         }
-        private[this] val getFooOkEncoder = jsonEncoderOf[F, Boolean]
-        private[this] val getFooOkEntityResponseGenerator = new org.http4s.dsl.impl.EntityResponseGenerator[F, F] {
+        protected[this] val getFooOkEncoder = jsonEncoderOf[F, Boolean]
+        protected[this] val getFooOkEntityResponseGenerator = new org.http4s.dsl.impl.EntityResponseGenerator[F, F] {
           def status = org.http4s.Status.Ok
           val liftG = cats.arrow.FunctionK.id
         }
-        private[this] val getOrderByIdOkEncoder = jsonEncoderOf[F, Order]
-        private[this] val getOrderByIdOkEntityResponseGenerator = new org.http4s.dsl.impl.EntityResponseGenerator[F, F] {
+        protected[this] val getOrderByIdOkEncoder = jsonEncoderOf[F, Order]
+        protected[this] val getOrderByIdOkEntityResponseGenerator = new org.http4s.dsl.impl.EntityResponseGenerator[F, F] {
           def status = org.http4s.Status.Ok
           val liftG = cats.arrow.FunctionK.id
         }
@@ -244,18 +244,18 @@ class Http4sServerTest extends AnyFunSuite with Matchers with SwaggerSpecRunner 
         object usingForGetOrderById { def unapply(r: Request[F]): Some[(Request[F], TraceBuilder[F])] = Some(r -> trace("store:getOrderById")(r)) }
         object usingForGetRoot { def unapply(r: Request[F]): Some[(Request[F], TraceBuilder[F])] = Some(r -> trace("store:getRoot")(r)) }
         object usingForPutBar { def unapply(r: Request[F]): Some[(Request[F], TraceBuilder[F])] = Some(r -> trace("store:putBar")(r)) }
-        private[this] val getFooBarOkEncoder = jsonEncoderOf[F, Boolean]
-        private[this] val getFooBarOkEntityResponseGenerator = new org.http4s.dsl.impl.EntityResponseGenerator[F, F] {
+        protected[this] val getFooBarOkEncoder = jsonEncoderOf[F, Boolean]
+        protected[this] val getFooBarOkEntityResponseGenerator = new org.http4s.dsl.impl.EntityResponseGenerator[F, F] {
           def status = org.http4s.Status.Ok
           val liftG = cats.arrow.FunctionK.id
         }
-        private[this] val getFooOkEncoder = jsonEncoderOf[F, Boolean]
-        private[this] val getFooOkEntityResponseGenerator = new org.http4s.dsl.impl.EntityResponseGenerator[F, F] {
+        protected[this] val getFooOkEncoder = jsonEncoderOf[F, Boolean]
+        protected[this] val getFooOkEntityResponseGenerator = new org.http4s.dsl.impl.EntityResponseGenerator[F, F] {
           def status = org.http4s.Status.Ok
           val liftG = cats.arrow.FunctionK.id
         }
-        private[this] val getOrderByIdOkEncoder = jsonEncoderOf[F, Order]
-        private[this] val getOrderByIdOkEntityResponseGenerator = new org.http4s.dsl.impl.EntityResponseGenerator[F, F] {
+        protected[this] val getOrderByIdOkEncoder = jsonEncoderOf[F, Order]
+        protected[this] val getOrderByIdOkEntityResponseGenerator = new org.http4s.dsl.impl.EntityResponseGenerator[F, F] {
           def status = org.http4s.Status.Ok
           val liftG = cats.arrow.FunctionK.id
         }
@@ -334,18 +334,18 @@ class Http4sServerTest extends AnyFunSuite with Matchers with SwaggerSpecRunner 
         object extractorForGetOrderById { def unapply(r: Request[F]): Some[(Request[F], E)] = Some(r -> customExtract("getOrderById")(r)) }
         object extractorForGetRoot { def unapply(r: Request[F]): Some[(Request[F], E)] = Some(r -> customExtract("getRoot")(r)) }
         object extractorForPutBar { def unapply(r: Request[F]): Some[(Request[F], E)] = Some(r -> customExtract("putBar")(r)) }
-        private[this] val getFooBarOkEncoder = jsonEncoderOf[F, Boolean]
-        private[this] val getFooBarOkEntityResponseGenerator = new org.http4s.dsl.impl.EntityResponseGenerator[F, F] {
+        protected[this] val getFooBarOkEncoder = jsonEncoderOf[F, Boolean]
+        protected[this] val getFooBarOkEntityResponseGenerator = new org.http4s.dsl.impl.EntityResponseGenerator[F, F] {
           def status = org.http4s.Status.Ok
           val liftG = cats.arrow.FunctionK.id
         }
-        private[this] val getFooOkEncoder = jsonEncoderOf[F, Boolean]
-        private[this] val getFooOkEntityResponseGenerator = new org.http4s.dsl.impl.EntityResponseGenerator[F, F] {
+        protected[this] val getFooOkEncoder = jsonEncoderOf[F, Boolean]
+        protected[this] val getFooOkEntityResponseGenerator = new org.http4s.dsl.impl.EntityResponseGenerator[F, F] {
           def status = org.http4s.Status.Ok
           val liftG = cats.arrow.FunctionK.id
         }
-        private[this] val getOrderByIdOkEncoder = jsonEncoderOf[F, Order]
-        private[this] val getOrderByIdOkEntityResponseGenerator = new org.http4s.dsl.impl.EntityResponseGenerator[F, F] {
+        protected[this] val getOrderByIdOkEncoder = jsonEncoderOf[F, Order]
+        protected[this] val getOrderByIdOkEntityResponseGenerator = new org.http4s.dsl.impl.EntityResponseGenerator[F, F] {
           def status = org.http4s.Status.Ok
           val liftG = cats.arrow.FunctionK.id
         }


### PR DESCRIPTION
Making encoders protected allows to overwrite them a provide a customized version (particularly to use streamJsonArrayEncoderOf instead of jsonEcnoderOf for Streams)
```
new SomeResource[F] {
 override  protected[this] val someOkEncoder = streamJsonArrayEncoderOf[F, fs2.Streamr[Entity]]

}
```

(not sure of the right collaboration protocol, let me know if something else is needed :) )
