### PR TITLE
Add Scala 3 code generation support (#2188)

### DIFF
--- a/modules/cli/src/main/scala/dev/guardrail/cli/CLICommon.scala
+++ b/modules/cli/src/main/scala/dev/guardrail/cli/CLICommon.scala
@@ -7,6 +7,7 @@ import scala.language.reflectiveCalls
 
 import dev.guardrail._
 import dev.guardrail.core.{ LogLevel, LogLevels }
+import dev.guardrail.generators.ScalaVersion
 import dev.guardrail.terms.protocol.PropertyRequirement
 import dev.guardrail.runner.GuardrailRunner
 
@@ -50,6 +51,7 @@ trait CLICommon extends GuardrailRunner {
     |   --module <module name>                           : Explicitly select libraries to satisfy composition requirements
     |   --custom-extraction                              : Permit supplying an akka-http Directive into the generated guardrail routing layer (server only)
     |   --package-from-tags                              : Use the tags, defined in the OpenAPI specification, to guide the generated package structures
+    |   --scala-version <version>                        : Target Scala version for generated code (2.12, 2.13, 3). Default: 2.13
     |
     |Examples:
     |  Generate two clients, put both in src/main/scala, under different packages, one with tracing, one without:
@@ -87,6 +89,12 @@ trait CLICommon extends GuardrailRunner {
       case "simple"  => Target.pure(AuthImplementation.Simple)
       case "custom"  => Target.pure(AuthImplementation.Custom)
       case _         => Target.raiseError(UnparseableArgument(s"${arg} ${value}", "Expected one of 'disable', 'native', 'simple' or 'custom'"))
+    }
+
+  def parseScalaVersion(arg: String, value: String): Target[ScalaVersion] =
+    ScalaVersion.fromString(value) match {
+      case Right(v)  => Target.pure(v)
+      case Left(err) => Target.raiseError(UnparseableArgument(arg, err))
     }
 
   def parseArgs(args: Array[String]): Target[List[Args]] = {
@@ -159,6 +167,11 @@ trait CLICommon extends GuardrailRunner {
               for {
                 auth <- parseAuthImplementation(arg, value)
                 res  <- Continue((sofar.modifyContext(_.withAuthImplementation(auth)) :: already, xs))
+              } yield res
+            case (sofar :: already, (arg @ "--scala-version") :: value :: xs) =>
+              for {
+                scalaVer <- parseScalaVersion(arg, value)
+                res      <- Continue((sofar.modifyContext(_.withScalaVersion(scalaVer)) :: already, xs))
               } yield res
             case (_, unknown) =>
               debug("Unknown argument") >> Bail(UnknownArguments(unknown))

--- a/modules/core/src/main/scala/dev/guardrail/generators/ScalaVersion.scala
+++ b/modules/core/src/main/scala/dev/guardrail/generators/ScalaVersion.scala
@@ -1,0 +1,22 @@
+package dev.guardrail.generators
+
+sealed abstract class ScalaVersion(val value: String) extends Product with Serializable {
+  def isScala3: Boolean = this == ScalaVersion.Scala3
+  def isScala2: Boolean = !isScala3
+}
+
+object ScalaVersion {
+  case object Scala212 extends ScalaVersion("2.12")
+  case object Scala213 extends ScalaVersion("2.13")
+  case object Scala3   extends ScalaVersion("3")
+
+  def fromString(version: String): Either[String, ScalaVersion] = version.trim.toLowerCase match {
+    case "2.12" | "2.12.x"       => Right(Scala212)
+    case "2.13" | "2.13.x"       => Right(Scala213)
+    case "3" | "3.x"             => Right(Scala3)
+    case s if s.startsWith("3.") => Right(Scala3)
+    case other                   => Left(s"Unsupported Scala version: $other. Supported: 2.12, 2.13, 3")
+  }
+
+  val default: ScalaVersion = Scala213
+}

--- a/modules/core/src/test/scala/dev/guardrail/generators/ScalaVersionSpec.scala
+++ b/modules/core/src/test/scala/dev/guardrail/generators/ScalaVersionSpec.scala
@@ -1,0 +1,87 @@
+package dev.guardrail.generators
+
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+class ScalaVersionSpec extends AnyFunSuite with Matchers {
+
+  test("ScalaVersion.fromString should parse 2.12") {
+    ScalaVersion.fromString("2.12") shouldBe Right(ScalaVersion.Scala212)
+  }
+
+  test("ScalaVersion.fromString should parse 2.12.x") {
+    ScalaVersion.fromString("2.12.x") shouldBe Right(ScalaVersion.Scala212)
+  }
+
+  test("ScalaVersion.fromString should parse 2.13") {
+    ScalaVersion.fromString("2.13") shouldBe Right(ScalaVersion.Scala213)
+  }
+
+  test("ScalaVersion.fromString should parse 2.13.x") {
+    ScalaVersion.fromString("2.13.x") shouldBe Right(ScalaVersion.Scala213)
+  }
+
+  test("ScalaVersion.fromString should parse 3") {
+    ScalaVersion.fromString("3") shouldBe Right(ScalaVersion.Scala3)
+  }
+
+  test("ScalaVersion.fromString should parse 3.x") {
+    ScalaVersion.fromString("3.x") shouldBe Right(ScalaVersion.Scala3)
+  }
+
+  test("ScalaVersion.fromString should parse 3.3.4") {
+    ScalaVersion.fromString("3.3.4") shouldBe Right(ScalaVersion.Scala3)
+  }
+
+  test("ScalaVersion.fromString should parse 3.4.0") {
+    ScalaVersion.fromString("3.4.0") shouldBe Right(ScalaVersion.Scala3)
+  }
+
+  test("ScalaVersion.fromString should handle whitespace") {
+    ScalaVersion.fromString("  3  ") shouldBe Right(ScalaVersion.Scala3)
+    ScalaVersion.fromString("  2.13  ") shouldBe Right(ScalaVersion.Scala213)
+  }
+
+  test("ScalaVersion.fromString should be case insensitive") {
+    ScalaVersion.fromString("3.X") shouldBe Right(ScalaVersion.Scala3)
+    ScalaVersion.fromString("2.13.X") shouldBe Right(ScalaVersion.Scala213)
+  }
+
+  test("ScalaVersion.fromString should return error for unsupported versions") {
+    ScalaVersion.fromString("2.11") shouldBe a[Left[_, _]]
+    ScalaVersion.fromString("invalid") shouldBe a[Left[_, _]]
+    ScalaVersion.fromString("") shouldBe a[Left[_, _]]
+  }
+
+  test("ScalaVersion.fromString error message should be informative") {
+    val result = ScalaVersion.fromString("2.11")
+    result match {
+      case Left(msg) =>
+        msg should include("Unsupported Scala version")
+        msg should include("2.11")
+      case Right(_) => fail("Expected Left")
+    }
+  }
+
+  test("ScalaVersion.default should be Scala213") {
+    ScalaVersion.default shouldBe ScalaVersion.Scala213
+  }
+
+  test("isScala3 should return true for Scala3") {
+    ScalaVersion.Scala3.isScala3 shouldBe true
+    ScalaVersion.Scala213.isScala3 shouldBe false
+    ScalaVersion.Scala212.isScala3 shouldBe false
+  }
+
+  test("isScala2 should return true for Scala 2 versions") {
+    ScalaVersion.Scala3.isScala2 shouldBe false
+    ScalaVersion.Scala213.isScala2 shouldBe true
+    ScalaVersion.Scala212.isScala2 shouldBe true
+  }
+
+  test("ScalaVersion.value should return correct string") {
+    ScalaVersion.Scala212.value shouldBe "2.12"
+    ScalaVersion.Scala213.value shouldBe "2.13"
+    ScalaVersion.Scala3.value shouldBe "3"
+  }
+}

--- a/modules/scala-akka-http/src/main/scala/dev/guardrail/generators/scala/akkaHttp/AkkaHttpClientGenerator.scala
+++ b/modules/scala-akka-http/src/main/scala/dev/guardrail/generators/scala/akkaHttp/AkkaHttpClientGenerator.scala
@@ -18,8 +18,10 @@ import dev.guardrail.generators.scala.CirceRefinedModelGenerator
 import dev.guardrail.generators.scala.JacksonModelGenerator
 import dev.guardrail.generators.scala.ModelGeneratorType
 import dev.guardrail.generators.scala.ResponseADTHelper
+import dev.guardrail.generators.scala.Scala3Compat
 import dev.guardrail.generators.scala.ScalaLanguage
 import dev.guardrail.generators.scala.syntax._
+import dev.guardrail.generators.ScalaVersion
 import dev.guardrail.generators.spi.ClientGeneratorLoader
 import dev.guardrail.generators.spi.ModuleLoadResult
 import dev.guardrail.generators.spi.ProtocolGeneratorLoader
@@ -108,8 +110,8 @@ class AkkaHttpClientGenerator private (modelGeneratorType: ModelGeneratorType) e
           }
           (responseDefinitions, clientOperations) = responseClientPair.unzip
           tracingName                             = Option(className.mkString("-")).filterNot(_.isEmpty)
-          ctorArgs    <- clientClsArgs(tracingName, serverUrls, context.tracing)
-          staticDefns <- buildStaticDefns(clientName, tracingName, serverUrls, ctorArgs, context.tracing)
+          ctorArgs    <- clientClsArgs(tracingName, serverUrls, context.tracing, context.scalaVersion)
+          staticDefns <- buildStaticDefns(clientName, tracingName, serverUrls, ctorArgs, context.tracing, context.scalaVersion)
           client <- buildClient(
             clientName,
             tracingName,
@@ -492,7 +494,8 @@ class AkkaHttpClientGenerator private (modelGeneratorType: ModelGeneratorType) e
   private def clientClsArgs(
       tracingName: Option[String],
       serverUrls: Option[NonEmptyList[URI]],
-      tracing: Boolean
+      tracing: Boolean,
+      scalaVersion: ScalaVersion
   ): Target[List[Term.ParamClause]] = {
     val implicits = List(
       param"httpClient: HttpRequest => Future[HttpResponse]",
@@ -508,7 +511,7 @@ class AkkaHttpClientGenerator private (modelGeneratorType: ModelGeneratorType) e
                                          else None),
         None
       ),
-      Term.ParamClause(implicits ++ protocolImplicits, Some(Mod.Implicit()))
+      Scala3Compat.implicitsClause(implicits ++ protocolImplicits, scalaVersion)
     )
   }
   private def generateResponseDefinitions(
@@ -527,7 +530,8 @@ class AkkaHttpClientGenerator private (modelGeneratorType: ModelGeneratorType) e
       tracingName: Option[String],
       serverUrls: Option[NonEmptyList[URI]],
       ctorArgs: List[Term.ParamClause],
-      tracing: Boolean
+      tracing: Boolean,
+      scalaVersion: ScalaVersion
   ): Target[StaticDefns[ScalaLanguage]] = {
     def extraConstructors(
         tracingName: Option[String],
@@ -553,7 +557,7 @@ class AkkaHttpClientGenerator private (modelGeneratorType: ModelGeneratorType) e
             List(param"httpClient: HttpRequest => Future[HttpResponse]", formatHost(serverUrls)) ++ tracingParams,
             None
           ),
-          Term.ParamClause(implicits ++ protocolImplicits, Some(Mod.Implicit()))
+          Scala3Compat.implicitsClause(implicits ++ protocolImplicits, scalaVersion)
         )
       } yield List(
         q"""def httpClient(...${args}): $tpe = $ctorCall"""

--- a/modules/scala-akka-http/src/main/scala/dev/guardrail/generators/scala/akkaHttp/AkkaHttpHelper.scala
+++ b/modules/scala-akka-http/src/main/scala/dev/guardrail/generators/scala/akkaHttp/AkkaHttpHelper.scala
@@ -47,16 +47,13 @@ object AkkaHttpHelper {
     case _                        => Left(s"Unknown modelGeneratorType: ${modelGeneratorType}")
   }
 
-  def protocolImplicits(modelGeneratorType: ModelGeneratorType): Target[Term.ParamClause] = modelGeneratorType match {
-    case _: CirceModelGenerator => Target.pure(Term.ParamClause(Nil))
+  def protocolImplicits(modelGeneratorType: ModelGeneratorType): Target[List[Term.Param]] = modelGeneratorType match {
+    case _: CirceModelGenerator => Target.pure(Nil)
     case _: JacksonModelGenerator =>
       Target.pure(
-        Term.ParamClause(
-          List(
-            param"mapper: com.fasterxml.jackson.databind.ObjectMapper",
-            param"validator: javax.validation.Validator"
-          ),
-          Some(Mod.Implicit())
+        List(
+          param"mapper: com.fasterxml.jackson.databind.ObjectMapper",
+          param"validator: javax.validation.Validator"
         )
       )
     case _ => Target.raiseError(RuntimeFailure(s"Unknown modelGeneratorType: ${modelGeneratorType}"))

--- a/modules/scala-akka-http/src/main/scala/dev/guardrail/generators/scala/akkaHttp/AkkaHttpServerGenerator.scala
+++ b/modules/scala-akka-http/src/main/scala/dev/guardrail/generators/scala/akkaHttp/AkkaHttpServerGenerator.scala
@@ -25,8 +25,10 @@ import dev.guardrail.generators.scala.CirceModelGenerator
 import dev.guardrail.generators.scala.CirceRefinedModelGenerator
 import dev.guardrail.generators.scala.JacksonModelGenerator
 import dev.guardrail.generators.scala.ModelGeneratorType
+import dev.guardrail.generators.scala.Scala3Compat
 import dev.guardrail.generators.scala.ScalaLanguage
 import dev.guardrail.generators.scala.syntax._
+import dev.guardrail.generators.ScalaVersion
 import dev.guardrail.generators.spi.ModuleLoadResult
 import dev.guardrail.generators.spi.ProtocolGeneratorLoader
 import dev.guardrail.generators.spi.ServerGeneratorLoader
@@ -150,7 +152,7 @@ class AkkaHttpServerGenerator private (akkaHttpVersion: AkkaHttpVersion, modelGe
               operationId           <- getOperationId(operation)
               responses             <- Responses.getResponses[ScalaLanguage, Target](operationId, operation, protocolElems, components)
               responseClsName       <- formatTypeName(operationId, Some("Response"))
-              responseDefinitions   <- generateResponseDefinitions(responseClsName, responses, protocolElems)
+              responseDefinitions   <- generateResponseDefinitions(responseClsName, responses, protocolElems, context.scalaVersion)
               methodName            <- formatMethodName(operationId)
               parameters            <- route.getParameters[ScalaLanguage, Target](components, protocolElems)
               customExtractionField <- buildCustomExtractionFields(operation, className, context.customExtraction)
@@ -174,7 +176,8 @@ class AkkaHttpServerGenerator private (akkaHttpVersion: AkkaHttpVersion, modelGe
             protocolElems,
             securitySchemes,
             securityExposure,
-            context.authImplementation
+            context.authImplementation,
+            context.scalaVersion
           )
           handlerSrc <- renderHandler(
             handlerName,
@@ -202,7 +205,8 @@ class AkkaHttpServerGenerator private (akkaHttpVersion: AkkaHttpVersion, modelGe
             renderedRoutes.supportDefinitions,
             renderedRoutes.securitySchemesDefinitions,
             context.customExtraction,
-            context.authImplementation
+            context.authImplementation,
+            context.scalaVersion
           )
         } yield Server[ScalaLanguage](className, frameworkImports ++ extraImports, handlerSrc, classSrc)
       }
@@ -217,7 +221,8 @@ class AkkaHttpServerGenerator private (akkaHttpVersion: AkkaHttpVersion, modelGe
   private def generateResponseDefinitions(
       responseClsName: String,
       responses: Responses[ScalaLanguage],
-      protocolElems: List[StrictProtocolElems[ScalaLanguage]]
+      protocolElems: List[StrictProtocolElems[ScalaLanguage]],
+      scalaVersion: ScalaVersion
   ) =
     for {
       _ <- Target.pure(())
@@ -287,6 +292,9 @@ class AkkaHttpServerGenerator private (akkaHttpVersion: AkkaHttpVersion, modelGe
         }
       protocolImplicits <- AkkaHttpHelper.protocolImplicits(modelGeneratorType)
       toResponseImplicits = List(param"ec: scala.concurrent.ExecutionContext") ++ protocolImplicits
+      implicitParamClause = NonEmptyList
+        .fromList(protocolImplicits)
+        .fold(List.empty[Term.ParamClause])(nel => List(Scala3Compat.implicitsClause(nel.toList, scalaVersion)))
       companion = q"""
           object ${responseSuperTerm} {
           ${Defn.Def(
@@ -295,7 +303,7 @@ class AkkaHttpServerGenerator private (akkaHttpVersion: AkkaHttpVersion, modelGe
           List(
             Member.ParamClauseGroup(
               Type.ParamClause(Nil),
-              NonEmptyList.fromList(protocolImplicits).fold(List.empty[Term.ParamClause])(nel => List(Term.ParamClause(nel.toList, Some(Mod.Implicit()))))
+              implicitParamClause
             )
           ),
           Some(t"ToResponseMarshaller[${responseSuperType}]"),
@@ -304,9 +312,9 @@ class AkkaHttpServerGenerator private (akkaHttpVersion: AkkaHttpVersion, modelGe
             implicit def ${Term
           .Name(
             s"${responseClsName.uncapitalized}TR"
-          )}(value: ${responseSuperType})(..${Term.ParamClause(
+          )}(value: ${responseSuperType})(..${Scala3Compat.implicitsClause(
           toResponseImplicits,
-          Some(Mod.Implicit())
+          scalaVersion
         )}): scala.concurrent.Future[List[Marshalling[HttpResponse]]] =
               ${Term.Match(Term.Name("value"), marshallers, Nil)}
 
@@ -371,10 +379,11 @@ class AkkaHttpServerGenerator private (akkaHttpVersion: AkkaHttpVersion, modelGe
       protocolElems: List[StrictProtocolElems[ScalaLanguage]],
       securitySchemes: Map[String, SecurityScheme[ScalaLanguage]],
       securityExposure: SecurityExposure,
-      authImplementation: AuthImplementation
+      authImplementation: AuthImplementation,
+      scalaVersion: ScalaVersion
   ) =
     for {
-      renderedRoutes <- routes.traverse(generateRoute(resourceName, basePath))
+      renderedRoutes <- routes.traverse(generateRoute(resourceName, basePath, scalaVersion))
       routeTerms = renderedRoutes.map(_.route)
       combinedRouteTerms <- combineRouteTerms(routeTerms)
       methodSigs = renderedRoutes.map(_.methodSig)
@@ -433,7 +442,8 @@ class AkkaHttpServerGenerator private (akkaHttpVersion: AkkaHttpVersion, modelGe
       supportDefinitions: List[scala.meta.Defn],
       securitySchemesDefinitions: List[scala.meta.Defn],
       customExtraction: Boolean,
-      authImplementation: AuthImplementation
+      authImplementation: AuthImplementation,
+      scalaVersion: ScalaVersion
   ): Target[List[Defn]] =
     for {
       _                 <- Target.log.debug(s"renderClass(${resourceName}, ${handlerName}, <combinedRouteTerms>, ${extraRouteParams})")
@@ -453,7 +463,7 @@ class AkkaHttpServerGenerator private (akkaHttpVersion: AkkaHttpVersion, modelGe
           List(param"handler: $handlerType") ++ extraRouteParams,
           None
         ),
-        Term.ParamClause(List(param"mat: akka.stream.Materializer") ++ protocolImplicits, Some(Mod.Implicit()))
+        Scala3Compat.implicitsClause(List(param"mat: akka.stream.Materializer") ++ protocolImplicits, scalaVersion)
       )
       List(q"""
         object ${Term.Name(resourceName)} {
@@ -1002,7 +1012,8 @@ class AkkaHttpServerGenerator private (akkaHttpVersion: AkkaHttpVersion, modelGe
 
   private def generateRoute(
       resourceName: String,
-      basePath: Option[String]
+      basePath: Option[String],
+      scalaVersion: ScalaVersion
   ): GenerateRouteMeta[ScalaLanguage] => Target[RenderedRoute] = {
     case GenerateRouteMeta(_, methodName, responseClsName, customExtractionFields, tracingFields, route, parameters, responses) =>
       // Generate the pair of the Handler method and the actual call to `complete(...)`
@@ -1107,7 +1118,7 @@ class AkkaHttpServerGenerator private (akkaHttpVersion: AkkaHttpVersion, modelGe
             )
           )
         )
-        codecs <- generateCodecs(methodName, bodyArgs, responses, consumes)
+        codecs <- generateCodecs(methodName, bodyArgs, responses, consumes, scalaVersion)
       } yield RenderedRoute(
         fullRoute,
         q"""def ${Term.Name(methodName)}(...${params}): scala.concurrent.Future[${responseType}]""",
@@ -1142,26 +1153,29 @@ class AkkaHttpServerGenerator private (akkaHttpVersion: AkkaHttpVersion, modelGe
       methodName: String,
       bodyArgs: Option[LanguageParameter[ScalaLanguage]],
       responses: Responses[ScalaLanguage],
-      consumes: Tracker[NonEmptyList[ContentType]]
+      consumes: Tracker[NonEmptyList[ContentType]],
+      scalaVersion: ScalaVersion
   ): Target[List[Defn.Def]] =
-    generateDecoders(methodName, bodyArgs, consumes)
+    generateDecoders(methodName, bodyArgs, consumes, scalaVersion)
 
   private def generateDecoders(
       methodName: String,
       bodyArgs: Option[LanguageParameter[ScalaLanguage]],
-      consumes: Tracker[NonEmptyList[ContentType]]
+      consumes: Tracker[NonEmptyList[ContentType]],
+      scalaVersion: ScalaVersion
   ): Target[List[Defn.Def]] =
     bodyArgs.toList.traverse { case LanguageParameter(_, _, _, _, argType) =>
       for {
         (decoder, baseType) <- AkkaHttpHelper.generateDecoder(argType, consumes, modelGeneratorType)
         decoderImplicits    <- AkkaHttpHelper.protocolImplicits(modelGeneratorType)
+        decoderImplicitClause = if (decoderImplicits.nonEmpty) List(Scala3Compat.implicitsClause(decoderImplicits, scalaVersion)) else Nil
       } yield Defn.Def(
         mods = List.empty,
         Term.Name(s"${methodName}Decoder"),
         List(
           Member.ParamClauseGroup(
             Type.ParamClause(Nil),
-            List(decoderImplicits).filter(_.nonEmpty)
+            decoderImplicitClause
           )
         ),
         Some(t"FromRequestUnmarshaller[$baseType]"),

--- a/modules/scala-akka-http/src/test/scala/tests/generators/akkaHttp/Scala3ServerTest.scala
+++ b/modules/scala-akka-http/src/test/scala/tests/generators/akkaHttp/Scala3ServerTest.scala
@@ -1,0 +1,123 @@
+package tests.generators.akkaHttp
+
+import dev.guardrail.Context
+import dev.guardrail.generators.{ Server, Servers }
+import dev.guardrail.generators.scala.ScalaGeneratorMappings.scalaInterpreter
+import dev.guardrail.generators.ScalaVersion
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+import support.{ ScalaMetaMatchers, SwaggerSpecRunner }
+
+class Scala3ServerTest extends AnyFunSuite with Matchers with SwaggerSpecRunner with ScalaMetaMatchers {
+  import scala.meta._
+
+  val spec: String = s"""
+    |swagger: '2.0'
+    |host: petstore.swagger.io
+    |paths:
+    |  "/store/order/{order_id}":
+    |    get:
+    |      tags:
+    |      - store
+    |      x-jvm-package: store
+    |      operationId: getOrderById
+    |      produces:
+    |      - application/json
+    |      parameters:
+    |      - name: order_id
+    |        in: path
+    |        required: true
+    |        type: integer
+    |        format: int64
+    |      responses:
+    |        '200':
+    |          description: successful operation
+    |          schema:
+    |            "$$ref": "#/definitions/Order"
+    |        '404':
+    |          description: Order not found
+    |definitions:
+    |  Order:
+    |    type: object
+    |    properties:
+    |      id:
+    |        type: integer
+    |        format: int64
+    |      status:
+    |        type: string
+    |""".stripMargin
+
+  test("Ensure routes are generated with 'implicit' for Scala 2.13 (default)") {
+    val (
+      _,
+      _,
+      Servers(Server(pkg, extraImports, genHandler, genResource :: Nil) :: Nil, Nil)
+    ) = runSwaggerSpec(scalaInterpreter)(spec)(Context.empty, "akka-http")
+
+    val resourceSyntax = genResource.syntax
+
+    // Should contain 'implicit' for Scala 2
+    resourceSyntax should include("implicit mat: akka.stream.Materializer")
+    resourceSyntax should include("implicit ec: scala.concurrent.ExecutionContext")
+
+    // Should NOT contain 'using'
+    resourceSyntax should not include "using mat:"
+    resourceSyntax should not include "using ec:"
+  }
+
+  test("Ensure routes are generated with 'using' for Scala 3") {
+    val (
+      _,
+      _,
+      Servers(Server(pkg, extraImports, genHandler, genResource :: Nil) :: Nil, Nil)
+    ) = runSwaggerSpec(scalaInterpreter)(spec)(Context.empty.withScalaVersion(ScalaVersion.Scala3), "akka-http")
+
+    val resourceSyntax = genResource.syntax
+
+    // Should contain 'using' for Scala 3
+    resourceSyntax should include("using mat: akka.stream.Materializer")
+    resourceSyntax should include("using ec: scala.concurrent.ExecutionContext")
+
+    // Should NOT contain 'implicit' in parameter clauses (but may contain in other places like implicit def)
+    resourceSyntax should not include "implicit mat:"
+    resourceSyntax should not include "implicit ec:"
+  }
+
+  test("Ensure Scala 2.12 generates 'implicit' syntax") {
+    val (
+      _,
+      _,
+      Servers(Server(pkg, extraImports, genHandler, genResource :: Nil) :: Nil, Nil)
+    ) = runSwaggerSpec(scalaInterpreter)(spec)(Context.empty.withScalaVersion(ScalaVersion.Scala212), "akka-http")
+
+    val resourceSyntax = genResource.syntax
+
+    // Should contain 'implicit' for Scala 2.12
+    resourceSyntax should include("implicit mat: akka.stream.Materializer")
+    resourceSyntax should not include "using mat:"
+  }
+
+  test("Ensure handler trait is the same for both Scala 2 and Scala 3") {
+    val (_, _, Servers(Server(_, _, genHandler2, _) :: Nil, Nil)) =
+      runSwaggerSpec(scalaInterpreter)(spec)(Context.empty.withScalaVersion(ScalaVersion.Scala213), "akka-http")
+
+    val (_, _, Servers(Server(_, _, genHandler3, _) :: Nil, Nil)) =
+      runSwaggerSpec(scalaInterpreter)(spec)(Context.empty.withScalaVersion(ScalaVersion.Scala3), "akka-http")
+
+    // Handler trait should be identical - it doesn't have implicit/using clauses
+    genHandler2.syntax shouldBe genHandler3.syntax
+  }
+
+  test("Ensure response TR methods use 'using' for Scala 3") {
+    val (
+      _,
+      _,
+      Servers(Server(pkg, extraImports, genHandler, genResource :: Nil) :: Nil, Nil)
+    ) = runSwaggerSpec(scalaInterpreter)(spec)(Context.empty.withScalaVersion(ScalaVersion.Scala3), "akka-http")
+
+    val resourceSyntax = genResource.syntax
+
+    // Response transform methods should use 'using ec:'
+    resourceSyntax should include("using ec: scala.concurrent.ExecutionContext")
+  }
+}

--- a/modules/scala-akka-http/src/test/scala/tests/generators/akkaHttp/client/Scala3ClientTest.scala
+++ b/modules/scala-akka-http/src/test/scala/tests/generators/akkaHttp/client/Scala3ClientTest.scala
@@ -1,0 +1,118 @@
+package tests.generators.akkaHttp.client
+
+import dev.guardrail.Context
+import dev.guardrail.generators.{ Client, Clients }
+import dev.guardrail.generators.scala.ScalaGeneratorMappings.scalaInterpreter
+import dev.guardrail.generators.scala.syntax.companionForStaticDefns
+import dev.guardrail.generators.ScalaVersion
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+import support.{ ScalaMetaMatchers, SwaggerSpecRunner }
+
+class Scala3ClientTest extends AnyFunSuite with Matchers with SwaggerSpecRunner with ScalaMetaMatchers {
+  import scala.meta._
+
+  val spec: String = s"""
+    |swagger: '2.0'
+    |host: petstore.swagger.io
+    |basePath: /v2
+    |paths:
+    |  "/store/order/{order_id}":
+    |    get:
+    |      tags:
+    |      - store
+    |      x-jvm-package: store
+    |      operationId: getOrderById
+    |      produces:
+    |      - application/json
+    |      parameters:
+    |      - name: order_id
+    |        in: path
+    |        required: true
+    |        type: integer
+    |        format: int64
+    |      responses:
+    |        '200':
+    |          description: successful operation
+    |          schema:
+    |            "$$ref": "#/definitions/Order"
+    |        '404':
+    |          description: Order not found
+    |definitions:
+    |  Order:
+    |    type: object
+    |    properties:
+    |      id:
+    |        type: integer
+    |        format: int64
+    |      status:
+    |        type: string
+    |""".stripMargin
+
+  test("Ensure client is generated with 'implicit' for Scala 2.13 (default)") {
+    val (
+      _,
+      Clients(Client(_, clientName, _, staticDefns, cls, _) :: _, _),
+      _
+    ) = runSwaggerSpec(scalaInterpreter)(spec)(Context.empty, "akka-http")
+
+    val clientSyntax = cls.head.value.syntax
+    val cmp          = companionForStaticDefns(staticDefns)
+    val staticSyntax = cmp.syntax
+
+    // Should contain 'implicit' for Scala 2
+    (clientSyntax + staticSyntax) should include("implicit")
+  }
+
+  test("Ensure client is generated with 'using' for Scala 3") {
+    val (
+      _,
+      Clients(Client(_, clientName, _, staticDefns, cls, _) :: _, _),
+      _
+    ) = runSwaggerSpec(scalaInterpreter)(spec)(Context.empty.withScalaVersion(ScalaVersion.Scala3), "akka-http")
+
+    val clientSyntax = cls.head.value.syntax
+    val cmp          = companionForStaticDefns(staticDefns)
+    val staticSyntax = cmp.syntax
+
+    // Should contain 'using' for Scala 3 in the apply method or constructor
+    (clientSyntax + staticSyntax) should include("using")
+  }
+
+  test("Ensure client constructor uses correct implicit/using based on Scala version") {
+    val (_, Clients(Client(_, _, _, staticDefns2, cls2, _) :: _, _), _) =
+      runSwaggerSpec(scalaInterpreter)(spec)(Context.empty.withScalaVersion(ScalaVersion.Scala213), "akka-http")
+
+    val (_, Clients(Client(_, _, _, staticDefns3, cls3, _) :: _, _), _) =
+      runSwaggerSpec(scalaInterpreter)(spec)(Context.empty.withScalaVersion(ScalaVersion.Scala3), "akka-http")
+
+    val cmp2 = companionForStaticDefns(staticDefns2)
+    val cmp3 = companionForStaticDefns(staticDefns3)
+
+    val syntax2 = cls2.head.value.syntax + cmp2.syntax
+    val syntax3 = cls3.head.value.syntax + cmp3.syntax
+
+    // Scala 2 should have 'implicit' and no 'using' in parameter clauses
+    syntax2 should include("implicit")
+
+    // Scala 3 should have 'using'
+    syntax3 should include("using")
+  }
+
+  test("Ensure Scala 2.12 client uses 'implicit'") {
+    val (
+      _,
+      Clients(Client(_, _, _, staticDefns, cls, _) :: _, _),
+      _
+    ) = runSwaggerSpec(scalaInterpreter)(spec)(Context.empty.withScalaVersion(ScalaVersion.Scala212), "akka-http")
+
+    val clientSyntax = cls.head.value.syntax
+    val cmp          = companionForStaticDefns(staticDefns)
+    val staticSyntax = cmp.syntax
+
+    // Should contain 'implicit' for Scala 2.12
+    (clientSyntax + staticSyntax) should include("implicit")
+    // Should not contain 'using' as a parameter modifier
+    (clientSyntax + staticSyntax) should not include "(using "
+  }
+}

--- a/modules/scala-http4s/src/main/scala/dev/guardrail/generators/scala/http4s/Http4sClientGenerator.scala
+++ b/modules/scala-http4s/src/main/scala/dev/guardrail/generators/scala/http4s/Http4sClientGenerator.scala
@@ -14,8 +14,10 @@ import dev.guardrail.generators.LanguageParameters
 import dev.guardrail.generators.RawParameterName
 import dev.guardrail.generators.RenderedClientOperation
 import dev.guardrail.generators.scala.ResponseADTHelper
+import dev.guardrail.generators.scala.Scala3Compat
 import dev.guardrail.generators.scala.ScalaLanguage
 import dev.guardrail.generators.scala.syntax._
+import dev.guardrail.generators.ScalaVersion
 import dev.guardrail.generators.spi.ClientGeneratorLoader
 import dev.guardrail.generators.spi.ModuleLoadResult
 import dev.guardrail.generators.syntax._
@@ -95,7 +97,7 @@ class Http4sClientGenerator(version: Http4sVersion) extends ClientTerms[ScalaLan
           }
           (responseDefinitions, clientOperations) = responseClientPair.unzip
           tracingName                             = Option(className.mkString("-")).filterNot(_.isEmpty)
-          ctorArgs    <- clientClsArgs(tracingName, serverUrls, context.tracing)
+          ctorArgs    <- clientClsArgs(tracingName, serverUrls, context.tracing, context.scalaVersion)
           staticDefns <- buildStaticDefns(clientName, tracingName, serverUrls, ctorArgs, context.tracing)
           client <- buildClient(
             clientName,
@@ -485,7 +487,12 @@ class Http4sClientGenerator(version: Http4sVersion) extends ClientTerms[ScalaLan
   }
   def getImports(tracing: Boolean): Target[List[scala.meta.Import]]      = Target.pure(List(q"import org.http4s.circe._"))
   def getExtraImports(tracing: Boolean): Target[List[scala.meta.Import]] = Target.pure(List.empty)
-  def clientClsArgs(tracingName: Option[String], serverUrls: Option[NonEmptyList[URI]], tracing: Boolean): Target[List[Term.ParamClause]] = {
+  def clientClsArgs(
+      tracingName: Option[String],
+      serverUrls: Option[NonEmptyList[URI]],
+      tracing: Boolean,
+      scalaVersion: ScalaVersion
+  ): Target[List[Term.ParamClause]] = {
     val ihc = param"httpClient: Http4sClient[F]"
     val ief = param"F: Async[F]"
     Target.pure(
@@ -496,7 +503,7 @@ class Http4sClientGenerator(version: Http4sVersion) extends ClientTerms[ScalaLan
                                            else None),
           None
         ),
-        Term.ParamClause(List(ief, ihc), Some(Mod.Implicit()))
+        Scala3Compat.implicitsClause(List(ief, ihc), scalaVersion)
       )
     )
   }

--- a/modules/scala-support/src/main/scala/dev/guardrail/generators/scala/Scala3Compat.scala
+++ b/modules/scala-support/src/main/scala/dev/guardrail/generators/scala/Scala3Compat.scala
@@ -1,0 +1,196 @@
+package dev.guardrail.generators.scala
+
+import scala.meta._
+
+import dev.guardrail.generators.ScalaVersion
+
+/** Utilities for generating Scala 2 or Scala 3 compatible code based on target version.
+  *
+  * Scala 3 uses `using` clauses instead of `implicit` parameter clauses, and `given` instances instead of `implicit val`/`implicit def`. This module provides
+  * helpers to generate the appropriate syntax based on the target Scala version.
+  */
+object Scala3Compat {
+
+  /** Create an implicit or using parameter clause based on Scala version.
+    *
+    * For Scala 2: `(implicit ec: ExecutionContext)` For Scala 3: `(using ec: ExecutionContext)`
+    *
+    * @param params
+    *   The parameters for the clause
+    * @param scalaVersion
+    *   The target Scala version
+    * @return
+    *   A Term.ParamClause with the appropriate modifier
+    */
+  def implicitsClause(params: List[Term.Param], scalaVersion: ScalaVersion): Term.ParamClause = {
+    val modOpt = if (scalaVersion.isScala3) Some(Mod.Using()) else Some(Mod.Implicit())
+    Term.ParamClause(params, modOpt)
+  }
+
+  /** Create an implicit val or given definition for a simple value.
+    *
+    * For Scala 2: `implicit val name: Type = rhs` For Scala 3: `given name: Type = rhs`
+    *
+    * @param name
+    *   The name of the definition
+    * @param tpe
+    *   The type of the definition
+    * @param rhs
+    *   The right-hand side expression
+    * @param scalaVersion
+    *   The target Scala version
+    * @return
+    *   A definition statement
+    */
+  def implicitVal(
+      name: Term.Name,
+      tpe: Type,
+      rhs: Term,
+      scalaVersion: ScalaVersion
+  ): Defn =
+    if (scalaVersion.isScala3) {
+      // For Scala 3: given name: Type = rhs
+      // Use the Defn.GivenAlias which is simpler for value-like givens
+      Defn.GivenAlias(
+        Nil,  // mods
+        name, // name
+        None, // paramClauseGroup (no type params or using params)
+        tpe,  // decltpe
+        rhs   // body
+      )
+    } else {
+      q"implicit val ${Pat.Var(name)}: $tpe = $rhs"
+    }
+
+  /** Create an implicit val or given definition using a pattern (for more complex cases).
+    *
+    * For Scala 2: {{{implicit val pattern: Type = rhs}}} For Scala 3: {{{given name: Type = rhs}}}
+    *
+    * Note: For Scala 3, we extract the name from the pattern if possible.
+    *
+    * @param pattern
+    *   The pattern for the val (typically Pat.Var)
+    * @param tpe
+    *   The type of the definition
+    * @param rhs
+    *   The right-hand side expression
+    * @param scalaVersion
+    *   The target Scala version
+    * @return
+    *   A definition statement
+    */
+  def implicitValWithPattern(
+      pattern: Pat,
+      tpe: Type,
+      rhs: Term,
+      scalaVersion: ScalaVersion
+  ): Defn =
+    pattern match {
+      case Pat.Var(name) => implicitVal(name, tpe, rhs, scalaVersion)
+      case _             =>
+        // For complex patterns, fall back to Scala 2 style (Scala 3 doesn't support patterns in given)
+        q"implicit val $pattern: $tpe = $rhs"
+    }
+
+  /** Create an implicit def or given definition with type parameters and/or implicit parameters.
+    *
+    * For Scala 2: `implicit def name[A](implicit ev: Show[A]): Encoder[A] = ...` For Scala 3: `given name[A](using ev: Show[A]): Encoder[A] = ...`
+    *
+    * @param name
+    *   The name of the definition
+    * @param typeParams
+    *   Type parameters
+    * @param implicitParams
+    *   Implicit/using parameters
+    * @param returnType
+    *   The return type
+    * @param body
+    *   The implementation body
+    * @param scalaVersion
+    *   The target Scala version
+    * @return
+    *   A definition statement
+    */
+  def implicitDef(
+      name: Term.Name,
+      typeParams: List[Type.Param],
+      implicitParams: List[Term.Param],
+      returnType: Type,
+      body: Term,
+      scalaVersion: ScalaVersion
+  ): Defn =
+    if (scalaVersion.isScala3) {
+      val usingClause = if (implicitParams.nonEmpty) {
+        List(Term.ParamClause(implicitParams, Some(Mod.Using())))
+      } else {
+        Nil
+      }
+      val paramClauseGroup = if (typeParams.nonEmpty || usingClause.nonEmpty) {
+        val tparamClause = Type.ParamClause(typeParams)
+        Some(Member.ParamClauseGroup(tparamClause, usingClause))
+      } else {
+        None
+      }
+      Defn.GivenAlias(
+        Nil,              // mods
+        name,             // name
+        paramClauseGroup, // paramClauseGroup
+        returnType,       // decltpe
+        body              // body
+      )
+    } else {
+      val paramClause = if (implicitParams.nonEmpty) {
+        List(Term.ParamClause(implicitParams, Some(Mod.Implicit())))
+      } else {
+        Nil
+      }
+      if (typeParams.nonEmpty) {
+        q"implicit def $name[..$typeParams](...$paramClause): $returnType = $body"
+      } else if (paramClause.nonEmpty) {
+        q"implicit def $name(...$paramClause): $returnType = $body"
+      } else {
+        q"implicit def $name: $returnType = $body"
+      }
+    }
+
+  /** Helper to create implicit/given with explicit Defn.Val syntax for Scala 2 compatibility.
+    *
+    * This is useful when you need to generate code that will be compared in tests, as it produces more predictable AST structure.
+    *
+    * @param mods
+    *   Additional modifiers (will have implicit prepended for Scala 2)
+    * @param name
+    *   The name of the val
+    * @param tpe
+    *   The declared type
+    * @param rhs
+    *   The right-hand side expression
+    * @param scalaVersion
+    *   The target Scala version
+    * @return
+    *   A definition statement
+    */
+  def implicitValExplicit(
+      mods: List[Mod],
+      name: Term.Name,
+      tpe: Type,
+      rhs: Term,
+      scalaVersion: ScalaVersion
+  ): Defn =
+    if (scalaVersion.isScala3) {
+      Defn.GivenAlias(
+        mods,
+        name,
+        None,
+        tpe,
+        rhs
+      )
+    } else {
+      Defn.Val(
+        Mod.Implicit() +: mods,
+        List(Pat.Var(name)),
+        Some(tpe),
+        rhs
+      )
+    }
+}

--- a/modules/scala-support/src/test/scala/dev/guardrail/generators/scala/Scala3CompatSpec.scala
+++ b/modules/scala-support/src/test/scala/dev/guardrail/generators/scala/Scala3CompatSpec.scala
@@ -1,0 +1,158 @@
+package dev.guardrail.generators.scala
+
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+import scala.meta._
+
+import dev.guardrail.generators.ScalaVersion
+
+class Scala3CompatSpec extends AnyFunSuite with Matchers {
+
+  test("implicitsClause should generate implicit modifier for Scala 2.12") {
+    val params = List(param"ec: scala.concurrent.ExecutionContext")
+    val result = Scala3Compat.implicitsClause(params, ScalaVersion.Scala212)
+
+    result.mod.map(_.structure) shouldBe Some(Mod.Implicit().structure)
+    result.values.map(_.structure) shouldBe params.map(_.structure)
+  }
+
+  test("implicitsClause should generate implicit modifier for Scala 2.13") {
+    val params = List(param"ec: scala.concurrent.ExecutionContext")
+    val result = Scala3Compat.implicitsClause(params, ScalaVersion.Scala213)
+
+    result.mod.map(_.structure) shouldBe Some(Mod.Implicit().structure)
+    result.values.map(_.structure) shouldBe params.map(_.structure)
+  }
+
+  test("implicitsClause should generate using modifier for Scala 3") {
+    val params = List(param"ec: scala.concurrent.ExecutionContext")
+    val result = Scala3Compat.implicitsClause(params, ScalaVersion.Scala3)
+
+    result.mod.map(_.structure) shouldBe Some(Mod.Using().structure)
+    result.values.map(_.structure) shouldBe params.map(_.structure)
+  }
+
+  test("implicitsClause should handle multiple parameters") {
+    val params = List(
+      param"ec: scala.concurrent.ExecutionContext",
+      param"mat: akka.stream.Materializer"
+    )
+
+    val scala2Result = Scala3Compat.implicitsClause(params, ScalaVersion.Scala213)
+    scala2Result.mod.map(_.structure) shouldBe Some(Mod.Implicit().structure)
+    scala2Result.values.size shouldBe 2
+
+    val scala3Result = Scala3Compat.implicitsClause(params, ScalaVersion.Scala3)
+    scala3Result.mod.map(_.structure) shouldBe Some(Mod.Using().structure)
+    scala3Result.values.size shouldBe 2
+  }
+
+  test("implicitsClause should handle empty parameters") {
+    val params = List.empty[Term.Param]
+
+    val scala2Result = Scala3Compat.implicitsClause(params, ScalaVersion.Scala213)
+    scala2Result.mod.map(_.structure) shouldBe Some(Mod.Implicit().structure)
+    scala2Result.values shouldBe empty
+
+    val scala3Result = Scala3Compat.implicitsClause(params, ScalaVersion.Scala3)
+    scala3Result.mod.map(_.structure) shouldBe Some(Mod.Using().structure)
+    scala3Result.values shouldBe empty
+  }
+
+  test("implicitsClause syntax output should be correct for Scala 2") {
+    val params = List(param"ec: ExecutionContext")
+    val result = Scala3Compat.implicitsClause(params, ScalaVersion.Scala213)
+
+    // The syntax should contain "implicit"
+    result.syntax should include("implicit")
+    result.syntax should not include "using"
+  }
+
+  test("implicitsClause syntax output should be correct for Scala 3") {
+    val params = List(param"ec: ExecutionContext")
+    val result = Scala3Compat.implicitsClause(params, ScalaVersion.Scala3)
+
+    // The syntax should contain "using"
+    result.syntax should include("using")
+    result.syntax should not include "implicit"
+  }
+
+  test("implicitVal should generate implicit val for Scala 2") {
+    val name = q"encoder"
+    val tpe  = t"Encoder[String]"
+    val rhs  = q"Encoder.encodeString"
+
+    val result = Scala3Compat.implicitVal(name, tpe, rhs, ScalaVersion.Scala213)
+
+    result.syntax should include("implicit")
+    result.syntax should include("val")
+    result.syntax should include("encoder")
+  }
+
+  test("implicitVal should generate given for Scala 3") {
+    val name = q"encoder"
+    val tpe  = t"Encoder[String]"
+    val rhs  = q"Encoder.encodeString"
+
+    val result = Scala3Compat.implicitVal(name, tpe, rhs, ScalaVersion.Scala3)
+
+    result.syntax should include("given")
+    result.syntax should include("encoder")
+    result.syntax should not include "implicit"
+  }
+
+  test("implicitDef should generate implicit def for Scala 2") {
+    val name           = q"showEncoder"
+    val typeParams     = List(tparam"A")
+    val implicitParams = List(param"ev: Show[A]")
+    val returnType     = t"Encoder[A]"
+    val body           = q"Encoder.encodeString.contramap(ev.show)"
+
+    val result = Scala3Compat.implicitDef(name, typeParams, implicitParams, returnType, body, ScalaVersion.Scala213)
+
+    result.syntax should include("implicit")
+    result.syntax should include("def")
+    result.syntax should include("showEncoder")
+  }
+
+  test("implicitDef should generate given for Scala 3") {
+    val name           = q"showEncoder"
+    val typeParams     = List(tparam"A")
+    val implicitParams = List(param"ev: Show[A]")
+    val returnType     = t"Encoder[A]"
+    val body           = q"Encoder.encodeString.contramap(ev.show)"
+
+    val result = Scala3Compat.implicitDef(name, typeParams, implicitParams, returnType, body, ScalaVersion.Scala3)
+
+    result.syntax should include("given")
+    result.syntax should include("showEncoder")
+    result.syntax should not include "implicit def"
+  }
+
+  test("implicitDef without type params should work for Scala 2") {
+    val name           = q"defaultEncoder"
+    val typeParams     = List.empty[Type.Param]
+    val implicitParams = List.empty[Term.Param]
+    val returnType     = t"Encoder[String]"
+    val body           = q"Encoder.encodeString"
+
+    val result = Scala3Compat.implicitDef(name, typeParams, implicitParams, returnType, body, ScalaVersion.Scala213)
+
+    result.syntax should include("implicit")
+    result.syntax should include("def")
+    result.syntax should include("defaultEncoder")
+  }
+
+  test("implicitDef without type params should work for Scala 3") {
+    val name           = q"defaultEncoder"
+    val typeParams     = List.empty[Type.Param]
+    val implicitParams = List.empty[Term.Param]
+    val returnType     = t"Encoder[String]"
+    val body           = q"Encoder.encodeString"
+
+    val result = Scala3Compat.implicitDef(name, typeParams, implicitParams, returnType, body, ScalaVersion.Scala3)
+
+    result.syntax should include("given")
+    result.syntax should include("defaultEncoder")
+  }
+}

--- a/project/src/main/scala/modules/core.scala
+++ b/project/src/main/scala/modules/core.scala
@@ -75,6 +75,7 @@ object core {
             param"propertyRequirement: dev.guardrail.terms.protocol.PropertyRequirement.Configured",
             param"tagsBehaviour: dev.guardrail.TagsBehaviour",
             param"authImplementation: dev.guardrail.AuthImplementation",
+            param"scalaVersion: dev.guardrail.generators.ScalaVersion",
           ),
           List(
             q"""
@@ -88,7 +89,8 @@ object core {
                   dev.guardrail.terms.protocol.PropertyRequirement.OptionalLegacy
                 ),
                 tagsBehaviour = TagsBehaviour.TagsAreIgnored,
-                authImplementation = AuthImplementation.Disable
+                authImplementation = AuthImplementation.Disable,
+                scalaVersion = dev.guardrail.generators.ScalaVersion.default
               )
             """
           ),


### PR DESCRIPTION
 ## Summary

  - Add `ScalaVersion` ADT to represent target Scala version (2.12, 2.13, 3)
  - Add `Scala3Compat` utility for generating `using` clauses instead of `implicit` for Scala 3
  - Add `scalaVersion` field to `Context` for version-aware code generation
  - Update AkkaHttp generators to use `Scala3Compat.implicitsClause`
  - Update Http4s client generator for Scala 3 compatibility

  Closes #2188

  ## Test plan

  - [x] Unit tests for `ScalaVersion` parsing and behavior (16 tests)
  - [x] Unit tests for `Scala3Compat` clause generation (13 tests)
  - [x] Unit tests verifying generated server code uses `using` for Scala 3 (5 tests)
  - [x] Unit tests verifying generated client code uses `using` for Scala 3 (4 tests)

  ## Notes on Integration Testing

  The current unit tests verify the AST structure contains correct `using`/`implicit` syntax based on Scala version. Full compilation-based integration testing (via
  `modules/sample-*`) would require adding Scala 3 to the build infrastructure, as sample modules currently only compile with Scala 2.12/2.13.

  Options for future work:
  1. Add a single `sample-scala3` module to validate compilation
  2. Cross-compile existing samples with Scala 3

  Happy to discuss the best approach for integration testing infrastructure.

  ## Related PRs

  - sbt-guardrail: Threading `scalaVersion` parameter (pending)
  - module-pekko-http: Scala 3 support for Pekko HTTP generators (pending)