### PR TITLE
Filter out server URLs that accept template variables

### DIFF
--- a/modules/core/src/main/scala/dev/guardrail/Common.scala
+++ b/modules/core/src/main/scala/dev/guardrail/Common.scala
@@ -49,6 +49,7 @@ object Common {
             server
               .downField("url", _.getUrl)
               .unwrapTracker
+              .filterNot(_.contains("{"))
               .map { x =>
                 val uri = new URI(x.iterateWhileM[Id](_.stripSuffix("/"))(_.endsWith("/")))
                 @SuppressWarnings(Array("org.wartremover.warts.Null"))
@@ -64,6 +65,7 @@ object Common {
       basePath = swagger
         .downField("servers", _.getServers)
         .cotraverse(_.downField("url", _.getUrl))
+        .filterNot(_.unwrapTracker.exists(_.contains("{")))
         .headOption
         .flatMap(_.unwrapTracker)
         .flatMap(url => Option(new URI(url).getPath))


### PR DESCRIPTION
Resolve #1897 

Ideally we'd have proper support for different servers with interpolated variables, but until that happens let's just filter them out.