### PR TITLE
Fix JavaParser parent links in Java generators

### DIFF
--- a/modules/java-dropwizard/src/main/scala/dev/guardrail/generators/java/dropwizard/DropwizardServerGenerator.scala
+++ b/modules/java-dropwizard/src/main/scala/dev/guardrail/generators/java/dropwizard/DropwizardServerGenerator.scala
@@ -254,7 +254,7 @@ class DropwizardServerGenerator private (implicit Cl: CollectionsLibTerms[JavaLa
       clsType <- safeParseClassOrInterfaceType(clsName)
     } yield {
       val cls = new ClassOrInterfaceDeclaration(new NodeList(publicModifier, staticModifier), false, clsName)
-        .setExtendedTypes(new NodeList(superClassType))
+        .setExtendedTypes(new NodeList(superClassType.clone()))
         .addAnnotation(generatedAnnotation(getClass))
 
       val (classDecls, creator) = response.value
@@ -283,12 +283,12 @@ class DropwizardServerGenerator private (implicit Cl: CollectionsLibTerms[JavaLa
 
           val creator = new FieldDeclaration(
             new NodeList(publicModifier, staticModifier, finalModifier),
-            new VariableDeclarator(clsType, clsName, new ObjectCreationExpr(null, clsType, new NodeList))
+            new VariableDeclarator(clsType.clone(), clsName, new ObjectCreationExpr(null, clsType.clone(), new NodeList))
           )
 
           (List(constructor), creator)
         } { valueType =>
-          val constructParam = new Parameter(new NodeList(finalModifier), valueType.unbox, new SimpleName("entityBody"))
+          val constructParam = new Parameter(new NodeList(finalModifier), valueType.unbox.clone(), new SimpleName("entityBody"))
 
           val constructor = new ConstructorDeclaration(new NodeList(privateModifier), clsName)
             .addParameter(constructParam)
@@ -314,10 +314,10 @@ class DropwizardServerGenerator private (implicit Cl: CollectionsLibTerms[JavaLa
 
           val entityBodyField = new FieldDeclaration(
             new NodeList(privateModifier, finalModifier),
-            new VariableDeclarator(valueType, "entityBody")
+            new VariableDeclarator(valueType.clone(), "entityBody")
           )
 
-          val entityBodyGetter = new MethodDeclaration(new NodeList(publicModifier), valueType, "getEntityBody")
+          val entityBodyGetter = new MethodDeclaration(new NodeList(publicModifier), valueType.clone(), "getEntityBody")
             .setBody(
               new BlockStmt(
                 new NodeList(
@@ -326,12 +326,12 @@ class DropwizardServerGenerator private (implicit Cl: CollectionsLibTerms[JavaLa
               )
             )
 
-          val creator = new MethodDeclaration(new NodeList(publicModifier, staticModifier), clsType, clsName)
-            .addParameter(constructParam)
+          val creator = new MethodDeclaration(new NodeList(publicModifier, staticModifier), clsType.clone(), clsName)
+            .addParameter(constructParam.clone())
             .setBody(
               new BlockStmt(
                 new NodeList(
-                  new ReturnStmt(new ObjectCreationExpr(null, clsType, new NodeList(constructParam.getNameAsExpression)))
+                  new ReturnStmt(new ObjectCreationExpr(null, clsType.clone(), new NodeList(constructParam.getNameAsExpression)))
                 )
               )
             )
@@ -460,7 +460,7 @@ class DropwizardServerGenerator private (implicit Cl: CollectionsLibTerms[JavaLa
               val tpe        = if (isOptional) parameter.getType.containedType else parameter.getType
 
               def transform(to: Type): Target[Parameter] = {
-                parameter.setType(if (isOptional) to.liftOptionalType else to)
+                parameter.setType(if (isOptional) to.clone().liftOptionalType else to.clone())
                 if (!isOptional) {
                   parameter.getAnnotations.add(0, new MarkerAnnotationExpr("UnwrapValidatedValue"))
                 }
@@ -490,8 +490,8 @@ class DropwizardServerGenerator private (implicit Cl: CollectionsLibTerms[JavaLa
             // on disk and use java.io.File.
             def transformMultipartFile(parameter: Parameter, param: LanguageParameter[JavaLanguage]): Target[Parameter] =
               (param.isFile, param.required) match {
-                case (true, true)  => Target.pure(parameter.setType(FILE_TYPE))
-                case (true, false) => Cl.liftOptionalType(FILE_TYPE).map(parameter.setType)
+                case (true, true)  => Target.pure(parameter.setType(FILE_TYPE.clone()))
+                case (true, false) => Cl.liftOptionalType(FILE_TYPE.clone()).map(parameter.setType)
                 case _             => Target.pure(parameter)
               }
 
@@ -575,7 +575,7 @@ class DropwizardServerGenerator private (implicit Cl: CollectionsLibTerms[JavaLa
               methodParams = (annotatedMethodParams ++ bareMethodParams).map(boxParameterTypes)
               _            = methodParams.foreach(method.addParameter)
               _ = method.addParameter(
-                new Parameter(new NodeList(finalModifier), ASYNC_RESPONSE_TYPE, new SimpleName("asyncResponse")).addMarkerAnnotation("Suspended")
+                new Parameter(new NodeList(finalModifier), ASYNC_RESPONSE_TYPE.clone(), new SimpleName("asyncResponse")).addMarkerAnnotation("Suspended")
               )
 
               (responseType, resultResumeBody) = ServerRawResponse(operation)
@@ -616,7 +616,7 @@ class DropwizardServerGenerator private (implicit Cl: CollectionsLibTerms[JavaLa
                         new ExpressionStmt(
                           new VariableDeclarationExpr(
                             new VariableDeclarator(
-                              RESPONSE_BUILDER_TYPE,
+                              RESPONSE_BUILDER_TYPE.clone(),
                               "builder",
                               new MethodCallExpr(
                                 new NameExpr("Response"),
@@ -640,7 +640,7 @@ class DropwizardServerGenerator private (implicit Cl: CollectionsLibTerms[JavaLa
                   )
                 } { _ =>
                   (
-                    RESPONSE_TYPE,
+                    RESPONSE_TYPE.clone(),
                     new NodeList(
                       new ExpressionStmt(
                         new MethodCallExpr(
@@ -737,7 +737,7 @@ class DropwizardServerGenerator private (implicit Cl: CollectionsLibTerms[JavaLa
     } yield {
       val resourceConstructor = new ConstructorDeclaration(new NodeList(publicModifier), resourceName)
       resourceConstructor.addAnnotation(new MarkerAnnotationExpr(new Name("Inject")))
-      resourceConstructor.addParameter(new Parameter(new NodeList(finalModifier), handlerType, new SimpleName("handler")))
+      resourceConstructor.addParameter(new Parameter(new NodeList(finalModifier), handlerType.clone(), new SimpleName("handler")))
       resourceConstructor.setBody(
         new BlockStmt(
           new NodeList(
@@ -754,12 +754,12 @@ class DropwizardServerGenerator private (implicit Cl: CollectionsLibTerms[JavaLa
         new FieldDeclaration(
           new NodeList(privateModifier, staticModifier, finalModifier),
           new VariableDeclarator(
-            LOGGER_TYPE,
+            LOGGER_TYPE.clone(),
             "logger",
-            new MethodCallExpr(new NameExpr("LoggerFactory"), "getLogger", new NodeList[Expression](new ClassExpr(resourceType)))
+            new MethodCallExpr(new NameExpr("LoggerFactory"), "getLogger", new NodeList[Expression](new ClassExpr(resourceType.clone())))
           )
         ),
-        new FieldDeclaration(new NodeList(privateModifier, finalModifier), new VariableDeclarator(handlerType, "handler")),
+        new FieldDeclaration(new NodeList(privateModifier, finalModifier), new VariableDeclarator(handlerType.clone(), "handler")),
         resourceConstructor
       )
 

--- a/modules/java-support/src/main/scala/dev/guardrail/generators/java/JavaGenerator.scala
+++ b/modules/java-support/src/main/scala/dev/guardrail/generators/java/JavaGenerator.scala
@@ -48,6 +48,10 @@ object JavaGenerator {
 
 @SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements", "org.wartremover.warts.Null"))
 class JavaGenerator private extends LanguageTerms[JavaLanguage, Target] {
+  @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+  private def cloneNodeList[A <: Node](nodes: NodeList[A]): NodeList[A] =
+    new NodeList[A](nodes.iterator.asScala.map(_.clone().asInstanceOf[A]).toSeq: _*)
+
   private def buildPkgDecl(parts: NonEmptyList[String]): Target[PackageDeclaration] =
     safeParseName(parts.toList.mkString(".")).map(new PackageDeclaration(_))
 
@@ -182,7 +186,7 @@ class JavaGenerator private extends LanguageTerms[JavaLanguage, Target] {
       tpe: com.github.javaparser.ast.`type`.Type,
       default: Option[com.github.javaparser.ast.Node]
   ): Target[com.github.javaparser.ast.body.Parameter] =
-    safeParseSimpleName(nameStr.asString).map(name => new Parameter(new NodeList(finalModifier), tpe, name))
+    safeParseSimpleName(nameStr.asString).map(name => new Parameter(new NodeList(finalModifier), tpe.clone(), name))
   override def typeNamesEqual(a: JavaTypeName, b: JavaTypeName): Target[Boolean] = Target.pure(a.asString == b.asString)
   override def typesEqual(a: com.github.javaparser.ast.`type`.Type, b: com.github.javaparser.ast.`type`.Type): Target[Boolean] = Target.pure(a.equals(b))
   override def extractTypeName(tpe: com.github.javaparser.ast.`type`.Type): Target[Option[JavaTypeName]] = {
@@ -211,11 +215,11 @@ class JavaGenerator private extends LanguageTerms[JavaLanguage, Target] {
     safeParseSimpleName(name.asString).map(
       new Parameter(
         param.getTokenRange.orElse(null),
-        param.getModifiers,
-        param.getAnnotations,
-        param.getType,
+        cloneNodeList(param.getModifiers),
+        cloneNodeList(param.getAnnotations),
+        param.getType.clone(),
         param.isVarArgs,
-        param.getVarArgsAnnotations,
+        cloneNodeList(param.getVarArgsAnnotations),
         _
       )
     )


### PR DESCRIPTION
## Summary
- clone JavaParser type and parameter child nodes before inserting them under new AST parents
- update the Dropwizard server generator to avoid reusing mutable parsed type nodes across declarations
- fixes the JavaParser 3.25.10 pretty-printer assertion seen in run 29050576090 job 86239765768

## Validation
- nix shell nixpkgs#jdk17 nixpkgs#sbt -c sbt 'guardrail-java-dropwizard / Test / testOnly core.issues.Issue314'
- nix shell nixpkgs#jdk17 nixpkgs#sbt -c sbt 'guardrail-java-dropwizard / Test / test'
- nix shell nixpkgs#jdk17 nixpkgs#sbt -c sbt checkFormatting
- nix shell nixpkgs#jdk17 nixpkgs#sbt -c sbt test