### PR TITLE
OpenAPI v3.1.0 spec files do not generate valid data classes

### DIFF
--- a/modules/core/src/main/scala/dev/guardrail/core/extract/VendorExtension.scala
+++ b/modules/core/src/main/scala/dev/guardrail/core/extract/VendorExtension.scala
@@ -64,8 +64,8 @@ object VendorExtension {
     implicit val defaultVendorExtensibleMapProperty: VendorExtensible[MapSchema] =
       build[MapSchema](m => key => Option(m.getExtensions).map(_.get(key)))
 
-    implicit val defaultVendorExtensibleObjectProperty: VendorExtensible[ObjectSchema] =
-      build[ObjectSchema](m => key => Option(m.getExtensions).map(_.get(key)))
+    implicit val defaultVendorExtensibleObjectProperty: VendorExtensible[Schema[Object]] =
+      build[Schema[Object]](m => key => Option(m.getExtensions).map(_.get(key)))
 
     implicit val defaultVendorExtensibleStringProperty: VendorExtensible[StringSchema] =
       build[StringSchema](m => key => Option(m.getExtensions).map(_.get(key)))

--- a/modules/java-support/src/main/scala/dev/guardrail/generators/java/jackson/JacksonGenerator.scala
+++ b/modules/java-support/src/main/scala/dev/guardrail/generators/java/jackson/JacksonGenerator.scala
@@ -84,6 +84,25 @@ object JacksonGenerator {
 @SuppressWarnings(Array("org.wartremover.warts.Null"))
 class JacksonGenerator private (implicit Cl: CollectionsLibTerms[JavaLanguage, Target], Ca: CollectionsAbstraction[JavaLanguage])
     extends ProtocolTerms[JavaLanguage, Target] {
+  // NB: In OpenAPI 3.1 ObjectSchema was broadly replaced with JsonSchema.
+  // This broke a lot of assumptions, but seems to indicate that we're moving
+  // into a world where OAI has encoding information pushed to all models,
+  // instead of hoping that the operation code generators or global
+  // object-mappers can manage it all.
+  //
+  // This seems like a good change, but I'm opting to defer major refactors
+  // until the particulars of this change have had a time to sink in.
+  //
+  // This extractor is copy/pasted to a few different classes in guardrail.
+  // Should you copy it further, please copy this note as well.
+  private object ObjectExtractor {
+    def unapply(m: Schema[_]): Option[Schema[Object]] = m match {
+      case m: ObjectSchema => Some(m)
+      case m: JsonSchema   => Some(m)
+      case _               => None
+    }
+  }
+
   import Ca._
 
   private val BUILDER_TYPE        = StaticJavaParser.parseClassOrInterfaceType("Builder")
@@ -108,7 +127,7 @@ class JacksonGenerator private (implicit Cl: CollectionsLibTerms[JavaLanguage, T
       Sw: OpenAPITerms[JavaLanguage, Target]
   ): Target[(List[ClassParent[JavaLanguage]], List[(String, Tracker[Schema[_]])])] = {
 
-    def firstInHierarchy(model: Tracker[Schema[_]]): Option[Tracker[ObjectSchema]] =
+    def firstInHierarchy(model: Tracker[Schema[_]]): Option[Tracker[Schema[Object]]] =
       model
         .refine { case x: ComposedSchema => x } { elem =>
           definitions.value
@@ -119,7 +138,7 @@ class JacksonGenerator private (implicit Cl: CollectionsLibTerms[JavaLanguage, T
             }
             .flatMap(
               _.refine { case x: ComposedSchema => x }(firstInHierarchy)
-                .orRefine { case o: ObjectSchema => o }(x => Option(x))
+                .orRefine { case ObjectExtractor(o) => o }(x => Option(x))
                 .getOrElse(None)
             )
         }
@@ -429,7 +448,7 @@ class JacksonGenerator private (implicit Cl: CollectionsLibTerms[JavaLanguage, T
       for {
         nestedClassName <- formatTypeName(name).map(formattedName => getClsName(name).append(formattedName))
         defn <- schema
-          .refine[Target[Option[Either[String, NestedProtocolElems[JavaLanguage]]]]] { case x: ObjectSchema => x }(o =>
+          .refine[Target[Option[Either[String, NestedProtocolElems[JavaLanguage]]]]] { case ObjectExtractor(x) => x }(o =>
             for {
               defn <- fromModel(
                 nestedClassName,
@@ -573,13 +592,13 @@ class JacksonGenerator private (implicit Cl: CollectionsLibTerms[JavaLanguage, T
   ): Target[ProtocolElems[JavaLanguage]] = {
     import Cl._
     import Fw._
-    val model: Option[Tracker[ObjectSchema]] = abstractModel
-      .refine[Option[Tracker[ObjectSchema]]] { case m: ObjectSchema => m }(x => Option(x))
+    val model: Option[Tracker[Schema[Object]]] = abstractModel
+      .refine[Option[Tracker[Schema[Object]]]] { case ObjectExtractor(m) => m }(x => Option(x))
       .orRefine { case m: ComposedSchema => m }(
         _.downField("allOf", _.getAllOf()).indexedCosequence
           .get(1)
           .flatMap(
-            _.refine { case o: ObjectSchema => o }(Option.apply)
+            _.refine { case ObjectExtractor(o) => o }(Option.apply)
               .orRefineFallback(_ => None)
           )
       )
@@ -680,7 +699,7 @@ class JacksonGenerator private (implicit Cl: CollectionsLibTerms[JavaLanguage, T
           tpe <- parseTypeName(clsName)
 
           discriminators <- (_extends :: concreteInterfaces).flatTraverse(
-            _.refine[Target[List[Discriminator[JavaLanguage]]]] { case m: ObjectSchema => m }(m =>
+            _.refine[Target[List[Discriminator[JavaLanguage]]]] { case ObjectExtractor(m) => m }(m =>
               Discriminator.fromSchema[JavaLanguage, Target](m).map(_.toList)
             )
               .getOrElse(List.empty[Discriminator[JavaLanguage]].pure[Target])
@@ -813,7 +832,7 @@ class JacksonGenerator private (implicit Cl: CollectionsLibTerms[JavaLanguage, T
               array            <- fromArray(formattedClsName, arr, concreteTypes, components)
             } yield array
           )
-          .orRefine { case o: ObjectSchema => o }(m =>
+          .orRefine { case ObjectExtractor(o) => o }(m =>
             for {
               formattedClsName <- formatTypeName(clsName)
               enum             <- fromEnum[Object](formattedClsName, m, dtoPackage, components)
@@ -1638,7 +1657,7 @@ class JacksonGenerator private (implicit Cl: CollectionsLibTerms[JavaLanguage, T
 
   private def extractProperties(spec: Tracker[Schema[_]]) =
     spec
-      .refine[Target[List[(String, Tracker[Schema[_]])]]] { case m: ObjectSchema => m }(m =>
+      .refine[Target[List[(String, Tracker[Schema[_]])]]] { case ObjectExtractor(m) => m }(m =>
         Target.pure(m.downField("properties", _.getProperties()).indexedCosequence.value)
       )
       .orRefine { case c: ComposedSchema => c } { comp =>

--- a/modules/scala-support/src/main/scala/dev/guardrail/generators/scala/jackson/JacksonProtocolGenerator.scala
+++ b/modules/scala-support/src/main/scala/dev/guardrail/generators/scala/jackson/JacksonProtocolGenerator.scala
@@ -53,6 +53,25 @@ object JacksonProtocolGenerator {
 }
 
 class JacksonProtocolGenerator private extends ProtocolTerms[ScalaLanguage, Target] {
+  // NB: In OpenAPI 3.1 ObjectSchema was broadly replaced with JsonSchema.
+  // This broke a lot of assumptions, but seems to indicate that we're moving
+  // into a world where OAI has encoding information pushed to all models,
+  // instead of hoping that the operation code generators or global
+  // object-mappers can manage it all.
+  //
+  // This seems like a good change, but I'm opting to defer major refactors
+  // until the particulars of this change have had a time to sink in.
+  //
+  // This extractor is copy/pasted to a few different classes in guardrail.
+  // Should you copy it further, please copy this note as well.
+  private object ObjectExtractor {
+    def unapply(m: Schema[_]): Option[Schema[Object]] = m match {
+      case m: ObjectSchema => Some(m)
+      case m: JsonSchema   => Some(m)
+      case _               => None
+    }
+  }
+
   private def discriminatorValue(discriminator: Discriminator[ScalaLanguage], className: String): String =
     discriminator.mapping
       .collectFirst { case (value, elem) if elem.name == className => value }
@@ -199,7 +218,7 @@ class JacksonProtocolGenerator private extends ProtocolTerms[ScalaLanguage, Targ
               array            <- fromArray(formattedClsName, arr, concreteTypes, components)
             } yield array
           )
-          .orRefine { case o: ObjectSchema => o }(m =>
+          .orRefine { case ObjectExtractor(o) => o }(m =>
             for {
               formattedClsName <- formatTypeName(clsName)
               enum             <- fromEnum[Object](formattedClsName, m, dtoPackage, components)
@@ -529,7 +548,7 @@ class JacksonProtocolGenerator private extends ProtocolTerms[ScalaLanguage, Targ
           tpe <- parseTypeName(clsName)
 
           discriminators <- (_extends :: concreteInterfaces).flatTraverse(
-            _.refine[Target[List[Discriminator[ScalaLanguage]]]] { case m: ObjectSchema => m }(m =>
+            _.refine[Target[List[Discriminator[ScalaLanguage]]]] { case ObjectExtractor(m) => m }(m =>
               Discriminator.fromSchema[ScalaLanguage, Target](m).map(_.toList)
             )
               .getOrElse(List.empty[Discriminator[ScalaLanguage]].pure[Target])
@@ -639,7 +658,7 @@ class JacksonProtocolGenerator private extends ProtocolTerms[ScalaLanguage, Targ
       for {
         nestedClassName <- formatTypeName(name).map(formattedName => getClsName(name).append(formattedName))
         defn <- schema
-          .refine[Target[Option[Either[String, NestedProtocolElems[ScalaLanguage]]]]] { case x: ObjectSchema => x }(o =>
+          .refine[Target[Option[Either[String, NestedProtocolElems[ScalaLanguage]]]]] { case ObjectExtractor(x) => x }(o =>
             for {
               defn <- fromModel(
                 nestedClassName,
@@ -785,13 +804,13 @@ class JacksonProtocolGenerator private extends ProtocolTerms[ScalaLanguage, Targ
   ): Target[ProtocolElems[ScalaLanguage]] = {
     import Cl._
     import Fw._
-    val model: Option[Tracker[ObjectSchema]] = abstractModel
-      .refine[Option[Tracker[ObjectSchema]]] { case m: ObjectSchema => m }(x => Option(x))
+    val model: Option[Tracker[Schema[Object]]] = abstractModel
+      .refine[Option[Tracker[Schema[Object]]]] { case ObjectExtractor(m) => m }(x => Option(x))
       .orRefine { case m: ComposedSchema => m }(
         _.downField("allOf", _.getAllOf()).indexedCosequence
           .get(1)
           .flatMap(
-            _.refine { case o: ObjectSchema => o }(Option.apply)
+            _.refine { case ObjectExtractor(o) => o }(Option.apply)
               .orRefineFallback(_ => None)
           )
       )
@@ -843,7 +862,7 @@ class JacksonProtocolGenerator private extends ProtocolTerms[ScalaLanguage, Targ
       Sw: OpenAPITerms[ScalaLanguage, Target]
   ): Target[(List[ClassParent[ScalaLanguage]], List[(String, Tracker[Schema[_]])])] = {
 
-    def firstInHierarchy(model: Tracker[Schema[_]]): Option[Tracker[ObjectSchema]] =
+    def firstInHierarchy(model: Tracker[Schema[_]]): Option[Tracker[Schema[Object]]] =
       model
         .refine { case x: ComposedSchema => x } { elem =>
           definitions.value
@@ -854,7 +873,7 @@ class JacksonProtocolGenerator private extends ProtocolTerms[ScalaLanguage, Targ
             }
             .flatMap(
               _.refine { case x: ComposedSchema => x }(firstInHierarchy)
-                .orRefine { case o: ObjectSchema => o }(x => Option(x))
+                .orRefine { case ObjectExtractor(o) => o }(x => Option(x))
                 .getOrElse(None)
             )
         }
@@ -1075,7 +1094,7 @@ class JacksonProtocolGenerator private extends ProtocolTerms[ScalaLanguage, Targ
 
   private def extractProperties(spec: Tracker[Schema[_]]) =
     spec
-      .refine[Target[List[(String, Tracker[Schema[_]])]]] { case o: ObjectSchema => o }(m =>
+      .refine[Target[List[(String, Tracker[Schema[_]])]]] { case ObjectExtractor(o) => o }(m =>
         Target.pure(m.downField("properties", _.getProperties()).indexedCosequence.value)
       )
       .orRefine { case c: ComposedSchema => c } { comp =>

--- a/src/test/scala/core/issues/Issue1854.scala
+++ b/src/test/scala/core/issues/Issue1854.scala
@@ -26,8 +26,7 @@ class ScalaTypesTest extends AnyFunSuite with Matchers with SwaggerSpecRunner wi
        |    type: object
        |    properties:
        |      foo:
-       |        type: string
-       |        x-scala-type: dev.guardrail.foo.bar.Baz
+       |        $$ref: '#/definitions/Baz'
        |""".stripMargin
 
   val spec30: String =
@@ -43,8 +42,7 @@ class ScalaTypesTest extends AnyFunSuite with Matchers with SwaggerSpecRunner wi
        |      type: object
        |      properties:
        |        foo:
-       |          type: string
-       |          x-scala-type: dev.guardrail.foo.bar.Baz
+       |          $$ref: '#/components/schemas/Baz'
        |""".stripMargin
 
   val spec31: String =
@@ -60,8 +58,7 @@ class ScalaTypesTest extends AnyFunSuite with Matchers with SwaggerSpecRunner wi
        |      type: object
        |      properties:
        |        foo:
-       |          type: string
-       |          x-scala-type: dev.guardrail.foo.bar.Baz
+       |          $$ref: '#/components/schemas/Baz'
        |""".stripMargin
 
   test("Generate no definitions") {
@@ -73,7 +70,7 @@ class ScalaTypesTest extends AnyFunSuite with Matchers with SwaggerSpecRunner wi
 
       val definition =
         q"""
-       case class Baz(foo: Option[dev.guardrail.foo.bar.Baz] = None)
+       case class Baz(foo: Option[Baz] = None)
      """
 
       val companion =
@@ -82,12 +79,12 @@ class ScalaTypesTest extends AnyFunSuite with Matchers with SwaggerSpecRunner wi
          implicit val encodeBaz: _root_.io.circe.Encoder.AsObject[Baz] = {
            _root_.io.circe.Encoder.AsObject.instance[Baz](a => _root_.io.circe.JsonObject.fromIterable(_root_.scala.Vector(("foo", a.foo.asJson))))
          }
-         implicit val decodeBaz: _root_.io.circe.Decoder[Baz] = new _root_.io.circe.Decoder[Baz] { final def apply(c: _root_.io.circe.HCursor): _root_.io.circe.Decoder.Result[Baz] = for (v0 <- c.downField("foo").as[Option[dev.guardrail.foo.bar.Baz]]) yield Baz(v0) }
+         implicit val decodeBaz: _root_.io.circe.Decoder[Baz] = new _root_.io.circe.Decoder[Baz] { final def apply(c: _root_.io.circe.HCursor): _root_.io.circe.Decoder.Result[Baz] = for (v0 <- c.downField("foo").as[Option[Baz]]) yield Baz(v0) }
        }
      """
 
-      cls.structure shouldEqual definition.structure
-      cmp.structure shouldEqual companion.structure
+      cls.syntax shouldEqual definition.syntax
+      cmp.syntax shouldEqual companion.syntax
     }
   }
 }

--- a/src/test/scala/core/issues/Issue1854.scala
+++ b/src/test/scala/core/issues/Issue1854.scala
@@ -1,0 +1,76 @@
+package core.issues
+
+import scala.meta._
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+import support.SwaggerSpecRunner
+import dev.guardrail.Context
+import dev.guardrail.generators.ProtocolDefinitions
+import dev.guardrail.generators.scala.ScalaGeneratorMappings.scalaInterpreter
+import dev.guardrail.generators.scala.syntax.companionForStaticDefns
+import dev.guardrail.terms.protocol.ClassDefinition
+import org.scalatest.Inside
+import org.scalatest.Inspectors.forAll
+
+class ScalaTypesTest extends AnyFunSuite with Matchers with SwaggerSpecRunner with Inside {
+
+  val spec20: String =
+    s"""
+       |swagger: "2.0"
+       |info:
+       |  title: Whatever
+       |  version: 1.0.0
+       |host: localhost:1234
+       |definitions:
+       |  Baz:
+       |    type: object
+       |    properties:
+       |      foo:
+       |        type: string
+       |        x-scala-type: dev.guardrail.foo.bar.Baz
+       |""".stripMargin
+
+  val spec31: String =
+    s"""
+       |openapi: "3.1.0"
+       |info:
+       |  title: Whatever
+       |  version: 1.0.0
+       |host: localhost:1234
+       |components:
+       |  schemas:
+       |    Baz:
+       |      type: object
+       |      properties:
+       |        foo:
+       |          type: string
+       |          x-scala-type: dev.guardrail.foo.bar.Baz
+       |""".stripMargin
+
+  test("Generate no definitions") {
+    forAll(Seq(spec20, spec31)) { spec =>
+      val result = runSwaggerSpec(scalaInterpreter)(spec)(Context.empty, "akka-http")
+      val (ProtocolDefinitions(ClassDefinition(_, _, _, cls, staticDefns, _) :: Nil, _, _, _, _), _, _) = result
+
+      val cmp = companionForStaticDefns(staticDefns)
+
+      val definition =
+        q"""
+       case class Baz(foo: Option[dev.guardrail.foo.bar.Baz] = None)
+     """
+
+      val companion =
+        q"""
+       object Baz {
+         implicit val encodeBaz: _root_.io.circe.Encoder.AsObject[Baz] = {
+           _root_.io.circe.Encoder.AsObject.instance[Baz](a => _root_.io.circe.JsonObject.fromIterable(_root_.scala.Vector(("foo", a.foo.asJson))))
+         }
+         implicit val decodeBaz: _root_.io.circe.Decoder[Baz] = new _root_.io.circe.Decoder[Baz] { final def apply(c: _root_.io.circe.HCursor): _root_.io.circe.Decoder.Result[Baz] = for (v0 <- c.downField("foo").as[Option[dev.guardrail.foo.bar.Baz]]) yield Baz(v0) }
+       }
+     """
+
+      cls.structure shouldEqual definition.structure
+      cmp.structure shouldEqual companion.structure
+    }
+  }
+}

--- a/src/test/scala/core/issues/Issue1854.scala
+++ b/src/test/scala/core/issues/Issue1854.scala
@@ -30,6 +30,23 @@ class ScalaTypesTest extends AnyFunSuite with Matchers with SwaggerSpecRunner wi
        |        x-scala-type: dev.guardrail.foo.bar.Baz
        |""".stripMargin
 
+  val spec30: String =
+    s"""
+       |openapi: "3.0.0"
+       |info:
+       |  title: Whatever
+       |  version: 1.0.0
+       |host: localhost:1234
+       |components:
+       |  schemas:
+       |    Baz:
+       |      type: object
+       |      properties:
+       |        foo:
+       |          type: string
+       |          x-scala-type: dev.guardrail.foo.bar.Baz
+       |""".stripMargin
+
   val spec31: String =
     s"""
        |openapi: "3.1.0"
@@ -48,7 +65,7 @@ class ScalaTypesTest extends AnyFunSuite with Matchers with SwaggerSpecRunner wi
        |""".stripMargin
 
   test("Generate no definitions") {
-    forAll(Seq(spec20, spec31)) { spec =>
+    forAll(Seq(spec20, spec30, spec31)) { spec =>
       val result = runSwaggerSpec(scalaInterpreter)(spec)(Context.empty, "akka-http")
       val (ProtocolDefinitions(ClassDefinition(_, _, _, cls, staticDefns, _) :: Nil, _, _, _, _), _, _) = result
 


### PR DESCRIPTION
~~If spec would contain paths that use said schemas, then models would be generated.~~ https://github.com/guardrail-dev/guardrail/pull/1854#issuecomment-1780667775