### PR TITLE
Avoid LA in language modules

### DIFF
--- a/modules/core/src/main/scala/dev/guardrail/terms/CoreTerms.scala
+++ b/modules/core/src/main/scala/dev/guardrail/terms/CoreTerms.scala
@@ -29,6 +29,3 @@ abstract class CoreTerms[L <: LA, F[_]] { self =>
     }
   }
 }
-object CoreTerms {
-  implicit def coreTerm[L <: LA, F[_]](implicit ev: CoreTerms[L, F]): CoreTerms[L, F] = ev
-}

--- a/modules/java-async-http/src/main/scala/dev/guardrail/generators/java/asyncHttpClient/AsyncHttpClientClientGenerator.scala
+++ b/modules/java-async-http/src/main/scala/dev/guardrail/generators/java/asyncHttpClient/AsyncHttpClientClientGenerator.scala
@@ -620,7 +620,7 @@ class AsyncHttpClientClientGenerator private (implicit Cl: CollectionsLibTerms[J
       val allProduces = operation.unwrapTracker.produces.flatMap(ContentType.unapply).toList
       val produces =
         responses.value
-          .map(resp => (resp.statusCode, ResponseHelpers.getBestProduces[JavaLanguage](operation, allProduces, resp, _.isPlain)))
+          .map(resp => (resp.statusCode, ResponseHelpers.getBestProduces(operation, allProduces, resp, _.isPlain)))
           .toMap
 
       val builderMethodCalls: List[(LanguageParameter[JavaLanguage], Statement)] = builderParamsMethodNames

--- a/modules/java-dropwizard/src/main/scala/dev/guardrail/generators/java/dropwizard/DropwizardServerGenerator.scala
+++ b/modules/java-dropwizard/src/main/scala/dev/guardrail/generators/java/dropwizard/DropwizardServerGenerator.scala
@@ -439,7 +439,7 @@ class DropwizardServerGenerator private (implicit Cl: CollectionsLibTerms[JavaLa
             NonEmptyList
               .fromList(
                 responses.value
-                  .flatMap(ResponseHelpers.getBestProduces[JavaLanguage](operation, allProduces, _, _.isPlain))
+                  .flatMap(ResponseHelpers.getBestProduces(operation, allProduces, _, _.isPlain))
                   .distinct
                   .map(toJaxRsAnnotationName)
               )

--- a/modules/java-support/src/main/scala/dev/guardrail/generators/java/jackson/JacksonGenerator.scala
+++ b/modules/java-support/src/main/scala/dev/guardrail/generators/java/jackson/JacksonGenerator.scala
@@ -39,7 +39,6 @@ import dev.guardrail.generators.ProtocolDefinitions
 import dev.guardrail.generators.ProtocolGenerator.{ WrapEnumSchema, wrapNumberEnumSchema, wrapObjectEnumSchema, wrapStringEnumSchema }
 import dev.guardrail.generators.RawParameterName
 import dev.guardrail.generators.java.JavaCollectionsGenerator
-import dev.guardrail.generators.java.JavaGenerator
 import dev.guardrail.generators.java.JavaLanguage
 import dev.guardrail.generators.java.JavaVavrCollectionsGenerator
 import dev.guardrail.generators.java.syntax._
@@ -1226,7 +1225,7 @@ class JacksonGenerator private (implicit Cl: CollectionsLibTerms[JavaLanguage, T
       supportPackage: List[String],
       selfParams: List[ProtocolParameter[JavaLanguage]],
       parents: List[SuperClass[JavaLanguage]]
-  ): Target[TypeDeclaration[_ <: TypeDeclaration[_]]] = {
+  )(implicit Lt: LanguageTerms[JavaLanguage, Target]): Target[TypeDeclaration[_ <: TypeDeclaration[_]]] = {
     val parentsWithDiscriminators = parents.collect { case p if p.discriminators.nonEmpty => p }
     val discriminators            = parents.flatMap(_.discriminators)
     val discriminatorNames        = discriminators.map(_.propertyName).toSet
@@ -1282,11 +1281,11 @@ class JacksonGenerator private (implicit Cl: CollectionsLibTerms[JavaLanguage, T
                 term.fieldType match {
                   case cls: ClassOrInterfaceType =>
                     // hopefully it's an enum type; nothing else really makes sense here
-                    JavaGenerator().formatEnumName(v).map(ev => new FieldAccessExpr(cls.getNameAsExpression, ev))
+                    Lt.formatEnumName(v).map(ev => new FieldAccessExpr(cls.getNameAsExpression, ev))
                   case tpe =>
                     Target.raiseUserError[Node](s"Unsupported discriminator type '${tpe.asString}' for property '${term.propertyName}'")
                 }
-            )(JavaGenerator())
+            )
             .flatMap[Expression] {
               case expr: Expression => Target.pure(expr)
               case node =>

--- a/modules/java-support/src/main/scala/dev/guardrail/generators/java/jackson/JacksonGenerator.scala
+++ b/modules/java-support/src/main/scala/dev/guardrail/generators/java/jackson/JacksonGenerator.scala
@@ -1271,7 +1271,7 @@ class JacksonGenerator private (implicit Cl: CollectionsLibTerms[JavaLanguage, T
             .getOrElse(clsName)
 
           JacksonHelpers
-            .discriminatorExpression[JavaLanguage](
+            .discriminatorExpression(
               discriminator.propertyName,
               discriminatorValue,
               term.rawType

--- a/modules/java-support/src/main/scala/dev/guardrail/generators/java/jackson/JacksonHelpers.scala
+++ b/modules/java-support/src/main/scala/dev/guardrail/generators/java/jackson/JacksonHelpers.scala
@@ -1,22 +1,24 @@
 package dev.guardrail.generators.java.jackson
 
+import com.github.javaparser.ast.Node
+import scala.util.Try
+
 import dev.guardrail.Target
 import dev.guardrail.core.{ LiteralRawType, ReifiedRawType }
-import dev.guardrail.languages.LA
+import dev.guardrail.generators.java.JavaLanguage
 import dev.guardrail.terms.LanguageTerms
-import scala.util.Try
 
 /* There's a copy of this file in guardrail-scala-support,
  * modules/scala-support/src/main/scala/dev/guardrail/generators/scala/jackson/JacksonHelpers.scala
  */
 object JacksonHelpers {
-  def discriminatorExpression[L <: LA](
+  def discriminatorExpression(
       discriminatorName: String,
       discriminatorValue: String,
       discriminatorTpe: ReifiedRawType
-  )(litBigInteger: String => Target[L#Term], litBigDecimal: String => Target[L#Term], fallback: String => Target[L#Term])(implicit
-      Lt: LanguageTerms[L, Target]
-  ): Target[L#Term] = {
+  )(litBigInteger: String => Target[Node], litBigDecimal: String => Target[Node], fallback: String => Target[Node])(implicit
+      Lt: LanguageTerms[JavaLanguage, Target]
+  ): Target[Node] = {
     import Lt._
 
     def parseLiteral[T](parser: String => T, friendlyName: String): Target[T] =
@@ -24,8 +26,8 @@ object JacksonHelpers {
         t => Target.raiseUserError[T](s"Unable to parse '$discriminatorValue' as '$friendlyName': ${t.getMessage}"),
         Target.pure[T]
       )
-    def errorUnsupported(tpe: String, fmt: String): Target[L#Term] =
-      Target.raiseUserError[L#Term](s"Unsupported discriminator type '$tpe' with format '$fmt' for property '$discriminatorName'")
+    def errorUnsupported(tpe: String, fmt: String): Target[Node] =
+      Target.raiseUserError[Node](s"Unsupported discriminator type '$tpe' with format '$fmt' for property '$discriminatorName'")
 
     discriminatorTpe match {
       case LiteralRawType(Some(tpe @ "string"), fmt) =>

--- a/modules/java-support/src/main/scala/dev/guardrail/java/helpers/ResponseHelpers.scala
+++ b/modules/java-support/src/main/scala/dev/guardrail/java/helpers/ResponseHelpers.scala
@@ -1,10 +1,12 @@
 package dev.guardrail.javaext.helpers
 
+import com.github.javaparser.ast.`type`.Type
+
 import cats.data.NonEmptyList
 import cats.syntax.all._
 import dev.guardrail.core.{ LiteralRawType, Tracker }
 import dev.guardrail.generators.LanguageParameters
-import dev.guardrail.languages.LA
+import dev.guardrail.generators.java.JavaLanguage
 import dev.guardrail.terms.{ ApplicationJson, BinaryContent, ContentType, MultipartFormData, OctetStream, Response, TextContent, TextPlain, UrlencodedFormData }
 import io.swagger.v3.oas.models.Operation
 
@@ -12,7 +14,7 @@ object ResponseHelpers {
   private val CONSUMES_PRIORITY = NonEmptyList.of(ApplicationJson.empty, TextPlain.empty, OctetStream.empty)
   private val PRODUCES_PRIORITY = NonEmptyList.of(ApplicationJson.empty, TextPlain.empty, OctetStream.empty)
 
-  def getBestConsumes[L <: LA](operation: Tracker[Operation], contentTypes: List[ContentType], parameters: LanguageParameters[L]): Option[ContentType] =
+  def getBestConsumes(operation: Tracker[Operation], contentTypes: List[ContentType], parameters: LanguageParameters[JavaLanguage]): Option[ContentType] =
     if (parameters.formParams.nonEmpty) {
       if (parameters.formParams.exists(_.isFile) || contentTypes.exists(ContentType.isSubtypeOf[MultipartFormData])) {
         Some(MultipartFormData.empty)
@@ -37,11 +39,11 @@ object ResponseHelpers {
       }
     }
 
-  def getBestProduces[L <: LA](
+  def getBestProduces(
       operation: Tracker[Operation],
       contentTypes: List[ContentType],
-      response: Response[L],
-      fallbackIsString: L#Type => Boolean
+      response: Response[JavaLanguage],
+      fallbackIsString: Type => Boolean
   ): Option[ContentType] =
     response.value
       .map(_._2)

--- a/modules/java-support/src/test/scala/tests/generators/helpers/JacksonHelpersTest.scala
+++ b/modules/java-support/src/test/scala/tests/generators/helpers/JacksonHelpersTest.scala
@@ -3,7 +3,6 @@ package tests.generators.helpers
 import dev.guardrail.core.LiteralRawType
 import dev.guardrail.generators.java.JavaGenerator
 import dev.guardrail.generators.java.jackson.JacksonHelpers
-import dev.guardrail.generators.java.JavaLanguage
 import dev.guardrail.{ Target, TargetValue }
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.must.Matchers
@@ -26,7 +25,7 @@ class JacksonHelpersTest extends AnyFreeSpec with Matchers {
   val BIG_DECIMAL_FQ_TYPE = StaticJavaParser.parseClassOrInterfaceType("java.math.BigDecimal")
 
   def discriminatorExpression(value: String, tpe: String, fmt: Option[String] = None): Target[ast.Node] =
-    JacksonHelpers.discriminatorExpression[JavaLanguage](
+    JacksonHelpers.discriminatorExpression(
       "discrim",
       value,
       LiteralRawType(Some(tpe), fmt)

--- a/modules/scala-dropwizard/src/main/scala/dev/guardrail/generators/scala/dropwizard/DropwizardServerGenerator.scala
+++ b/modules/scala-dropwizard/src/main/scala/dev/guardrail/generators/scala/dropwizard/DropwizardServerGenerator.scala
@@ -453,7 +453,7 @@ class DropwizardServerGenerator private extends ServerTerms[ScalaLanguage, Targe
         val producesAnnotation = NonEmptyList
           .fromList(
             responses.value
-              .flatMap(ResponseHelpers.getBestProduces[ScalaLanguage](operation, allProduces, _, isTypePlain))
+              .flatMap(ResponseHelpers.getBestProduces(operation, allProduces, _, isTypePlain))
               .distinct
               .map(toJaxRsAnnotationName)
           )

--- a/modules/scala-support/src/main/scala/dev/guardrail/generators/scala/circe/CirceRefinedProtocolGenerator.scala
+++ b/modules/scala-support/src/main/scala/dev/guardrail/generators/scala/circe/CirceRefinedProtocolGenerator.scala
@@ -18,7 +18,7 @@ import dev.guardrail.core.{ DataRedacted, DataVisible, EmptyIsEmpty, EmptyIsNull
 import dev.guardrail.generators.ProtocolGenerator.{ WrapEnumSchema, wrapNumberEnumSchema, wrapObjectEnumSchema, wrapStringEnumSchema }
 import dev.guardrail.generators.protocol.{ ClassChild, ClassHierarchy, ClassParent }
 import dev.guardrail.generators.scala.circe.CirceProtocolGenerator.WithValidations
-import dev.guardrail.generators.scala.{ CirceModelGenerator, CirceRefinedModelGenerator, ScalaGenerator, ScalaLanguage }
+import dev.guardrail.generators.scala.{ CirceModelGenerator, CirceRefinedModelGenerator, ScalaLanguage }
 import dev.guardrail.generators.spi.{ ModuleLoadResult, ProtocolGeneratorLoader }
 import dev.guardrail.generators.{ ProtocolDefinitions, RawParameterName }
 import dev.guardrail.terms.framework.FrameworkTerms
@@ -1048,7 +1048,7 @@ class CirceRefinedProtocolGenerator private (circeVersion: CirceModelGenerator, 
       requirement: PropertyRequirement,
       isCustomType: Boolean,
       defaultValue: Option[scala.meta.Term]
-  ): Target[ProtocolParameter[ScalaLanguage]] =
+  )(implicit Lt: LanguageTerms[ScalaLanguage, Target]): Target[ProtocolParameter[ScalaLanguage]] =
     Target.log.function(s"transformProperty") {
       val fallbackRawType = ReifiedRawType.of(property.downField("type", _.getType()).unwrapTracker, property.downField("format", _.getFormat()).unwrapTracker)
       for {
@@ -1104,8 +1104,8 @@ class CirceRefinedProtocolGenerator private (circeVersion: CirceModelGenerator, 
           _.map(regex => PropertyValidations(Some(regex)))
         )
 
-        presence     <- ScalaGenerator().selectTerm(NonEmptyList.ofInitLast(supportPackage, "Presence"))
-        presenceType <- ScalaGenerator().selectType(NonEmptyList.ofInitLast(supportPackage, "Presence"))
+        presence     <- Lt.selectTerm(NonEmptyList.ofInitLast(supportPackage, "Presence"))
+        presenceType <- Lt.selectType(NonEmptyList.ofInitLast(supportPackage, "Presence"))
         (finalDeclType, finalDefaultValue) = requirement match {
           case PropertyRequirement.Required => tpe -> defaultValue
           case PropertyRequirement.Optional | PropertyRequirement.Configured(PropertyRequirement.Optional, PropertyRequirement.Optional) =>
@@ -1245,7 +1245,7 @@ class CirceRefinedProtocolGenerator private (circeVersion: CirceModelGenerator, 
       supportPackage: List[String],
       selfParams: List[ProtocolParameter[ScalaLanguage]],
       parents: List[SuperClass[ScalaLanguage]] = Nil
-  ): Target[Option[Defn.Val]] = {
+  )(implicit Lt: LanguageTerms[ScalaLanguage, Target]): Target[Option[Defn.Val]] = {
     val discriminators            = parents.flatMap(_.discriminators)
     val discriminatorNames        = discriminators.map(_.propertyName).toSet
     val allParams                 = parents.reverse.flatMap(_.params) ++ selfParams
@@ -1253,7 +1253,7 @@ class CirceRefinedProtocolGenerator private (circeVersion: CirceModelGenerator, 
     val needsEmptyToNull: Boolean = params.exists(_.emptyToNull == EmptyIsNull)
     val paramCount                = params.length
     for {
-      presence <- ScalaGenerator().selectTerm(NonEmptyList.ofInitLast(supportPackage, "Presence"))
+      presence <- Lt.selectTerm(NonEmptyList.ofInitLast(supportPackage, "Presence"))
       decVal <-
         if (paramCount == 0) {
           Target.pure(

--- a/modules/scala-support/src/main/scala/dev/guardrail/generators/scala/jackson/JacksonHelpers.scala
+++ b/modules/scala-support/src/main/scala/dev/guardrail/generators/scala/jackson/JacksonHelpers.scala
@@ -1,22 +1,24 @@
 package dev.guardrail.generators.scala.jackson
 
+import scala.util.Try
+import scala.meta.Term
+
 import dev.guardrail.Target
 import dev.guardrail.core.{ LiteralRawType, ReifiedRawType }
-import dev.guardrail.languages.LA
+import dev.guardrail.generators.scala.ScalaLanguage
 import dev.guardrail.terms.LanguageTerms
-import scala.util.Try
 
 /* There's a copy of this file in guardrail-java-support,
  * modules/java-support/src/main/scala/dev/guardrail/generators/java/jackson/JacksonHelpers.scala
  */
 object JacksonHelpers {
-  def discriminatorExpression[L <: LA](
+  def discriminatorExpression(
       discriminatorName: String,
       discriminatorValue: String,
       discriminatorTpe: ReifiedRawType
-  )(litBigInteger: String => Target[L#Term], litBigDecimal: String => Target[L#Term], fallback: String => Target[L#Term])(implicit
-      Lt: LanguageTerms[L, Target]
-  ): Target[L#Term] = {
+  )(litBigInteger: String => Target[Term], litBigDecimal: String => Target[Term], fallback: String => Target[Term])(implicit
+      Lt: LanguageTerms[ScalaLanguage, Target]
+  ): Target[Term] = {
     import Lt._
 
     def parseLiteral[T](parser: String => T, friendlyName: String): Target[T] =
@@ -24,8 +26,8 @@ object JacksonHelpers {
         t => Target.raiseUserError[T](s"Unable to parse '$discriminatorValue' as '$friendlyName': ${t.getMessage}"),
         Target.pure[T]
       )
-    def errorUnsupported(tpe: String, fmt: String): Target[L#Term] =
-      Target.raiseUserError[L#Term](s"Unsupported discriminator type '$tpe' with format '$fmt' for property '$discriminatorName'")
+    def errorUnsupported(tpe: String, fmt: String): Target[Term] =
+      Target.raiseUserError[Term](s"Unsupported discriminator type '$tpe' with format '$fmt' for property '$discriminatorName'")
 
     discriminatorTpe match {
       case LiteralRawType(Some(tpe @ "string"), fmt) =>

--- a/modules/scala-support/src/main/scala/dev/guardrail/generators/scala/jackson/JacksonProtocolGenerator.scala
+++ b/modules/scala-support/src/main/scala/dev/guardrail/generators/scala/jackson/JacksonProtocolGenerator.scala
@@ -1193,7 +1193,7 @@ class JacksonProtocolGenerator private extends ProtocolTerms[ScalaLanguage, Targ
         for {
           discrimTpe <- Target.fromOption(param.term.decltpe, RuntimeFailure(s"Property ${param.name.value} has no type"))
           discrimValue <- JacksonHelpers
-            .discriminatorExpression[ScalaLanguage](
+            .discriminatorExpression(
               param.name.value,
               discriminatorValue(discriminator, className),
               param.rawType

--- a/modules/scala-support/src/main/scala/dev/guardrail/scala/helpers/ResponseHelpers.scala
+++ b/modules/scala-support/src/main/scala/dev/guardrail/scala/helpers/ResponseHelpers.scala
@@ -2,17 +2,19 @@ package dev.guardrail.scalaext.helpers
 
 import cats.data.NonEmptyList
 import cats.syntax.all._
+import io.swagger.v3.oas.models.Operation
+import scala.meta.Type
+
 import dev.guardrail.core.{ LiteralRawType, Tracker }
 import dev.guardrail.generators.LanguageParameters
-import dev.guardrail.languages.LA
+import dev.guardrail.generators.scala.ScalaLanguage
 import dev.guardrail.terms.{ ApplicationJson, BinaryContent, ContentType, MultipartFormData, OctetStream, Response, TextContent, TextPlain, UrlencodedFormData }
-import io.swagger.v3.oas.models.Operation
 
 object ResponseHelpers {
   private val CONSUMES_PRIORITY = NonEmptyList.of(ApplicationJson.empty, TextPlain.empty, OctetStream.empty)
   private val PRODUCES_PRIORITY = NonEmptyList.of(ApplicationJson.empty, TextPlain.empty, OctetStream.empty)
 
-  def getBestConsumes[L <: LA](operation: Tracker[Operation], contentTypes: List[ContentType], parameters: LanguageParameters[L]): Option[ContentType] =
+  def getBestConsumes(operation: Tracker[Operation], contentTypes: List[ContentType], parameters: LanguageParameters[ScalaLanguage]): Option[ContentType] =
     if (parameters.formParams.nonEmpty) {
       if (parameters.formParams.exists(_.isFile) || contentTypes.exists(ContentType.isSubtypeOf[MultipartFormData])) {
         Some(MultipartFormData.empty)
@@ -37,11 +39,11 @@ object ResponseHelpers {
       }
     }
 
-  def getBestProduces[L <: LA](
+  def getBestProduces(
       operation: Tracker[Operation],
       contentTypes: List[ContentType],
-      response: Response[L],
-      fallbackIsString: L#Type => Boolean
+      response: Response[ScalaLanguage],
+      fallbackIsString: Type => Boolean
   ): Option[ContentType] =
     response.value
       .map(_._2)

--- a/modules/scala-support/src/test/scala/tests/generators/helpers/JacksonHelpersTest.scala
+++ b/modules/scala-support/src/test/scala/tests/generators/helpers/JacksonHelpersTest.scala
@@ -3,7 +3,6 @@ package tests.generators.helpers
 import dev.guardrail.core.LiteralRawType
 import dev.guardrail.generators.scala.ScalaGenerator
 import dev.guardrail.generators.scala.jackson.JacksonHelpers
-import dev.guardrail.generators.scala.ScalaLanguage
 import dev.guardrail.{ Target, TargetValue }
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.must.Matchers
@@ -20,7 +19,7 @@ class JacksonHelpersTest extends AnyFreeSpec with Matchers {
   }
 
   def discriminatorExpression(value: String, tpe: String, fmt: Option[String] = None): Target[Term] =
-    JacksonHelpers.discriminatorExpression[ScalaLanguage](
+    JacksonHelpers.discriminatorExpression(
       "discrim",
       value,
       LiteralRawType(Some(tpe), fmt)


### PR DESCRIPTION
- Any interpreters provided in `$lang-support` modules should be fully scoped to the languages they operate in.
- Remove unnecessary `CoreTerms. coreTerm` as that pattern is now unused