### PR TITLE
Resolve 1904

### DIFF
--- a/modules/core/src/main/scala/dev/guardrail/WriteTree.scala
+++ b/modules/core/src/main/scala/dev/guardrail/WriteTree.scala
@@ -30,8 +30,10 @@ object WriteTree {
                   .zipWithIndex
                   .find { case ((a, b), _) => a != b }
                   .map(_._2)
-                  .orElse(Some(Math.max(exists.length, data.length)))
-                  .filterNot(Function.const(data.length == exists.length))
+                  .orElse(
+                    Some(Math.max(exists.length, data.length))
+                      .filterNot(Function.const(data.length == exists.length))
+                  )
 
               diffIdx.fold[Writer[List[String], WriteTreeState]](Writer.value(FileIdentical)) { diffIdx =>
                 val existSample = new String(exists, UTF_8)

--- a/modules/core/src/main/scala/dev/guardrail/terms/LanguageTerms.scala
+++ b/modules/core/src/main/scala/dev/guardrail/terms/LanguageTerms.scala
@@ -125,7 +125,7 @@ abstract class LanguageTerms[L <: LA, F[_]] { self =>
       server: Server[L]
   ): F[List[WriteTree]]
 
-  def wrapToObject(name: L#TermName, imports: List[L#Import], definitions: List[L#Definition]): F[Option[L#ObjectDefinition]]
+  def wrapToObject(name: L#TermName, imports: List[L#Import], definitions: List[L#Definition], statements: List[L#Statement]): F[Option[L#ObjectDefinition]]
 
   def copy(
       litString: String => F[L#Term] = self.litString _,
@@ -209,7 +209,7 @@ abstract class LanguageTerms[L <: LA, F[_]] { self =>
         self.writeClient _,
       writeServer: (Path, NonEmptyList[String], List[L#Import], List[L#TermName], Option[NonEmptyList[String]], Server[L]) => F[List[WriteTree]] =
         self.writeServer _,
-      wrapToObject: (L#TermName, List[L#Import], List[L#Definition]) => F[Option[L#ObjectDefinition]] = self.wrapToObject _
+      wrapToObject: (L#TermName, List[L#Import], List[L#Definition], List[L#Statement]) => F[Option[L#ObjectDefinition]] = self.wrapToObject _
   ) = {
     val newLitString                  = litString
     val newLitFloat                   = litFloat
@@ -383,7 +383,8 @@ abstract class LanguageTerms[L <: LA, F[_]] { self =>
           dtoComponents: Option[NonEmptyList[String]],
           server: Server[L]
       ) = newWriteServer(pkgPath, pkgName, customImports, frameworkImplicitNames, dtoComponents, server)
-      def wrapToObject(name: L#TermName, imports: List[L#Import], definitions: List[L#Definition]) = newWrapToObject(name, imports, definitions)
+      def wrapToObject(name: L#TermName, imports: List[L#Import], definitions: List[L#Definition], statements: List[L#Statement]) =
+        newWrapToObject(name, imports, definitions, statements)
     }
   }
 }

--- a/modules/java-support/src/main/scala/dev/guardrail/generators/java/JavaGenerator.scala
+++ b/modules/java-support/src/main/scala/dev/guardrail/generators/java/JavaGenerator.scala
@@ -427,7 +427,8 @@ class JavaGenerator private extends LanguageTerms[JavaLanguage, Target] {
   override def wrapToObject(
       name: com.github.javaparser.ast.expr.Name,
       imports: List[com.github.javaparser.ast.ImportDeclaration],
-      definitions: List[com.github.javaparser.ast.body.BodyDeclaration[_ <: com.github.javaparser.ast.body.BodyDeclaration[_]]]
+      definitions: List[com.github.javaparser.ast.body.BodyDeclaration[_ <: com.github.javaparser.ast.body.BodyDeclaration[_]]],
+      statements: List[com.github.javaparser.ast.Node]
   ): Target[Option[Nothing]] =
     Target.pure(Option.empty[Nothing])
 }

--- a/modules/java-support/src/main/scala/dev/guardrail/generators/java/jackson/JacksonGenerator.scala
+++ b/modules/java-support/src/main/scala/dev/guardrail/generators/java/jackson/JacksonGenerator.scala
@@ -764,14 +764,14 @@ class JacksonGenerator private (implicit Cl: CollectionsLibTerms[JavaLanguage, T
           for {
             widenClass          <- widenClassDefinition(classDefinition.cls)
             companionTerm       <- pureTermName(classDefinition.name)
-            companionDefinition <- wrapToObject(companionTerm, classDefinition.staticDefns.extraImports, classDefinition.staticDefns.definitions)
+            companionDefinition <- wrapToObject(companionTerm, classDefinition.staticDefns.extraImports, classDefinition.staticDefns.definitions, Nil)
             widenCompanion      <- companionDefinition.traverse(widenObjectDefinition)
           } yield List(widenClass) ++ widenCompanion.fold(classDefinition.staticDefns.definitions)(List(_))
         case enumDefinition: EnumDefinition[JavaLanguage] =>
           for {
             widenClass          <- widenClassDefinition(enumDefinition.cls)
             companionTerm       <- pureTermName(enumDefinition.name)
-            companionDefinition <- wrapToObject(companionTerm, enumDefinition.staticDefns.extraImports, enumDefinition.staticDefns.definitions)
+            companionDefinition <- wrapToObject(companionTerm, enumDefinition.staticDefns.extraImports, enumDefinition.staticDefns.definitions, Nil)
             widenCompanion      <- companionDefinition.traverse(widenObjectDefinition)
           } yield List(widenClass) ++ widenCompanion.fold(enumDefinition.staticDefns.definitions)(List(_))
       }

--- a/modules/sample-akkaHttp/src/test/scala/core/issues/Issue195.scala
+++ b/modules/sample-akkaHttp/src/test/scala/core/issues/Issue195.scala
@@ -7,26 +7,45 @@ import io.circe._, io.circe.syntax._
 import issues.issue195.server.akkaHttp.definitions._
 
 class Issue195 extends AnyFunSpec with Matchers {
-  def emit[A](label: String, func: () => A, expected: Json)(implicit ev: A => Foo): Unit =
-    describe(label) {
-      it("should encode") {
-        Foo(func()).asJson shouldBe expected
-      }
-
-      it("should decode") {
-        expected.as[Foo] shouldBe Right(Foo(func()))
-      }
-
-      it("should round-trip") {
-        Foo(func()).asJson.as[Foo] shouldBe Right(Foo(func()))
-      }
-    }
-
   describe("oneOf mapping") {
+    def emit[A](label: String, func: () => A, expected: Json)(implicit ev: A => Foo): Unit =
+      describe(label) {
+        it("should encode") {
+          Foo(func()).asJson shouldBe expected
+        }
+
+        it("should decode") {
+          expected.as[Foo] shouldBe Right(Foo(func()))
+        }
+
+        it("should round-trip") {
+          Foo(func()).asJson.as[Foo] shouldBe Right(Foo(func()))
+        }
+      }
     emit("TypeA", () => TypeA("foo"), Json.obj("type" -> Json.fromString("foo"), "beepBorp" -> Json.fromString("typea")))
     emit("TypeB", () => TypeB("foo"), Json.obj("type" -> Json.fromString("foo"), "beepBorp" -> Json.fromString("TypeB")))
     emit("TypeC", () => Foo.WrappedC(TypeC("foo")), Json.obj("C" -> Json.obj("type" -> Json.fromString("foo")), "beepBorp" -> Json.fromString("WrappedC")))
     emit("typed", () => Foo.Nested2(Typed("foo")), Json.obj("D" -> Json.obj("type" -> Json.fromString("foo")), "beepBorp" -> Json.fromString("Nested2")))
     emit("TypeE", () => Foo.Nested3(TypeE("foo")), Json.obj("E" -> Json.obj("type" -> Json.fromString("foo")), "beepBorp" -> Json.fromString("Nested3")))
+  }
+
+  describe("anonymous oneOf mapping") {
+    def emit[A](label: String, func: () => A, expected: Json)(implicit ev: A => X.Links): Unit =
+      describe(label) {
+        it("should encode") {
+          X(func()).asJson shouldBe expected
+        }
+
+        it("should decode") {
+          expected.as[X] shouldBe Right(X(func()))
+        }
+
+        it("should round-trip") {
+          X(func()).asJson.as[X] shouldBe Right(X(func()))
+        }
+      }
+
+    emit("first branch, Vector[String]", () => X.Links(Vector("1", "2")), Json.obj("links" -> Json.arr(Json.fromString("1"), Json.fromString("2"))))
+    emit("second branch, object", () => X.Links(Json.obj("a" -> Json.fromString("hey"))), Json.obj("links" -> Json.obj("a" -> Json.fromString("hey"))))
   }
 }

--- a/modules/sample/src/main/resources/issues/issue195.yaml
+++ b/modules/sample/src/main/resources/issues/issue195.yaml
@@ -51,6 +51,16 @@ components:
         propertyName: beepBorp
         mapping:
           typea: '#/components/schemas/TypeA'
+    X:
+      type: object
+      required: [ links ]
+      properties:
+        links:
+          oneOf:
+            - type: array
+              items:
+                type: string
+            - type: object
 paths:
   /foobar:
     get:

--- a/modules/scala-support/src/main/scala/dev/guardrail/generators/scala/ScalaGenerator.scala
+++ b/modules/scala-support/src/main/scala/dev/guardrail/generators/scala/ScalaGenerator.scala
@@ -510,12 +510,14 @@ class ScalaGenerator private extends LanguageTerms[ScalaLanguage, Target] {
   override def wrapToObject(
       name: scala.meta.Term.Name,
       imports: List[scala.meta.Import],
-      definitions: List[scala.meta.Defn]
+      definitions: List[scala.meta.Defn],
+      statements: List[scala.meta.Stat]
   ): Target[Option[scala.meta.Defn.Object]] =
     Target.pure(Some(q"""
            object $name {
                ..$imports
                ..$definitions
+               ..$statements
            }
          """))
 }

--- a/modules/scala-support/src/main/scala/dev/guardrail/generators/scala/circe/CirceProtocolGenerator.scala
+++ b/modules/scala-support/src/main/scala/dev/guardrail/generators/scala/circe/CirceProtocolGenerator.scala
@@ -788,17 +788,29 @@ class CirceProtocolGenerator private (circeVersion: CirceModelGenerator, applyVa
           .orRefine { case o: ComposedSchema => o }(o =>
             for {
               parents <- extractParents(o, definitions, concreteTypes, dtoPackage, supportPackage, defaultPropertyRequirement, components)
-              maybeClassDefinition <- fromModel(
-                nestedClassName,
-                o,
-                parents,
-                concreteTypes,
-                definitions,
-                dtoPackage,
-                supportPackage,
-                defaultPropertyRequirement,
-                components
+              model <- fromModel(
+                clsName = nestedClassName,
+                model = o,
+                parents = parents,
+                concreteTypes = concreteTypes,
+                definitions = definitions,
+                dtoPackage = dtoPackage,
+                supportPackage = supportPackage,
+                defaultPropertyRequirement = defaultPropertyRequirement,
+                components = components
               )
+              oneOf <- fromOneOf(
+                clsName = nestedClassName,
+                model = o,
+                // parents,
+                definitions = definitions,
+                dtoPackage = dtoPackage,
+                supportPackage = supportPackage,
+                concreteTypes = concreteTypes,
+                defaultPropertyRequirement = defaultPropertyRequirement,
+                components = components
+              )
+              maybeClassDefinition = model.orElse(oneOf)
             } yield Option(maybeClassDefinition)
           )
           .orRefine { case a: ArraySchema => a }(_.downField("items", _.getItems()).indexedCosequence.flatTraverse(processProperty(name, _)))

--- a/modules/scala-support/src/main/scala/dev/guardrail/generators/scala/circe/CirceProtocolGenerator.scala
+++ b/modules/scala-support/src/main/scala/dev/guardrail/generators/scala/circe/CirceProtocolGenerator.scala
@@ -606,10 +606,10 @@ class CirceProtocolGenerator private (circeVersion: CirceModelGenerator, applyVa
       Fw: FrameworkTerms[ScalaLanguage, Target],
       Sw: OpenAPITerms[ScalaLanguage, Target],
       P: ProtocolTerms[ScalaLanguage, Target]
-  ): Target[Either[String, NestedProtocolElems[ScalaLanguage]]] =
+  ): Target[Either[String, ClassDefinition[ScalaLanguage]]] =
     NonEmptyList
       .fromList(model.downField("oneOf", _.getOneOf()).indexedDistribute)
-      .fold[Target[Either[String, NestedProtocolElems[ScalaLanguage]]]](Target.pure(Left("Does not have oneOf"))) { xs =>
+      .fold[Target[Either[String, ClassDefinition[ScalaLanguage]]]](Target.pure(Left("Does not have oneOf"))) { xs =>
         for {
           nameGenerator <- Target.pure(new java.util.concurrent.atomic.AtomicInteger(1))
           getNewName = () => Target.pure(nameGenerator).map(ng => s"Nested${ng.getAndIncrement()}")

--- a/modules/scala-support/src/main/scala/dev/guardrail/generators/scala/circe/CirceProtocolGenerator.scala
+++ b/modules/scala-support/src/main/scala/dev/guardrail/generators/scala/circe/CirceProtocolGenerator.scala
@@ -606,10 +606,10 @@ class CirceProtocolGenerator private (circeVersion: CirceModelGenerator, applyVa
       Fw: FrameworkTerms[ScalaLanguage, Target],
       Sw: OpenAPITerms[ScalaLanguage, Target],
       P: ProtocolTerms[ScalaLanguage, Target]
-  ): Target[Either[String, StrictProtocolElems[ScalaLanguage]]] =
+  ): Target[Either[String, NestedProtocolElems[ScalaLanguage]]] =
     NonEmptyList
       .fromList(model.downField("oneOf", _.getOneOf()).indexedDistribute)
-      .fold[Target[Either[String, StrictProtocolElems[ScalaLanguage]]]](Target.pure(Left("Does not have oneOf"))) { xs =>
+      .fold[Target[Either[String, NestedProtocolElems[ScalaLanguage]]]](Target.pure(Left("Does not have oneOf"))) { xs =>
         for {
           nameGenerator <- Target.pure(new java.util.concurrent.atomic.AtomicInteger(1))
           getNewName = () => Target.pure(nameGenerator).map(ng => s"Nested${ng.getAndIncrement()}")

--- a/modules/scala-support/src/main/scala/dev/guardrail/generators/scala/circe/CirceProtocolGenerator.scala
+++ b/modules/scala-support/src/main/scala/dev/guardrail/generators/scala/circe/CirceProtocolGenerator.scala
@@ -573,14 +573,14 @@ class CirceProtocolGenerator private (circeVersion: CirceModelGenerator, applyVa
           for {
             widenClass          <- widenClassDefinition(classDefinition.cls)
             companionTerm       <- pureTermName(classDefinition.name)
-            companionDefinition <- wrapToObject(companionTerm, classDefinition.staticDefns.extraImports, classDefinition.staticDefns.definitions)
+            companionDefinition <- wrapToObject(companionTerm, classDefinition.staticDefns.extraImports, classDefinition.staticDefns.definitions, Nil)
             widenCompanion      <- companionDefinition.traverse(widenObjectDefinition)
           } yield List(widenClass) ++ widenCompanion.fold(classDefinition.staticDefns.definitions)(List(_))
         case enumDefinition: EnumDefinition[ScalaLanguage] =>
           for {
             widenClass          <- widenClassDefinition(enumDefinition.cls)
             companionTerm       <- pureTermName(enumDefinition.name)
-            companionDefinition <- wrapToObject(companionTerm, enumDefinition.staticDefns.extraImports, enumDefinition.staticDefns.definitions)
+            companionDefinition <- wrapToObject(companionTerm, enumDefinition.staticDefns.extraImports, enumDefinition.staticDefns.definitions, Nil)
             widenCompanion      <- companionDefinition.traverse(widenObjectDefinition)
           } yield List(widenClass) ++ widenCompanion.fold(enumDefinition.staticDefns.definitions)(List(_))
       }

--- a/modules/scala-support/src/main/scala/dev/guardrail/generators/scala/circe/CirceRefinedProtocolGenerator.scala
+++ b/modules/scala-support/src/main/scala/dev/guardrail/generators/scala/circe/CirceRefinedProtocolGenerator.scala
@@ -662,14 +662,14 @@ class CirceRefinedProtocolGenerator private (circeVersion: CirceModelGenerator, 
           for {
             widenClass          <- widenClassDefinition(classDefinition.cls)
             companionTerm       <- pureTermName(classDefinition.name)
-            companionDefinition <- wrapToObject(companionTerm, classDefinition.staticDefns.extraImports, classDefinition.staticDefns.definitions)
+            companionDefinition <- wrapToObject(companionTerm, classDefinition.staticDefns.extraImports, classDefinition.staticDefns.definitions, Nil)
             widenCompanion      <- companionDefinition.traverse(widenObjectDefinition)
           } yield List(widenClass) ++ widenCompanion.fold(classDefinition.staticDefns.definitions)(List(_))
         case enumDefinition: EnumDefinition[ScalaLanguage] =>
           for {
             widenClass          <- widenClassDefinition(enumDefinition.cls)
             companionTerm       <- pureTermName(enumDefinition.name)
-            companionDefinition <- wrapToObject(companionTerm, enumDefinition.staticDefns.extraImports, enumDefinition.staticDefns.definitions)
+            companionDefinition <- wrapToObject(companionTerm, enumDefinition.staticDefns.extraImports, enumDefinition.staticDefns.definitions, Nil)
             widenCompanion      <- companionDefinition.traverse(widenObjectDefinition)
           } yield List(widenClass) ++ widenCompanion.fold(enumDefinition.staticDefns.definitions)(List(_))
       }

--- a/modules/scala-support/src/main/scala/dev/guardrail/generators/scala/jackson/JacksonProtocolGenerator.scala
+++ b/modules/scala-support/src/main/scala/dev/guardrail/generators/scala/jackson/JacksonProtocolGenerator.scala
@@ -610,14 +610,14 @@ class JacksonProtocolGenerator private extends ProtocolTerms[ScalaLanguage, Targ
           for {
             widenClass          <- widenClassDefinition(classDefinition.cls)
             companionTerm       <- pureTermName(classDefinition.name)
-            companionDefinition <- wrapToObject(companionTerm, classDefinition.staticDefns.extraImports, classDefinition.staticDefns.definitions)
+            companionDefinition <- wrapToObject(companionTerm, classDefinition.staticDefns.extraImports, classDefinition.staticDefns.definitions, Nil)
             widenCompanion      <- companionDefinition.traverse(widenObjectDefinition)
           } yield List(widenClass) ++ widenCompanion.fold(classDefinition.staticDefns.definitions)(List(_))
         case enumDefinition: EnumDefinition[ScalaLanguage] =>
           for {
             widenClass          <- widenClassDefinition(enumDefinition.cls)
             companionTerm       <- pureTermName(enumDefinition.name)
-            companionDefinition <- wrapToObject(companionTerm, enumDefinition.staticDefns.extraImports, enumDefinition.staticDefns.definitions)
+            companionDefinition <- wrapToObject(companionTerm, enumDefinition.staticDefns.extraImports, enumDefinition.staticDefns.definitions, Nil)
             widenCompanion      <- companionDefinition.traverse(widenObjectDefinition)
           } yield List(widenClass) ++ widenCompanion.fold(enumDefinition.staticDefns.definitions)(List(_))
       }


### PR DESCRIPTION
Resolve #1904 

`oneOf`, when used in `properties`, emits broken code.

This PR unfortunately ran into an issue with `PropMeta`, wherein `ModelResolver` has no way to distinguish between guardrail-generated models and just other types that exist on the JVM. I worked around this by testing whether the type is leading with the fully-qualified to the wrapping class.

Relying on tests to keep this working for now, until a ModelResolver refactor.