### PR TITLE
Resolve OpenAPI specs fully

### DIFF
--- a/modules/core/src/main/scala/dev/guardrail/ReadSwagger.scala
+++ b/modules/core/src/main/scala/dev/guardrail/ReadSwagger.scala
@@ -15,6 +15,7 @@ object ReadSwagger {
     if (rs.path.toFile.exists()) {
       val opts = new ParseOptions()
       opts.setResolve(true)
+      opts.setResolveFully(true)
       val result = new OpenAPIParser().readLocation(rs.path.toAbsolutePath.toString, new util.LinkedList(), opts)
       Option(result.getMessages()).foreach(_.asScala.foreach(println))
       Target

--- a/modules/sample/src/main/resources/issues/issue1766.yaml
+++ b/modules/sample/src/main/resources/issues/issue1766.yaml
@@ -1,0 +1,27 @@
+openapi: 3.0.2
+info:
+  version: 1.0.0
+components:
+  schemas:
+    TokenIntrospectionRequest:
+      properties:
+        token:
+          description: access token to introspect
+          type: string
+      required:
+        - token
+      type: object
+paths:
+  /api/v1/oauth/token/introspect:
+    post:
+      deprecated: false
+      description: 'Token introspection for Daml Hub access tokens, as per [rfc7662#section-2](https://datatracker.ietf.org/doc/html/rfc7662#section-2)'
+      operationId: introspectAccessToken
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/TokenIntrospectionRequest'
+      responses:
+        200: {}

--- a/project/src/main/scala/RegressionTests.scala
+++ b/project/src/main/scala/RegressionTests.scala
@@ -85,6 +85,7 @@ object RegressionTests {
     ExampleCase(sampleResource("issues/issue1260.yaml"), "issues.issue1260"),
     ExampleCase(sampleResource("issues/issue1218.yaml"), "issues.issue1218").frameworks("scala" -> Set("http4s", "http4s-v0.22")),
     ExampleCase(sampleResource("issues/issue1594.yaml"), "issues.issue1594"),
+    ExampleCase(sampleResource("issues/issue1766.yaml"), "issues.issue1766"),
     ExampleCase(sampleResource("multipart-form-data.yaml"), "multipartFormData"),
     ExampleCase(sampleResource("petstore.json"), "examples").args("--import", "examples.support.PositiveLong"),
     // ExampleCase(sampleResource("petstore-openapi-3.0.2.yaml"), "examples.petstore.openapi302").args("--import", "examples.support.PositiveLong"),


### PR DESCRIPTION
Resolves #1766 

Specifications, despite being "resolved", were not being "_fully_ resolved", leading to partial domain objects

- Set `resolveFully` in `ReadSwagger`

This may mean all the `Deferred` stuff can be removed, which would be quite nice.