### PR TITLE
Better snapshot version numbers

### DIFF
--- a/project/src/main/scala/Build.scala
+++ b/project/src/main/scala/Build.scala
@@ -14,7 +14,7 @@ import sbtversionpolicy.SbtVersionPolicyPlugin.autoImport._
 object Build {
   val stableVersion: SettingKey[String] = SettingKey("stable-version")
 
-  def useStableVersions(moduleName: String): Boolean = {
+  def useStableVersions(moduleSegment: String): Boolean = {
     // NB: Currently, any time any PR that breaks semver is merged, it breaks
     //     the build until the next release.
     //
@@ -28,7 +28,7 @@ object Build {
     if (isCi || isRelease) {
       val ignoreBincompat = {
         import scala.sys.process._
-        Seq("support/current-pr-labels.sh", moduleName)
+        Seq("support/current-pr-labels.sh", moduleSegment)
           .lineStream_!
           .exists(Set("major", "minor").contains)
       }
@@ -243,8 +243,8 @@ object Build {
           (current ++ fromOther).distinct
         })
 
-    def customDependsOn(moduleName: String, other: Project, useProvided: Boolean = false): Project = {
-      if (useStableVersions(moduleName)) {
+    def customDependsOn(moduleSegment: String, other: Project, useProvided: Boolean = false): Project = {
+      if (useStableVersions(moduleSegment)) {
         project
           .settings(libraryDependencySchemes += "dev.guardrail" % other.id % "early-semver")
           .settings(libraryDependencies += {
@@ -267,7 +267,7 @@ object Build {
       }
     }
 
-    def providedDependsOn(moduleName: String, other: Project): Project =
-      customDependsOn(moduleName, other, true)
+    def providedDependsOn(moduleSegment: String, other: Project): Project =
+      customDependsOn(moduleSegment, other, true)
   }
 }

--- a/support/current-pr-labels.sh
+++ b/support/current-pr-labels.sh
@@ -28,7 +28,7 @@ labels_since_last_release() {
     echo '{"labels":[]}'
   else
     module_released_on="$(git show "${latest_tag}" --format=%cI)"
-    gh_api "search/issues?q=repo:guardrail-dev/guardrail+type:pr+is:merged+closed:>${module_released_on}" \
+    gh_api "search/issues?q=repo:guardrail-dev/guardrail+type:pr+is:merged+closed:>${module_released_on}+label:${module_name}" \
       | jq -cM '{labels: (.items | map(.labels) | flatten | map(.name) | unique | map({ name: . })) }'
   fi
 }

--- a/support/current-pr-labels.sh
+++ b/support/current-pr-labels.sh
@@ -6,7 +6,7 @@ module_name="$1"
 
 gh_api() {
   path="$1"; shift
-  curl \
+  curl -s \
     -H "Accept: application/vnd.github.v3+json" \
     -H "Authorization: Bearer ${GITHUB_TOKEN}" \
     "$@" \
@@ -39,35 +39,37 @@ merge_labels() {
 }
 
 cachedir=target/github
+mkdir -p "$cachedir"
+
 if [ -n "$GITHUB_EVENT_PATH" ]; then
-  mkdir -p "$cachedir"
   pr_number="$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")"
-  cache="$cachedir/guardrail-ci-${pr_number}-labels-cache.json"
-
-  if [ -f "$cache" ]; then
-    echo "Using PR labels from $cache" >&2
-  else
-    # If $pr_number is null, we're either building a branch or master,
-    # so either way just skip labels.
-    sofar='{"labels": []}'
-
-    # Accumulate all labels up until now
-    if [ -n "$module_name" ]; then
-      sofar="$(labels_since_last_release "$module_name" | merge_labels "$sofar")"
-    fi
-    # Include this PR's labels too
-    if [ "$pr_number" != "null" ]; then
-      sofar="$(fetch_pr "$pr_number" | merge_labels "$sofar")"
-    fi
-    echo "$sofar" > "$cache"
-  fi
-
-  msg="$(jq -r .message < "$cache")"
-  if [ -n "$msg" ] && [ "$msg" != "null" ]; then  # If the API returned an error message
-    echo "ERROR: ${msg}" >&2
-    exit 1
-  fi
-  cat "$cache" | jq -r '.labels | map(.name)[]'
+  cache="$cachedir/guardrail-ci-${pr_number}-${module_name}-labels-cache.json"
 else
-  echo 'Skipping finding labels because GITHUB_EVENT_PATH is not defined' >&2
+  rev="$(git rev-parse --short @)"
+  cache="$cachedir/guardrail-ci-${rev}-${module_name}-labels-cache.json"
 fi
+
+if [ -f "$cache" ]; then
+  echo "Using PR labels from $cache" >&2
+else
+  # If $pr_number is null, we're either building a branch or master,
+  # so either way just skip labels.
+  sofar='{"labels": []}'
+
+  # Accumulate all labels up until now
+  if [ -n "$module_name" ]; then
+    sofar="$(labels_since_last_release "$module_name" | merge_labels "$sofar")"
+  fi
+  # Include this PR's labels too
+  if [ -n "$pr_number" ] && [ "$pr_number" != "null" ]; then
+    sofar="$(fetch_pr "$pr_number" | merge_labels "$sofar")"
+  fi
+  echo "$sofar" > "$cache"
+fi
+
+msg="$(jq -r .message < "$cache")"
+if [ -n "$msg" ] && [ "$msg" != "null" ]; then  # If the API returned an error message
+  echo "ERROR: ${msg}" >&2
+  exit 1
+fi
+cat "$cache" | jq -r '.labels | map(.name)[]'


### PR DESCRIPTION
- Incorporate some of the version bumping semantics from release-drafter into `support/current-pr-labels.sh`
- Always search for PR labels, even if we are not running inside GitHub (or not inside a PR)
- Disambiguate `moduleName` (`guardrail-core`) vs `moduleSegment` (`core`)