### PR TITLE
Skip Codecov upload for fork PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         GUARDRAIL_CI: true
     - uses: codecov/codecov-action@84508663e988701840491b86de86b666e8a86bed # 4.3.0
+      if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
       with:
         file: ./target/scala-${{ matrix.scala.bincompat }}/scoverage-report/scoverage.xml
         fail_ci_if_error: true
@@ -82,6 +83,7 @@ jobs:
     - name: Run tests
       run:  sbt ++${{ matrix.scala.version }} clean samples/clean coverage "runExample java ${{ matrix.framework.framework }}" ${{ matrix.framework.project }}/test coverageAggregate
     - uses: codecov/codecov-action@84508663e988701840491b86de86b666e8a86bed # 4.3.0
+      if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
       with:
         file: ./target/scala-${{ matrix.scala.bincompat }}/scoverage-report/scoverage.xml
         fail_ci_if_error: true
@@ -124,7 +126,7 @@ jobs:
       if: ${{ env.combo_enabled == 'true' }}
       run:  sbt ++${{ matrix.scala.version }} clean samples/clean coverage "runExample scala ${{ matrix.framework.framework }}" ${{ matrix.framework.project }}/test coverageAggregate
     - uses: codecov/codecov-action@84508663e988701840491b86de86b666e8a86bed # 4.3.0
-      if: ${{ env.combo_enabled == 'true' }}
+      if: ${{ env.combo_enabled == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
       with:
         file: ./target/scala-${{ matrix.scala.bincompat }}/scoverage-report/scoverage.xml
         fail_ci_if_error: true


### PR DESCRIPTION
## Summary

Skip Codecov uploads for pull requests from forks, where repository secrets are unavailable and Codecov rejects protected-branch uploads without a token.

This lets forked dependency-bump PRs complete their SBT test jobs instead of failing after successful tests during coverage upload.

## Validation

- Parsed `.github/workflows/ci.yml` with Ruby YAML loader
