### PR TITLE
Update CI Java setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ '1.14' ]
+        java: [ '14' ]
         scala: [
             { version: '2.12.18', bincompat: '2.12' }
           ]
@@ -25,9 +25,11 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
-    - uses: olafurpg/setup-scala@v14
+    - uses: actions/setup-java@v4
       with:
-        java-version: zulu@${{ matrix.java }}
+        distribution: zulu
+        java-version: ${{ matrix.java }}
+    - uses: sbt/setup-sbt@v1
     - name: Set scala version for matrix
       id: set-scala-versions  # The greps on the following line are to ensure as much as possible that we've caught the right line
       run: echo "scala_versions=$(sbt 'print githubMatrixSettings' | grep '^\[{' | grep 'bincompat' | tail -n 1)" >> $GITHUB_OUTPUT
@@ -56,7 +58,7 @@ jobs:
     needs: [core]
     strategy:
       matrix:
-        java: [ '1.14', '1.17' ]
+        java: [ '14', '17' ]
         scala: [
             { version: '2.12.16', bincompat: '2.12' }
           ]
@@ -69,9 +71,11 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
-    - uses: olafurpg/setup-scala@v14
+    - uses: actions/setup-java@v4
       with:
-        java-version: zulu@${{ matrix.java }}
+        distribution: zulu
+        java-version: ${{ matrix.java }}
+    - uses: sbt/setup-sbt@v1
     - name: print Java version
       run: java -version
     - uses: actions/cache@v4
@@ -93,7 +97,7 @@ jobs:
     needs: [core]
     strategy:
       matrix:
-        java: [ '1.14', '1.17' ]
+        java: [ '14', '17' ]
         scala: ${{ fromJson(needs.core.outputs.scala_versions) }}
         framework: [
             { framework: 'akka-http',         project: 'sample-akkaHttp'        },
@@ -105,15 +109,17 @@ jobs:
     steps:
     - run: echo 'combo_enabled=true' >> $GITHUB_ENV
     - run: echo 'combo_enabled=false' >> $GITHUB_ENV
-      if: ${{ matrix.java == '1.17' && matrix.scala.bincompat == '2.12' }}
+      if: ${{ matrix.java == '17' && matrix.scala.bincompat == '2.12' }}
     - run: echo 'combo_enabled=false' >> $GITHUB_ENV
       if: matrix.scala.bincompat == '2.13' && matrix.framework.framework == 'dropwizard'
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
-    - uses: olafurpg/setup-scala@v14
+    - uses: actions/setup-java@v4
       with:
-        java-version: zulu@${{ matrix.java }}
+        distribution: zulu
+        java-version: ${{ matrix.java }}
+    - uses: sbt/setup-sbt@v1
     - name: print Java version
       run: java -version
     - uses: actions/cache@v4


### PR DESCRIPTION
This moves CI from olafurpg/setup-scala's Jabba-provided Java install to actions/setup-java plus sbt/setup-sbt. The current Java 17 matrix is resolving to an old 17.0.0 build that crashes on GitHub's cgroup v2 environment before tests start.