### PR TITLE
Drop JDK 14 from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       GUARDRAIL_CI: true
     strategy:
       matrix:
-        java: [ '14' ]
+        java: [ '17' ]
         scala: [
             { version: '2.12.18', bincompat: '2.12' }
           ]
@@ -61,7 +61,7 @@ jobs:
       GUARDRAIL_CI: true
     strategy:
       matrix:
-        java: [ '14', '17' ]
+        java: [ '17', '25' ]
         scala: [
             { version: '2.12.16', bincompat: '2.12' }
           ]
@@ -103,7 +103,7 @@ jobs:
       GUARDRAIL_CI: true
     strategy:
       matrix:
-        java: [ '14', '17' ]
+        java: [ '17', '25' ]
         scala: ${{ fromJson(needs.core.outputs.scala_versions) }}
         framework: [
             { framework: 'akka-http',         project: 'sample-akkaHttp'        },
@@ -115,7 +115,7 @@ jobs:
     steps:
     - run: echo 'combo_enabled=true' >> $GITHUB_ENV
     - run: echo 'combo_enabled=false' >> $GITHUB_ENV
-      if: ${{ matrix.java == '17' && matrix.scala.bincompat == '2.12' }}
+      if: ${{ matrix.java == '25' && matrix.scala.bincompat == '2.12' }}
     - run: echo 'combo_enabled=false' >> $GITHUB_ENV
       if: matrix.scala.bincompat == '2.13' && matrix.framework.framework == 'dropwizard'
     - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: zulu
-          java-version: 14
+          java-version: 17
       - name: 'Print versions'
         run: |
           java -version

--- a/build.sbt
+++ b/build.sbt
@@ -83,6 +83,7 @@ publishMavenStyle := true
 
 val javaSampleSettings = Seq(
     Test / testOptions += Tests.Argument(TestFrameworks.JUnit, "-a", "-v"),
+    Test / testOptions += Tests.Setup(() => System.setProperty("net.bytebuddy.experimental", "true")),
     javacOptions ++= Seq(
       "-Xlint:all"
     ),

--- a/modules/sample-dropwizard/src/test/scala/helpers/MockHelpers.scala
+++ b/modules/sample-dropwizard/src/test/scala/helpers/MockHelpers.scala
@@ -8,6 +8,7 @@ import java.nio.charset.StandardCharsets
 import java.util.Collections
 import java.util.concurrent.CompletableFuture
 import javax.ws.rs.container.AsyncResponse
+import org.mockito.Mockito
 import org.asynchttpclient.Response
 import org.asynchttpclient.uri.Uri
 import org.mockito.{ ArgumentMatchersSugar, MockitoSugar }
@@ -49,7 +50,7 @@ object MockHelpers extends Assertions with MockitoSugar with ArgumentMatchersSug
         when(response.getResponseBody(any)) thenReturn responseStr
         when(response.getResponseBody) thenReturn responseStr
         when(response.getResponseBodyAsStream) thenReturn new ByteArrayInputStream(responseBytes)
-        when(response.getResponseBodyAsByteBuffer) thenReturn ByteBuffer.wrap(responseBytes)
+        Mockito.doAnswer(_ => ByteBuffer.wrap(responseBytes)).when(response).getResponseBodyAsByteBuffer
         when(response.getResponseBodyAsBytes) thenReturn responseBytes
     }
     response

--- a/project/src/main/scala/Build.scala
+++ b/project/src/main/scala/Build.scala
@@ -93,6 +93,7 @@ object Build {
       "-Xfatal-warnings",
       "-Ydelambdafy:method",
       "-Yrangepos",
+      "-release:17",
       // "-Ywarn-unused-import",  // TODO: Enable this! https://github.com/guardrail-dev/guardrail/pull/282
       "-feature",
       "-unchecked",
@@ -100,6 +101,7 @@ object Build {
       "-encoding",
       "utf8"
     ),
+    javacOptions ++= Seq("--release", "17"),
     Test / scalacOptions -= "-Xfatal-warnings",
     Compile / console / scalacOptions -= "-Xfatal-warnings",
     Compile / consoleQuick / scalacOptions -= "-Xfatal-warnings",


### PR DESCRIPTION
## Summary
- drop JDK 14 from CI and release workflows
- make JDK 17 the minimum tested/release JDK
- add JDK 25 as the tip CI lane
- preserve the existing Scala 2.12 duplicate-lane skip by moving it to JDK 25

## Validation
- Parsed `.github/workflows/ci.yml` and `.github/workflows/release.yml` with Ruby YAML
- Ran `nix shell nixpkgs#jdk17 nixpkgs#sbt -c sbt 'show githubMatrixSettings'`
