### PR TITLE
Rely entirely on custom version mangling inside sbt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,10 +39,6 @@ jobs:
         key: ${{ runner.os }}-scala-${{ matrix.scala.version }}-${{ hashFiles('**/*.sbt') }}
         restore-keys: |
           ${{ runner.os }}-scala-${{ matrix.scala.version }}-
-    - name: Bump version
-      run: support/apply-pr-label-locally.sh
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Run tests
       run:  sbt ++${{ matrix.scala.version }} 'show stableVersion' clean samples/clean checkFormatting coverage test coverageAggregate versionPolicyCheck microsite/compile
       env:

--- a/project/src/main/scala/Build.scala
+++ b/project/src/main/scala/Build.scala
@@ -119,18 +119,25 @@ object Build {
   def injectPRVersionPolicy(moduleSegment: String)(gitVersion: String): String = {
     val labels = currentBuildLabels(moduleSegment)
     val extractor = raw"^([0-9]+)\.([0-9]+)\.([0-9]+)(-[0-9]+-g[a-f0-9]+)?(-SNAPSHOT)?".r
+    println(s"injectPRVersionPolicy($moduleSegment)($gitVersion):")
     val newVersion: String = gitVersion match {
       case extractor(major, minor, patch, gitSlug, other) =>
         if (labels.contains("major")) {
           val newMajor = major.toInt + 1
+          println(s"  major: ${major.toInt} -> ${newMajor}")
           List(Some(s"${newMajor}.0.0"), Option(gitSlug), Option(other)).flatten.mkString("")
         } else if (labels.contains("minor")) {
           val newMinor = minor.toInt + 1
+          println(s"  minor: ${minor.toInt} -> ${newMinor}")
           List(Some(s"${major}.${newMinor}.0"), Option(gitSlug), Option(other)).flatten.mkString("")
         } else {
-          gitVersion
+          val newPatch = patch.toInt + 1
+          println(s"  patch: ${patch.toInt} -> ${newPatch}")
+          List(Some(s"${major}.${minor}.${newPatch}"), Option(gitSlug), Option(other)).flatten.mkString("")
         }
-      case _ => gitVersion
+      case other =>
+        println(s"  other: ${gitVersion}")
+        gitVersion
     }
     newVersion
   }

--- a/support/apply-pr-label-locally.sh
+++ b/support/apply-pr-label-locally.sh
@@ -1,3 +1,5 @@
+exit 0
+
 pr_number="$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")"
 labels=(
   $(curl \


### PR DESCRIPTION
Avoid duplicating work. After #1895, local version tagging occurs twice.

Disable the legacy one, as the new version also applies to manually releasing modules via GHA