### PR TITLE
Minor cleanup

### DIFF
--- a/modules/cli/src/main/scala/dev/guardrail/cli/CLICommon.scala
+++ b/modules/cli/src/main/scala/dev/guardrail/cli/CLICommon.scala
@@ -239,7 +239,6 @@ trait CLICommon extends GuardrailRunner {
             fallback
           case UserError(message) =>
             putErrLn(s"${AnsiColor.RED}Error: $message${AnsiColor.RESET}")
-            unsafePrintHelp()
             fallback
           case MissingModule(section, choices) =>
             putErrLn(s"${AnsiColor.RED}Error: Missing module ${section} (options are: ${choices.mkString(",")})${AnsiColor.RESET}")


### PR DESCRIPTION
- Reflow to avoid reimplementing `raiseErrorIfEmpty`
- Remove `unsafePrintHelp()` from `UserError` in CLI driver