### PR TITLE
Breaking `Resolved[L]` out from lazy protocol objects

### DIFF
--- a/modules/core/src/main/scala/dev/guardrail/terms/OpenAPITerms.scala
+++ b/modules/core/src/main/scala/dev/guardrail/terms/OpenAPITerms.scala
@@ -44,7 +44,7 @@ abstract class OpenAPITerms[L <: LA, F[_]] {
   def getParameterName(parameter: Tracker[Parameter]): F[String]
   def getParameterSchema(parameter: Tracker[Parameter], components: Tracker[Option[Components]]): F[Tracker[SchemaProjection]]
   def getRefParameterRef(parameter: Tracker[Parameter]): F[Tracker[String]]
-  def fallbackParameterHandler(parameter: Tracker[Parameter]): F[(core.ResolvedType[L], Boolean)]
+  def fallbackParameterHandler(parameter: Tracker[Parameter]): F[(Either[core.LazyResolvedType[L], core.Resolved[L]], Boolean)]
   def getOperationId(operation: Tracker[Operation]): F[String]
   def getResponses(operationId: String, operation: Tracker[Operation]): F[NonEmptyList[(String, Tracker[ApiResponse])]]
   def getSimpleRef(ref: Tracker[Option[Schema[_]]]): F[String]

--- a/modules/java-support/src/main/scala/dev/guardrail/generators/java/jackson/JacksonGenerator.scala
+++ b/modules/java-support/src/main/scala/dev/guardrail/generators/java/jackson/JacksonGenerator.scala
@@ -1722,7 +1722,7 @@ class JacksonGenerator private (implicit Cl: CollectionsLibTerms[JavaLanguage, T
             for {
               innerType <- concreteType.fold(safeParseType(tpeName))(Target.pure)
               tpe       <- Cl.liftMapType(innerType, containerTpe)
-            } yield (tpe, Option.empty, ReifiedRawType.ofVector(fallbackRawType))
+            } yield (tpe, Option.empty, ReifiedRawType.ofMap(fallbackRawType))
         }
 
         expressionDefaultValue <- (defaultValue match {

--- a/modules/java-support/src/main/scala/dev/guardrail/generators/java/jackson/JacksonGenerator.scala
+++ b/modules/java-support/src/main/scala/dev/guardrail/generators/java/jackson/JacksonGenerator.scala
@@ -1681,7 +1681,7 @@ class JacksonGenerator private (implicit Cl: CollectionsLibTerms[JavaLanguage, T
       name: String,
       fieldName: String,
       property: Tracker[Schema[_]],
-      meta: core.ResolvedType[JavaLanguage],
+      meta: Either[core.LazyResolvedType[JavaLanguage], core.Resolved[JavaLanguage]],
       requirement: PropertyRequirement,
       isCustomType: Boolean,
       defaultValue: Option[com.github.javaparser.ast.Node]
@@ -1702,28 +1702,35 @@ class JacksonGenerator private (implicit Cl: CollectionsLibTerms[JavaLanguage, T
 
         dataRedaction = DataRedaction(property).getOrElse(DataVisible)
 
-        (tpe, classDep, rawType) <- meta match {
-          case core.Resolved(declType, classDep, _, rawType) =>
-            Target.pure((declType, classDep, rawType))
-          case core.Deferred(tpeName) =>
-            val tpe = concreteTypes.find(_.clsName == tpeName).map(x => Target.pure(x.tpe)).getOrElse {
-              println(s"Unable to find definition for ${tpeName}, just inlining")
-              safeParseType(tpeName)
+        (tpe, classDep, rawType) <- meta
+          .bimap(
+            {
+              case core.Deferred(tpeName) =>
+                concreteTypes
+                  .find(_.clsName == tpeName)
+                  .fold(
+                    for {
+                      _   <- Target.log.info(s"Unable to find definition for ${tpeName}, just inlining")
+                      res <- safeParseType(tpeName)
+                    } yield res
+                  )(x => Target.pure(x.tpe))
+                  .map((_, Option.empty, fallbackRawType))
+              case core.DeferredArray(tpeName, containerTpe) =>
+                for {
+                  innerType <- lookupTypeName(tpeName, concreteTypes).fold(safeParseType(tpeName))(Target.pure)
+                  tpe       <- Cl.liftVectorType(innerType, containerTpe)
+                } yield (tpe, Option.empty, ReifiedRawType.ofVector(fallbackRawType))
+              case core.DeferredMap(tpeName, containerTpe) =>
+                for {
+                  innerType <- lookupTypeName(tpeName, concreteTypes).fold(safeParseType(tpeName))(Target.pure)
+                  tpe       <- Cl.liftMapType(innerType, containerTpe)
+                } yield (tpe, Option.empty, ReifiedRawType.ofMap(fallbackRawType))
+            },
+            { case core.Resolved(declType, classDep, _, rawType) =>
+              Target.pure((declType, classDep, rawType))
             }
-            tpe.map((_, Option.empty, fallbackRawType))
-          case core.DeferredArray(tpeName, containerTpe) =>
-            val concreteType = lookupTypeName(tpeName, concreteTypes)
-            for {
-              innerType <- concreteType.fold(safeParseType(tpeName))(Target.pure)
-              tpe       <- Cl.liftVectorType(innerType, containerTpe)
-            } yield (tpe, Option.empty, ReifiedRawType.ofVector(fallbackRawType))
-          case core.DeferredMap(tpeName, containerTpe) =>
-            val concreteType = lookupTypeName(tpeName, concreteTypes)
-            for {
-              innerType <- concreteType.fold(safeParseType(tpeName))(Target.pure)
-              tpe       <- Cl.liftMapType(innerType, containerTpe)
-            } yield (tpe, Option.empty, ReifiedRawType.ofMap(fallbackRawType))
-        }
+          )
+          .merge
 
         expressionDefaultValue <- (defaultValue match {
           case Some(e: Expression) => Target.pure(Some(e))
@@ -1788,18 +1795,18 @@ class JacksonGenerator private (implicit Cl: CollectionsLibTerms[JavaLanguage, T
     Target.pure(StaticDefns[JavaLanguage](clsName, List.empty, List.empty))
 
   private def extractArrayType(
-      arr: core.ResolvedType[JavaLanguage],
+      arr: Either[core.LazyResolvedType[JavaLanguage], core.Resolved[JavaLanguage]],
       concreteTypes: List[PropMeta[JavaLanguage]]
   ): Target[Type] =
     for {
       result <- arr match {
-        case core.Resolved(tpe, dep, default, _) => Target.pure(tpe)
-        case core.Deferred(tpeName) =>
+        case Right(core.Resolved(tpe, dep, default, _)) => Target.pure(tpe)
+        case Left(core.Deferred(tpeName)) =>
           Target.fromOption(lookupTypeName(tpeName, concreteTypes), UserError(s"Unresolved reference ${tpeName}"))
-        case core.DeferredArray(tpeName, containerTpe) =>
+        case Left(core.DeferredArray(tpeName, containerTpe)) =>
           lookupTypeName(tpeName, concreteTypes)
             .fold[Target[Type]](Target.raiseUserError(s"Unresolved reference ${tpeName}"))(Cl.liftVectorType(_, containerTpe))
-        case core.DeferredMap(tpeName, containerTpe) =>
+        case Left(core.DeferredMap(tpeName, containerTpe)) =>
           lookupTypeName(tpeName, concreteTypes).fold[Target[Type]](
             Target.raiseUserError(s"Unresolved reference ${tpeName}")
           )(tpe => Cl.liftMapType(tpe, None).flatMap(mapTpe => Cl.liftVectorType(mapTpe, containerTpe)))

--- a/modules/scala-support/src/main/scala/dev/guardrail/generators/scala/circe/CirceProtocolGenerator.scala
+++ b/modules/scala-support/src/main/scala/dev/guardrail/generators/scala/circe/CirceProtocolGenerator.scala
@@ -1336,9 +1336,6 @@ class CirceProtocolGenerator private (circeVersion: CirceModelGenerator, applyVa
       }
     } yield result
 
-  private def extractConcreteTypes(definitions: Either[String, List[PropMeta[ScalaLanguage]]]) =
-    definitions.fold[Target[List[PropMeta[ScalaLanguage]]]](Target.raiseUserError _, Target.pure _)
-
   private def protocolImports() =
     Target.pure(
       List(

--- a/modules/scala-support/src/main/scala/dev/guardrail/generators/scala/circe/CirceProtocolGenerator.scala
+++ b/modules/scala-support/src/main/scala/dev/guardrail/generators/scala/circe/CirceProtocolGenerator.scala
@@ -990,7 +990,7 @@ class CirceProtocolGenerator private (circeVersion: CirceModelGenerator, applyVa
       name: String,
       fieldName: String,
       property: Tracker[Schema[_]],
-      meta: core.ResolvedType[ScalaLanguage],
+      meta: Either[core.LazyResolvedType[ScalaLanguage], core.Resolved[ScalaLanguage]],
       requirement: PropertyRequirement,
       isCustomType: Boolean,
       defaultValue: Option[scala.meta.Term]
@@ -1012,14 +1012,15 @@ class CirceProtocolGenerator private (circeVersion: CirceModelGenerator, applyVa
         dataRedaction = DataRedaction(property).getOrElse(DataVisible)
 
         (tpe, classDep, rawType) <- meta match {
-          case core.Resolved(declType, classDep, _, rawType @ LiteralRawType(Some(rawTypeStr), rawFormat)) if isFile(rawTypeStr, rawFormat) && !isCustomType =>
+          case Right(core.Resolved(declType, classDep, _, rawType @ LiteralRawType(Some(rawTypeStr), rawFormat)))
+              if isFile(rawTypeStr, rawFormat) && !isCustomType =>
             // assume that binary data are represented as a string. allow users to override.
             Target.pure((t"String", classDep, rawType))
-          case core.Resolved(declType, classDep, _, rawType) =>
+          case Right(core.Resolved(declType, classDep, _, rawType)) =>
             for {
               validatedType <- applyValidations(clsName, declType, property)
             } yield (validatedType, classDep, rawType)
-          case core.Deferred(tpeName) =>
+          case Left(core.Deferred(tpeName)) =>
             val tpe = concreteTypes.find(_.clsName == tpeName).map(_.tpe).getOrElse {
               println(s"Unable to find definition for ${tpeName}, just inlining")
               Type.Name(tpeName)
@@ -1027,14 +1028,14 @@ class CirceProtocolGenerator private (circeVersion: CirceModelGenerator, applyVa
             for {
               validatedType <- applyValidations(clsName, tpe, property)
             } yield (validatedType, Option.empty, fallbackRawType)
-          case core.DeferredArray(tpeName, containerTpe) =>
+          case Left(core.DeferredArray(tpeName, containerTpe)) =>
             val concreteType = lookupTypeName(tpeName, concreteTypes)(identity)
             val innerType    = concreteType.getOrElse(Type.Name(tpeName))
             val tpe          = t"${containerTpe.getOrElse(t"_root_.scala.Vector")}[$innerType]"
             for {
               validatedType <- applyValidations(clsName, tpe, property)
             } yield (validatedType, Option.empty, ReifiedRawType.ofVector(fallbackRawType))
-          case core.DeferredMap(tpeName, customTpe) =>
+          case Left(core.DeferredMap(tpeName, customTpe)) =>
             val concreteType = lookupTypeName(tpeName, concreteTypes)(identity)
             val innerType    = concreteType.getOrElse(Type.Name(tpeName))
             val tpe          = t"${customTpe.getOrElse(t"_root_.scala.Predef.Map")}[_root_.scala.Predef.String, $innerType]"
@@ -1315,18 +1316,18 @@ class CirceProtocolGenerator private (circeVersion: CirceModelGenerator, applyVa
     )
   }
 
-  private def extractArrayType(arr: core.ResolvedType[ScalaLanguage], concreteTypes: List[PropMeta[ScalaLanguage]]) =
+  private def extractArrayType(arr: Either[core.LazyResolvedType[ScalaLanguage], core.Resolved[ScalaLanguage]], concreteTypes: List[PropMeta[ScalaLanguage]]) =
     for {
       result <- arr match {
-        case core.Resolved(tpe, dep, default, _) => Target.pure(tpe)
-        case core.Deferred(tpeName) =>
+        case Right(core.Resolved(tpe, dep, default, _)) => Target.pure(tpe)
+        case Left(core.Deferred(tpeName)) =>
           Target.fromOption(lookupTypeName(tpeName, concreteTypes)(identity), UserError(s"Unresolved reference ${tpeName}"))
-        case core.DeferredArray(tpeName, containerTpe) =>
+        case Left(core.DeferredArray(tpeName, containerTpe)) =>
           Target.fromOption(
             lookupTypeName(tpeName, concreteTypes)(tpe => t"${containerTpe.getOrElse(t"_root_.scala.Vector")}[${tpe}]"),
             UserError(s"Unresolved reference ${tpeName}")
           )
-        case core.DeferredMap(tpeName, customTpe) =>
+        case Left(core.DeferredMap(tpeName, customTpe)) =>
           Target.fromOption(
             lookupTypeName(tpeName, concreteTypes)(tpe =>
               t"_root_.scala.Vector[${customTpe.getOrElse(t"_root_.scala.Predef.Map")}[_root_.scala.Predef.String, ${tpe}]]"

--- a/modules/scala-support/src/main/scala/dev/guardrail/generators/scala/circe/CirceProtocolGenerator.scala
+++ b/modules/scala-support/src/main/scala/dev/guardrail/generators/scala/circe/CirceProtocolGenerator.scala
@@ -114,7 +114,7 @@ class CirceProtocolGenerator private (circeVersion: CirceModelGenerator, applyVa
           .orRefine { case ObjectExtractor(o) => o }(m =>
             for {
               formattedClsName <- formatTypeName(clsName)
-              enum             <- fromEnum[Object](formattedClsName, m, dtoPackage, components)
+              enum_            <- fromEnum[Object](formattedClsName, m, dtoPackage, components)
               model <- fromModel(
                 NonEmptyList.of(formattedClsName),
                 m,
@@ -127,12 +127,12 @@ class CirceProtocolGenerator private (circeVersion: CirceModelGenerator, applyVa
                 components
               )
               alias <- modelTypeAlias(formattedClsName, m, components)
-            } yield enum.orElse(model).getOrElse(alias)
+            } yield enum_.orElse(model).getOrElse(alias)
           )
           .orRefine { case x: StringSchema => x }(x =>
             for {
               formattedClsName <- formatTypeName(clsName)
-              enum             <- fromEnum(formattedClsName, x, dtoPackage, components)
+              enum_            <- fromEnum(formattedClsName, x, dtoPackage, components)
               model <- fromModel(
                 NonEmptyList.of(formattedClsName),
                 x,
@@ -147,12 +147,12 @@ class CirceProtocolGenerator private (circeVersion: CirceModelGenerator, applyVa
 
               (declType, _) <- ModelResolver.determineTypeName[ScalaLanguage, Target](x, Tracker.cloneHistory(x, CustomTypeName(x, prefixes)), components)
               alias         <- typeAlias(formattedClsName, declType)
-            } yield enum.orElse(model).getOrElse(alias)
+            } yield enum_.orElse(model).getOrElse(alias)
           )
           .orRefine { case x: IntegerSchema => x }(x =>
             for {
               formattedClsName <- formatTypeName(clsName)
-              enum             <- fromEnum(formattedClsName, x, dtoPackage, components)
+              enum_            <- fromEnum(formattedClsName, x, dtoPackage, components)
               model <- fromModel(
                 NonEmptyList.of(formattedClsName),
                 x,
@@ -166,7 +166,7 @@ class CirceProtocolGenerator private (circeVersion: CirceModelGenerator, applyVa
               )
               (declType, _) <- ModelResolver.determineTypeName[ScalaLanguage, Target](x, Tracker.cloneHistory(x, CustomTypeName(x, prefixes)), components)
               alias         <- typeAlias(formattedClsName, declType)
-            } yield enum.orElse(model).getOrElse(alias)
+            } yield enum_.orElse(model).getOrElse(alias)
           )
           .valueOr(x =>
             for {
@@ -279,11 +279,11 @@ class CirceProtocolGenerator private (circeVersion: CirceModelGenerator, applyVa
       } yield EnumDefinition[ScalaLanguage](clsName, classType, fullType, wrappedValues, defn, staticDefns)
 
     for {
-      enum     <- extractEnum(schema.map(wrapEnumSchema))
+      enum_    <- extractEnum(schema.map(wrapEnumSchema))
       prefixes <- vendorPrefixes()
       (tpe, _) <- ModelResolver.determineTypeName[ScalaLanguage, Target](schema, Tracker.cloneHistory(schema, CustomTypeName(schema, prefixes)), components)
       fullType <- selectType(NonEmptyList.ofInitLast(dtoPackage, clsName))
-      res      <- enum.traverse(validProg(_, tpe, fullType))
+      res      <- enum_.traverse(validProg(_, tpe, fullType))
     } yield res
   }
 

--- a/modules/scala-support/src/main/scala/dev/guardrail/generators/scala/circe/CirceProtocolGenerator.scala
+++ b/modules/scala-support/src/main/scala/dev/guardrail/generators/scala/circe/CirceProtocolGenerator.scala
@@ -116,15 +116,15 @@ class CirceProtocolGenerator private (circeVersion: CirceModelGenerator, applyVa
               formattedClsName <- formatTypeName(clsName)
               enum_            <- fromEnum[Object](formattedClsName, m, dtoPackage, components)
               model <- fromModel(
-                NonEmptyList.of(formattedClsName),
-                m,
-                List.empty,
-                concreteTypes,
-                definitions.value,
-                dtoPackage,
-                supportPackage.toList,
-                defaultPropertyRequirement,
-                components
+                clsName = NonEmptyList.of(formattedClsName),
+                model = m,
+                parents = List.empty,
+                concreteTypes = concreteTypes,
+                definitions = definitions.value,
+                dtoPackage = dtoPackage,
+                supportPackage = supportPackage.toList,
+                defaultPropertyRequirement = defaultPropertyRequirement,
+                components = components
               )
               alias <- modelTypeAlias(formattedClsName, m, components)
             } yield enum_.orElse(model).getOrElse(alias)

--- a/modules/scala-support/src/main/scala/dev/guardrail/generators/scala/jackson/JacksonProtocolGenerator.scala
+++ b/modules/scala-support/src/main/scala/dev/guardrail/generators/scala/jackson/JacksonProtocolGenerator.scala
@@ -1116,7 +1116,7 @@ class JacksonProtocolGenerator private extends ProtocolTerms[ScalaLanguage, Targ
       name: String,
       fieldName: String,
       property: Tracker[Schema[_]],
-      meta: core.ResolvedType[ScalaLanguage],
+      meta: Either[core.LazyResolvedType[ScalaLanguage], core.Resolved[ScalaLanguage]],
       requirement: PropertyRequirement,
       isCustomType: Boolean,
       defaultValue: Option[scala.meta.Term]
@@ -1138,23 +1138,24 @@ class JacksonProtocolGenerator private extends ProtocolTerms[ScalaLanguage, Targ
         dataRedaction = DataRedaction(property).getOrElse(DataVisible)
 
         (tpe, classDep, rawType) <- meta match { // TODO: Target is not used
-          case core.Resolved(declType, classDep, _, rawType @ LiteralRawType(Some(rawTypeStr), rawFormat)) if isFile(rawTypeStr, rawFormat) && !isCustomType =>
+          case Right(core.Resolved(declType, classDep, _, rawType @ LiteralRawType(Some(rawTypeStr), rawFormat)))
+              if isFile(rawTypeStr, rawFormat) && !isCustomType =>
             // assume that binary data are represented as a string. allow users to override.
             Target.pure((t"String", classDep, rawType))
-          case core.Resolved(declType, classDep, _, rawType) =>
+          case Right(core.Resolved(declType, classDep, _, rawType)) =>
             Target.pure((declType, classDep, rawType))
-          case core.Deferred(tpeName) =>
+          case Left(core.Deferred(tpeName)) =>
             val tpe = concreteTypes.find(_.clsName == tpeName).map(_.tpe).getOrElse {
               println(s"Unable to find definition for ${tpeName}, just inlining")
               Type.Name(tpeName)
             }
             Target.pure((tpe, Option.empty, fallbackRawType))
-          case core.DeferredArray(tpeName, containerTpe) =>
+          case Left(core.DeferredArray(tpeName, containerTpe)) =>
             val concreteType = lookupTypeName(tpeName, concreteTypes)(identity)
             val innerType    = concreteType.getOrElse(Type.Name(tpeName))
             val tpe          = t"${containerTpe.getOrElse(t"_root_.scala.Vector")}[$innerType]"
             Target.pure((tpe, Option.empty, ReifiedRawType.ofVector(fallbackRawType)))
-          case core.DeferredMap(tpeName, customTpe) =>
+          case Left(core.DeferredMap(tpeName, customTpe)) =>
             val concreteType = lookupTypeName(tpeName, concreteTypes)(identity)
             val innerType    = concreteType.getOrElse(Type.Name(tpeName))
             val tpe          = t"${customTpe.getOrElse(t"_root_.scala.Predef.Map")}[_root_.scala.Predef.String, $innerType]"
@@ -1346,18 +1347,18 @@ class JacksonProtocolGenerator private extends ProtocolTerms[ScalaLanguage, Targ
     )
   }
 
-  private def extractArrayType(arr: core.ResolvedType[ScalaLanguage], concreteTypes: List[PropMeta[ScalaLanguage]]) =
+  private def extractArrayType(arr: Either[core.LazyResolvedType[ScalaLanguage], core.Resolved[ScalaLanguage]], concreteTypes: List[PropMeta[ScalaLanguage]]) =
     for {
       result <- arr match {
-        case core.Resolved(tpe, dep, default, _) => Target.pure(tpe)
-        case core.Deferred(tpeName) =>
+        case Right(core.Resolved(tpe, dep, default, _)) => Target.pure(tpe)
+        case Left(core.Deferred(tpeName)) =>
           Target.fromOption(lookupTypeName(tpeName, concreteTypes)(identity), UserError(s"Unresolved reference ${tpeName}"))
-        case core.DeferredArray(tpeName, containerTpe) =>
+        case Left(core.DeferredArray(tpeName, containerTpe)) =>
           Target.fromOption(
             lookupTypeName(tpeName, concreteTypes)(tpe => t"${containerTpe.getOrElse(t"_root_.scala.Vector")}[${tpe}]"),
             UserError(s"Unresolved reference ${tpeName}")
           )
-        case core.DeferredMap(tpeName, customTpe) =>
+        case Left(core.DeferredMap(tpeName, customTpe)) =>
           Target.fromOption(
             lookupTypeName(tpeName, concreteTypes)(tpe =>
               t"_root_.scala.Vector[${customTpe.getOrElse(t"_root_.scala.Predef.Map")}[_root_.scala.Predef.String, ${tpe}]]"

--- a/project/WelcomeMessage.scala
+++ b/project/WelcomeMessage.scala
@@ -35,6 +35,7 @@ object WelcomeMessage {
         |${section("Generate sample sources")}
         |${subItem("runScalaExample")} - Only generate Scala sources for integration tests
         |${subItem("runJavaExample")} - Only generate Java sources for integration tests
+        |${subItem("runIssue")} - Only run codegen for a single issue (usage: runIssue [scala|java|*] $$framework <file>)
         |${item("publishLocal")} - Publish to local ivy repo
         |${item("publishM2")} - Publish to local m2 repo
         |${item("mdoc")} - Generate the docs microsite locally

--- a/src/test/scala/tests/core/EscapeTreeSpec.scala
+++ b/src/test/scala/tests/core/EscapeTreeSpec.scala
@@ -13,7 +13,7 @@ class EscapeTreeSpec extends AnyFunSuite with Matchers {
   }
 
   List[(Tree, String)](
-    (Init(Type.Name("dashy-enum"), Name("what"), List()), "`dashy-enum`"),
+    (Init.After_4_6_0(Type.Name("dashy-enum"), Name("what"), List()), "`dashy-enum`"),
     (Term.Name("dashy-class"), "`dashy-class`"),
     (
       Term.Param(Nil, Term.Name("dashy-param"), Some(Type.Apply(Type.Name("Option"), Type.ArgClause(List(Type.Name("Long"))))), Some(Term.Name("None"))),


### PR DESCRIPTION
Part of the problem with the type hierarchy here is that even though it's convenient, `Resolved` should never be conflated with `LazyResolved`. That conflation led to #1873 sticking around for so long.