### PR TITLE
Resolve structured logger log duplication

### DIFF
--- a/modules/cli/src/main/scala/dev/guardrail/cli/CLICommon.scala
+++ b/modules/cli/src/main/scala/dev/guardrail/cli/CLICommon.scala
@@ -104,8 +104,7 @@ trait CLICommon extends GuardrailRunner {
       FlatMap[Target].tailRecM[From, To](start) { case pair @ (sofars, rest) =>
         val empty = sofars
           .filter(_.defaults)
-          .reverse
-          .headOption
+          .lastOption
           .getOrElse(defaultArgs)
           .copy(defaults = false)
         def Continue(x: From): Target[Either[From, To]] = Target.pure(Either.left(x))

--- a/modules/core/src/main/scala/dev/guardrail/core/StructuredLogger.scala
+++ b/modules/core/src/main/scala/dev/guardrail/core/StructuredLogger.scala
@@ -81,12 +81,11 @@ sealed trait StructuredLoggerInstances extends StructuredLoggerLowPriority {
           case ((acc, newHistory), StructuredLoggerReset) =>
             (acc, Chain.empty)
           case ((acc, newHistory), StructuredLogBlock(lines)) =>
-            val newAcc: Chain[(LogLevel, NonEmptyChain[String], String)] = acc ++ lines
+            val history = NonEmptyChain.fromChain[String](newHistory).getOrElse(NonEmptyChain("<root>"))
+            val nextLines: Chain[(LogLevel, NonEmptyChain[String], String)] = lines
               .filter(_._1 >= desiredLevel)
-              .map { case (level, message) =>
-                (level, NonEmptyChain.fromChain[String](newHistory).getOrElse(NonEmptyChain("<root>")), message)
-              }
-            (newAcc, newHistory)
+              .map { case (level, message) => (level, history, message) }
+            (acc ++ nextLines, newHistory)
         }
         ._1
         .foldLeft((Chain.empty[String], Chain.empty[String])) { case ((lastHistory, messages), (level, history, message)) =>

--- a/src/test/scala/core/StructuredLoggerSuite.scala
+++ b/src/test/scala/core/StructuredLoggerSuite.scala
@@ -32,4 +32,63 @@ class StructuredLoggerSuite extends AnyFunSuite with Matchers {
       logEntries.show should ===(expected)
     }
   }
+
+  test("Structured Logger handles prependedLogs") {
+    val start = (List.empty[Args], List(
+      "--defaults",
+      "--specPath", "modules/sample/src/main/resources/issues/issue1.yaml",
+      "--specPath", "modules/sample/src/main/resources/issues/issue2.yaml",
+      "--specPath", "modules/sample/src/main/resources/issues/issue3.yaml",
+      ))
+    val defaultArgs =
+      Args.empty.copy(context = Args.empty.context, defaults = true)
+    type From = (List[Args], List[String])
+    type To   = List[Args]
+    import Target.log.debug
+    val structure = {
+      Target.loggerEnabled.set(true)  // Before program
+      val value = Target.log.function("parseArgs") {
+        cats.FlatMap[Target].tailRecM[From, To](start) { case pair @ (sofars, rest) =>
+          val empty = sofars
+            .filter(_.defaults)
+            .lastOption
+            .getOrElse(defaultArgs)
+            .copy(defaults = false)
+
+          def Continue(x: From): Target[Either[From, To]] = Target.pure(Either.left(x))
+          def Return(x: To): Target[Either[From, To]]     = Target.pure(Either.right(x))
+          def Bail(x: Error): Target[Either[From, To]]    = Target.raiseError(x)
+          for {
+            _ <- debug(s"Processing: ${rest.take(5).mkString(" ")}${if (rest.length > 3) "..." else ""} of ${rest.length}")
+            step <- pair match {
+              case (already, Nil) => debug("Finished") >> Return(already)
+              case (already, "--defaults" :: xs) => Continue((empty.copy(defaults = true) :: already, xs))
+              case (Nil, xs @ (_ :: _)) => Continue((empty :: Nil, xs))
+              case (sofar :: already, "--specPath" :: value :: xs) => Continue((sofar.copy(specPath = Option(value)) :: already, xs))
+              case (_, unknown) =>
+                debug(s"Unknown argument: ${unknown}") >> Bail(UnknownArguments(unknown))
+            }
+          } yield step
+        }
+      }
+      Target.loggerEnabled.set(false)  // After program
+      value
+    }
+
+    val logEntries = structure.logEntries
+    val expected = """
+      |  DEBUG    parseArgs: Processing: --defaults --specPath modules/sample/src/main/resources/issues/issue1.yaml --specPath modules/sample/src/main/resources/issues/issue2.yaml... of 7
+      |  DEBUG    parseArgs: Processing: --specPath modules/sample/src/main/resources/issues/issue1.yaml --specPath modules/sample/src/main/resources/issues/issue2.yaml --specPath... of 6
+      |  DEBUG    parseArgs: Processing: --specPath modules/sample/src/main/resources/issues/issue2.yaml --specPath modules/sample/src/main/resources/issues/issue3.yaml... of 4
+      |  DEBUG    parseArgs: Processing: --specPath modules/sample/src/main/resources/issues/issue3.yaml of 2
+      |  DEBUG    parseArgs: Processing:  of 0
+      |  DEBUG    parseArgs: Finished
+      """.trim.stripMargin
+
+    {
+      implicit val logLevel = LogLevels.Debug
+      logEntries.entries.length should ===(3)  // pushLogger, StructuredLogBlock, pop
+      logEntries.show should ===(expected)
+    }
+  }
 }


### PR DESCRIPTION
There was an issue with `prependLogger` which ended up actually duplicating log lines instead of only prepending them.