### PR TITLE
Remove deprecations

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -69,9 +69,6 @@ addCommandAlias("runtimeAkkaHttpSuite", "; resetSample ; runExample scala akka-h
 
 addCommandAlias("resetSample", "; " ++ (scalaFrameworks ++ javaFrameworks).map(x => s"sample-${x.projectName}/clean").mkString(" ; "))
 
-// Deprecated command
-addCommandAlias("example", "runtimeSuite")
-
 addCommandAlias("cli", "runMain dev.guardrail.cli.CLI")
 addCommandAlias("runtimeScalaSuite", "; resetSample ; runScalaExample ; " + scalaFrameworks.map(x => s"sample-${x.projectName}/test").mkString("; "))
 addCommandAlias("runtimeJavaSuite", "; resetSample ; runJavaExample ; " + javaFrameworks.map(x => s"sample-${x.projectName}/test").mkString("; "))

--- a/modules/core/src/main/scala/dev/guardrail/core/Tracker.scala
+++ b/modules/core/src/main/scala/dev/guardrail/core/Tracker.scala
@@ -131,13 +131,7 @@ trait HighPriorityTrackerSyntax extends LowPriorityTrackerSyntax {
 
     def showHistory: String = tracker.history.mkString("")
 
-    @deprecated("Tracker.get will be removed once the migration has been completed. Please use the fold/traverse combinators to get values out.", "0.0.0")
-    def get: A = tracker.get
-
     def unwrapTracker: A = tracker.get
-
-    @deprecated("Tracker.get will be removed once the migration has been completed. Please use the fold/traverse combinators to get values out.", "0.0.0")
-    def history: Vector[String] = tracker.history
 
     def forceConvince[C](implicit ev: Tracker.Convincer[Option[A], C]): Tracker[C] =
       tracker.map(x => ev(Option(x)))

--- a/modules/core/src/main/scala/dev/guardrail/core/extract/package.scala
+++ b/modules/core/src/main/scala/dev/guardrail/core/extract/package.scala
@@ -6,16 +6,9 @@ package object extract {
   private def extractFromNames[F: VendorExtension.VendorExtensible, T: Extractable](v: F, names: List[String]): Option[T] =
     names.collectFirstSome(VendorExtension(v).extract[T](_))
 
-  private def extractWithFallback[F: VendorExtension.VendorExtensible, T: Extractable](v: F, name: String, fallbackName: String): Option[T] = {
+  private def extractName[F: VendorExtension.VendorExtensible, T: Extractable](v: F, name: String): Option[T] = {
     val ve = VendorExtension(v)
     ve.extract[T](name)
-      .orElse {
-        val value = ve.extract[T](fallbackName)
-        if (value.isDefined) {
-          println(s"WARNING: Deprecated vendor extension '${fallbackName}'; please migrate to use '${name}' instead")
-        }
-        value
-      }
   }
 
   def CustomTypeName[F: VendorExtension.VendorExtensible](v: F, vendorPrefixes: List[String]): Option[String] =
@@ -28,7 +21,7 @@ package object extract {
     extractFromNames[F, String](v, vendorPrefixes.map(_ + "-map-type"))
 
   def TracingLabel[F: VendorExtension.VendorExtensible](v: F): Option[String] =
-    extractWithFallback[F, String](v, "x-tracing-label", "x-scala-tracing-label")
+    extractName[F, String](v, "x-tracing-label")
 
   def PackageName[F: VendorExtension.VendorExtensible](v: F, vendorPrefixes: List[String]): Option[String] =
     extractFromNames[F, String](v, vendorPrefixes.map(_ + "-package"))
@@ -40,10 +33,10 @@ package object extract {
     VendorExtension(v).extract[Boolean]("x-server-raw-response")
 
   def EmptyValueIsNull[F: VendorExtension.VendorExtensible](v: F): Option[EmptyToNullBehaviour] =
-    extractWithFallback[F, EmptyToNullBehaviour](v, "x-empty-is-null", "x-scala-empty-is-null")
+    extractName[F, EmptyToNullBehaviour](v, "x-empty-is-null")
 
   def FileHashAlgorithm[F: VendorExtension.VendorExtensible](v: F): Option[String] =
-    extractWithFallback[F, String](v, "x-file-hash", "x-scala-file-hash")
+    extractName[F, String](v, "x-file-hash")
 
   def DataRedaction[F: VendorExtension.VendorExtensible](v: F): Option[RedactionBehaviour] =
     VendorExtension(v).extract[RedactionBehaviour]("x-data-redaction")

--- a/modules/java-support/src/main/scala/dev/guardrail/generators/java/syntax/Java.scala
+++ b/modules/java-support/src/main/scala/dev/guardrail/generators/java/syntax/Java.scala
@@ -51,9 +51,6 @@ package object syntax {
       tpe.isPrimitiveType || tpe.isNamed("BigInteger") || tpe.isNamed("BigDecimal") || tpe.isNamed("String") || tpe.isNamed("OffsetDateTime") || tpe.isNamed(
         "LocalDate"
       )
-
-    @deprecated("Just use Type#asString", "0.0.0")
-    def name: Option[String] = Option(tpe.asString)
   }
 
   implicit class RichNode(private val n: Node) extends AnyVal {

--- a/modules/scala-akka-http/src/test/scala/core/issues/Issue145.scala
+++ b/modules/scala-akka-http/src/test/scala/core/issues/Issue145.scala
@@ -27,15 +27,15 @@ class Issue145 extends AnyFunSpec with Matchers with SwaggerSpecRunner {
       |     properties:
       |       name:
       |         type: string
-      |         x-scala-empty-is-null: true
+      |         x-empty-is-null: true
       |         x-scala-type: CustomThing
       |       underscore_name:
       |         type: string
-      |         x-scala-empty-is-null: true
+      |         x-empty-is-null: true
       |         x-scala-type: CustomThing
       |       dash-name:
       |         type: string
-      |         x-scala-empty-is-null: true
+      |         x-empty-is-null: true
       |         x-scala-type: CustomThing
       |""".stripMargin
 

--- a/modules/scala-akka-http/src/test/scala/tests/generators/akkaHttp/server/FormFieldsTest.scala
+++ b/modules/scala-akka-http/src/test/scala/tests/generators/akkaHttp/server/FormFieldsTest.scala
@@ -38,7 +38,7 @@ class FormFieldsServerTest extends AnyFunSuite with Matchers with SwaggerSpecRun
     |          in: formData
     |          type: file
     |          required: true
-    |          x-scala-file-hash: SHA-512
+    |          x-file-hash: SHA-512
     |      responses:
     |        200:
     |          description: Success

--- a/modules/scala-http4s/src/main/scala/dev/guardrail/generators/scala/http4s/Http4sClientGenerator.scala
+++ b/modules/scala-http4s/src/main/scala/dev/guardrail/generators/scala/http4s/Http4sClientGenerator.scala
@@ -39,18 +39,11 @@ class Http4sClientGeneratorLoader extends ClientGeneratorLoader {
 }
 
 object Http4sClientGenerator {
-  @deprecated("Please specify which http4s version to use", "0.72.0")
-  def apply(): ClientTerms[ScalaLanguage, Target] =
-    new Http4sClientGenerator(Http4sVersion.V0_23)
-
   def apply(version: Http4sVersion): ClientTerms[ScalaLanguage, Target] =
     new Http4sClientGenerator(version)
 }
 
 class Http4sClientGenerator(version: Http4sVersion) extends ClientTerms[ScalaLanguage, Target] {
-  @deprecated("Please specify which http4s version to use", "0.72.0")
-  def this() = this(Http4sVersion.V0_23)
-
   override implicit def MonadF: Monad[Target] = Target.targetInstances
 
   def splitOperationParts(operationId: String): (List[String], String) = {


### PR DESCRIPTION
In preparation for 1.0.0, delete deprecated methods and `println`'s.